### PR TITLE
[PLAT-3630] Temporarily omit camera data when updating name/supplied id

### DIFF
--- a/src/components/scene/SceneDrawer.tsx
+++ b/src/components/scene/SceneDrawer.tsx
@@ -47,8 +47,14 @@ export function SceneDrawer({
   });
 
   async function onSubmit(data: FormData) {
+    // Omit camera data when saving this form, since it's not
+    // updated. This prevents a bug where the `fovY` value is
+    // not correctly represented as a Float, and causes the
+    // save to fail.
+    // https://vertexvis.atlassian.net/browse/PLAT-3630
+    const updateData = { ...data, camera: undefined };
     await fetch("/api/scenes", {
-      body: JSON.stringify({ id: scene?.id, ...data }),
+      body: JSON.stringify({ id: scene?.id, ...updateData }),
       method: "PATCH",
     });
     onClose();


### PR DESCRIPTION
## Summary

Omits the `camera` field of a scene when attempting to save the scene. This prevents an issue where we attempt to send a `fovY` of `45`, which is rejected as a bad request. See https://vertexvis.atlassian.net/browse/PLAT-3630.

## Test Plan

- Verify that supplied IDs can be added to Scenes
- Verify that Scenes can be renamed

## Release Notes

N/A

## Possible Regressions

Camera saving

## Dependencies

N/A
