### PR TITLE
Bump number of queued-translations that we show to 50 instead of 10

### DIFF
--- a/src/pages/api/queued-translations.ts
+++ b/src/pages/api/queued-translations.ts
@@ -42,7 +42,7 @@ async function get(
     const { cursors, page } = await getPage(() =>
       c.translationInspections.getQueuedTranslations({
         pageCursor: pc,
-        pageSize: ps ? parseInt(ps, 10) : 10,
+        pageSize: ps ? parseInt(ps, 10) : 50,
         filterStatus: status,
       })
     );


### PR DESCRIPTION
## Summary
Bump number of queued-translations that we show to 50 instead of 10