### PR TITLE
[PLAT-8634] Fix binary file size display

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "next": "^15.5.18",
     "next-connect": "^0.13.0",
     "next-iron-session": "^4.2",
-    "pretty-bytes": "^7.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.63.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@vertexvis/api-client-node": "^0.40.0",
     "@vertexvis/geometry": "^0.24.2",
     "@vertexvis/viewer-react": "^0.24.2",
+    "filesize": "^11.0.17",
     "lodash.debounce": "^4.0",
     "multer": "2.1.1",
     "next": "^15.5.18",

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,5 +1,4 @@
-const BYTE_UNITS = ["B", "kB", "MB", "GB", "TB", "PB"] as const;
-const BYTES_PER_UNIT = 1024;
+import { filesize } from "filesize";
 
 export function toDisplayValue(value?: string): string {
   return value == null || value.trim().length === 0 ? "N/A" : value;
@@ -8,19 +7,5 @@ export function toDisplayValue(value?: string): string {
 export function toFileSizeDisplay(size?: number): string | undefined {
   if (size == null) return undefined;
 
-  if (size === 0) return "0 B";
-
-  const exponent = Math.min(
-    Math.floor(Math.log(size) / Math.log(BYTES_PER_UNIT)),
-    BYTE_UNITS.length - 1
-  );
-  const value = size / BYTES_PER_UNIT ** exponent;
-  const minimumSignificantDigits = Math.max(
-    3,
-    Math.trunc(value).toString().length
-  );
-
-  return `${Number(value.toPrecision(minimumSignificantDigits))} ${
-    BYTE_UNITS[exponent]
-  }`;
+  return filesize(size, { pad: true, round: 1, standard: "jedec" });
 }

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,4 +1,5 @@
-import prettyBytes from "pretty-bytes";
+const BYTE_UNITS = ["B", "kB", "MB", "GB", "TB", "PB"] as const;
+const BYTES_PER_UNIT = 1024;
 
 export function toDisplayValue(value?: string): string {
   return value == null || value.trim().length === 0 ? "N/A" : value;
@@ -7,5 +8,19 @@ export function toDisplayValue(value?: string): string {
 export function toFileSizeDisplay(size?: number): string | undefined {
   if (size == null) return undefined;
 
-  return prettyBytes(size);
+  if (size === 0) return "0 B";
+
+  const exponent = Math.min(
+    Math.floor(Math.log(size) / Math.log(BYTES_PER_UNIT)),
+    BYTE_UNITS.length - 1
+  );
+  const value = size / BYTES_PER_UNIT ** exponent;
+  const minimumSignificantDigits = Math.max(
+    3,
+    Math.trunc(value).toString().length
+  );
+
+  return `${Number(value.toPrecision(minimumSignificantDigits))} ${
+    BYTE_UNITS[exponent]
+  }`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2227,6 +2227,11 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+filesize@^11.0.17:
+  version "11.0.17"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-11.0.17.tgz#fea569a71f0f716129fd7f5110427b7868499823"
+  integrity sha512-oHLTvMLw6imZUl1se/RBQrFlyy50nXce4sU7yGR6Qc0JgCwqnfiFsAnEwotdGmfKLD7SArGUk2/5STU0k8LOBQ==
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3251,11 +3251,6 @@ prettier@^2.4:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
-pretty-bytes@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-7.1.0.tgz#d788c9906241dbdcd4defab51b6d7470243db9bd"
-  integrity sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==
-
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
## Summary
- calculate Dev Dashboard file sizes with 1024-byte units
- keep existing file size labels such as MB and GB instead of switching to MiB/GiB

## Verification
- yarn lint
- yarn build
- direct formatter check: 5 * 1024^3 bytes => 5 GB