### PR TITLE
Debug: add logging around getToken failures

### DIFF
--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -1,4 +1,4 @@
-import { OAuth2Token } from "@vertexvis/api-client-node";
+import { logError, OAuth2Token } from "@vertexvis/api-client-node";
 import { NextApiResponse } from "next";
 
 import { ErrorRes, MethodNotAllowed, Res } from "../../lib/api";
@@ -31,7 +31,8 @@ export default withSession(async function (
     let token: OAuth2Token | undefined;
     try {
       token = await getToken(b.id, b.secret, b.env, b.networkConfig);
-    } catch {
+    } catch (e) {
+      logError(e);
       return res.status(401).json({ status: 401, message: "Unauthorized" });
     }
 


### PR DESCRIPTION
## Summary
A private cloud customer seems to be experiencing some network-level errors between dev-dashboard and the platform API. Currently, we don't see any specific error other than `401 Unauthorized` on the client (browser)

## Test Plan
Build and push a new image with this change, force deploy a new ECS task definition of dev-dashboard, pointed at this image in marketplace, then try to log into dev-dashboard again with application credentials
