### PR TITLE
[PLAT-6032][PLAT-5941] Show part revision name and file upload size limit

### DIFF
--- a/src/components/file/CreateFileDialog.tsx
+++ b/src/components/file/CreateFileDialog.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   Fade,
   FormControlLabel,
+  FormHelperText,
   LinearProgress,
   TextField,
 } from "@mui/material";
@@ -116,6 +117,9 @@ export default function CreateFileDialog({
             <Button variant="outlined" component="span">
               Choose File
             </Button>
+            <FormHelperText variant="filled">
+              Choose a file up to 1MB in size to upload.
+            </FormHelperText>
           </label>
           {!!file && <span style={{ marginLeft: "auto" }}>{file?.name}</span>}
         </Box>

--- a/src/components/part/PartRow.tsx
+++ b/src/components/part/PartRow.tsx
@@ -88,6 +88,7 @@ export default function PartRow({
             <Table sx={{ minWidth: 650 }}>
               <TableHead>
                 <TableRow>
+                  <TableCell>Name</TableCell>
                   <TableCell>ID</TableCell>
                   <TableCell>Supplied ID</TableCell>
                   <TableCell>Supplied Iteration ID</TableCell>
@@ -102,6 +103,7 @@ export default function PartRow({
                       key={r.id}
                       sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                     >
+                      <TableCell> {r.name} </TableCell>
                       <TableCell> {r.id} </TableCell>
                       <TableCell>{r.suppliedId}</TableCell>
                       <TableCell>{r.suppliedIterationId}</TableCell>


### PR DESCRIPTION
## Summary
This PR adds an explanation on the upload size limit in the dialog to upload a file. Further, this PR also adds the name of a part revision in the list of a part's revisions.

## Test Plan
- Verify a user sees the upload size limit text in the dialog to upload a file
- Verify a user sees the name of part revisions

## Release Notes
None

## Possible Regressions
- Uploading files
- Viewing part revisions

## Dependencies
None
