### PR TITLE
[PLAT-3106] Allowing the Server to configure the network configuration

### DIFF
--- a/src/lib/with-session.ts
+++ b/src/lib/with-session.ts
@@ -19,7 +19,7 @@ export interface NetworkConfig {
   renderingHost: string;
   sceneTreeHost: string;
   sceneViewHost: string;
-  name?: string;
+  name: string | null;
 }
 
 export interface CommonProps {

--- a/src/lib/with-session.ts
+++ b/src/lib/with-session.ts
@@ -19,6 +19,7 @@ export interface NetworkConfig {
   renderingHost: string;
   sceneTreeHost: string;
   sceneViewHost: string;
+  name?: string;
 }
 
 export interface CommonProps {

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(
+  _: NextApiRequest,
+  res: NextApiResponse
+): void {
+  res.status(200).json({ status: 'ok' });
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -115,6 +115,8 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     } else if (res.status === 200) router.push("/");
   }
 
+  const predefinedEnv = serverProvidedNetworkConfig != null ? ` for ${serverProvidedNetworkConfig?.name ?? serverProvidedNetworkConfig.apiHost}`: '';
+  
   return (
     <Box sx={{ display: "flex", height: "100vh", justifyContent: "center" }}>
       <Paper
@@ -135,7 +137,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
           <Image src="/vertex-logo.svg" alt="Vertex" width="50" height="50" />
         </Box>
 
-        <FormLabel component="legend">Enter your API credentials</FormLabel>
+        <FormLabel component="legend">{`Enter your API credentials${predefinedEnv}`}</FormLabel>
         <TextField
           error={invalidId}
           fullWidth
@@ -302,7 +304,8 @@ function getNetworkConfigFromEnvironmentVariables(): NetworkConfig | null {
       apiHost: process.env.API_HOST,
       renderingHost: process.env.RENDERING_HOST,
       sceneTreeHost: process.env.SCENE_TREE_HOST,
-      sceneViewHost: process.env.SCENE_VIEW_HOST
+      sceneViewHost: process.env.SCENE_VIEW_HOST,
+      name: process.env.ENV_NAME // could be undefined
     };
   }
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -11,7 +11,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { GetServerSideProps, GetServerSidePropsResult } from "next";
+import { GetServerSidePropsResult } from "next";
 import dynamic from 'next/dynamic'
 import Image from "next/image";
 import { useRouter } from "next/router";
@@ -31,7 +31,7 @@ interface NetworkConfigInput {
 }
 
 interface Props {
-  serverProvidedNetworkConfig: NetworkConfig | undefined
+  serverProvidedNetworkConfig: NetworkConfig | null
 }
 
 const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
@@ -293,7 +293,7 @@ const DynamicPage = dynamic(() => Promise.resolve(LoginPage), {
 });
 
 
-function getNetworkConfigFromEnvironmentVariables(): NetworkConfig | undefined {
+function getNetworkConfigFromEnvironmentVariables(): NetworkConfig | null {
   /**
    * If the host values are configured from the server, disallow the option on the client to switch.
    */
@@ -306,7 +306,7 @@ function getNetworkConfigFromEnvironmentVariables(): NetworkConfig | undefined {
     };
   }
 
-  return undefined;
+  return null;
 }
 
 export const getServerSideProps = ((): GetServerSidePropsResult<Props> => {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -116,7 +116,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
   }
 
   const predefinedEnv = serverProvidedNetworkConfig != null ? ` for ${serverProvidedNetworkConfig?.name ?? serverProvidedNetworkConfig.apiHost}`: '';
-  
+
   return (
     <Box sx={{ display: "flex", height: "100vh", justifyContent: "center" }}>
       <Paper
@@ -305,7 +305,7 @@ function getNetworkConfigFromEnvironmentVariables(): NetworkConfig | null {
       renderingHost: process.env.RENDERING_HOST,
       sceneTreeHost: process.env.SCENE_TREE_HOST,
       sceneViewHost: process.env.SCENE_VIEW_HOST,
-      name: process.env.ENV_NAME // could be undefined
+      name: process.env.ENV_NAME ?? null
     };
   }
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -45,7 +45,10 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState("");
   const [env, setEnv] = React.useState(() => {
-    if (typeof window !== "undefined") {
+    if (serverProvidedNetworkConfig != null) {
+      return "custom";
+    }
+    else if (typeof window !== "undefined") {
       return localStorage.getItem("vertexvis.env") || "platprod";
     }
 


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
These changes enable environment variables to configure the network config. When all are set, the deployment does not support other configurations:

![image](https://github.com/Vertexvis/vertex-dev-dashboard/assets/49169871/c3f08ff0-8e43-4537-901f-480077838f4c)

Additionally adding a `/health` endpoint to the API


## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
