### PR TITLE
Additional fix to enable rotate around tap point

### DIFF
--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -163,7 +163,6 @@ function UnwrappedViewer({
       }}
       id={viewerId}
       ref={viewer}
-      rotateAroundTapPoint={true}
       src={`urn:vertex:stream-key:${credentials.streamKey}`}
       {...props}
     >

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -126,7 +126,7 @@ export default function SceneViewer({
             onViewStateCreated={mutate}
             networkConfig={networkConfig}
             featureLines={featureLines}
-            rotateAroundTapPoint={false}
+            rotateAroundTapPoint={true}
             onSceneReady={async () => {
               const scene = await viewer.ref.current?.scene();
               if (scene) setViewId(scene.sceneViewId);


### PR DESCRIPTION
## Summary
Additional fix to enable rotate around tap point.

## Test Plan
Test in production :)

## Release Notes
Developer dashboard viewer will now have support for rotating around tap point by default.

## Possible Regressions
N/A

## Dependencies
N/A