### PR TITLE
[PLAT-5270] Fix overflow scrollbars

### DIFF
--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -18,6 +18,7 @@ export function Header(): JSX.Element {
         display: "flex",
         justifyContent: "space-between",
         width: "100%",
+        height: "56px",
       }}
     >
       <Box sx={{ alignItems: "center", display: "flex" }}>

--- a/src/components/viewer/Layout.tsx
+++ b/src/components/viewer/Layout.tsx
@@ -2,6 +2,7 @@ import { AppBar as MuiAppBar, Box, Toolbar } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import React from "react";
 
+export const HeaderHeight = 56;
 export const BottomDrawerHeight = 240;
 export const DenseToolbarHeight = 48;
 export const LeftDrawerWidth = 300;
@@ -92,6 +93,7 @@ export function Layout({
       <Main
         sx={{
           display: "flex",
+          height: `calc(100% - ${HeaderHeight}px)`,
         }}
         bottomDrawerHeight={bdh}
       >

--- a/src/components/viewer/SceneViewStateList.tsx
+++ b/src/components/viewer/SceneViewStateList.tsx
@@ -26,7 +26,7 @@ export function SceneViewStateList({
   return (
     <>
       <DrawerTitle />
-      <List>
+      <List sx={{ flexGrow: 1, overflow: "auto" }}>
         {sceneViewStates.map((s, i) => {
           return (
             <ListItem


### PR DESCRIPTION
## Summary
Previously, when the right panel overflowed, the user saw two scrollbars, one for the panel itself and one for the entire page. If a user scrolled to the bottom, they would no longer see the header.

This PR updates the right panel's overflow behavior to ensure that only one scrollbar is visible.

## Test Plan
- Verify that only one scrollbar is visible when the right hand panel is overflowing
- Verify the header is always visible, even when the right hand panel is overflowing

## Release Notes
None

## Possible Regressions
Formatting and handling of overflowing content 

## Dependencies
None