### PR TITLE
[PLAT-5397] Add description for "root file name"

### DIFF
--- a/src/components/file/CreateFileDialog.tsx
+++ b/src/components/file/CreateFileDialog.tsx
@@ -80,7 +80,7 @@ export default function CreateFileDialog({
 
   return (
     <Dialog fullWidth onClose={onClose} open={open}>
-      <DialogTitle>Add new File</DialogTitle>
+      <DialogTitle>Add New File</DialogTitle>
       <DialogContent>
         <TextField
           fullWidth
@@ -97,6 +97,8 @@ export default function CreateFileDialog({
           onChange={(e) => setRootFileName(e.target.value)}
           size="small"
           type="text"
+          helperText="If uploading an assembly file, include the name (with file extension) of the root model file.
+          If uploading a single model file, leave this field blank."
         />
 
         <Box sx={{ py: 2, display: "flex" }}>

--- a/src/components/shared/LeftDrawer.tsx
+++ b/src/components/shared/LeftDrawer.tsx
@@ -33,7 +33,11 @@ export function LeftDrawer(): JSX.Element {
       variant="permanent"
     >
       <Toolbar variant="dense" />
-      <List>
+      <List
+        sx={{
+          paddingTop: "15px",
+        }}
+      >
         <ListItemButton
           onClick={() => router.push("/")}
           selected={router.route === "/"}


### PR DESCRIPTION
## Summary
It was not clear to users what should be entered in the "Root File Name" textbox in the "Add New File" dialog and the file creation failed if an incorrect value was entered. Therefore, this PR adds a description to the textbox to inform users that they should include the complete file name (with extension) of the root model file when uploading an assembly file and leave the field blank when uploading a single model file.

## Test Plan
Verify the description for the "root file name" appears below the text box

## Release Notes
None

## Possible Regressions
None

## Dependencies
None
