### PR TITLE
Set depth buffers to load for final frames.

### DIFF
--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -156,6 +156,7 @@ function UnwrappedViewer({
       }
       css={{ height: "100%", width: "100%" }}
       clientId={credentials.clientId}
+      depthBuffers="final"
       featureLines={{
         width: 1.0,
         color: { r: 100, g: 100, b: 100 },


### PR DESCRIPTION
## Summary
Enables depth buffers for final frames so that rotate around tap point will be functional.

## Test Plan
Test in production :)

## Release Notes
Developer dashboard viewer will now have support for rotating around tap point by default.

## Possible Regressions
N/A

## Dependencies
N/A
