### PR TITLE
[PLAT-8766] Add file sorting to dev dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "mockserver-client": "^7.1.0",
+    "msw": "1.3.5",
     "prettier": "^2.4",
     "testcontainers": "10.28.0",
     "ts-jest": "^29.4.11",

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import fetch, { Headers, Request, Response } from "node-fetch";
 import React from "react";
 import { SWRConfig } from "swr";
 
+import { server } from "../../../../test/msw/server";
 import FileTable from "../../../components/file/FileTable";
 
 jest.mock("next/router", () => ({
@@ -36,21 +39,50 @@ const pagedPage = {
 };
 
 describe("FileTable", () => {
+  beforeAll(() => {
+    Object.assign(global, {
+      Headers,
+      Request,
+      Response,
+      fetch,
+    });
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
   afterEach(() => {
+    server.resetHandlers();
     jest.restoreAllMocks();
   });
 
+  afterAll(() => {
+    server.close();
+  });
+
   it("loads files sorted by created descending by default", async () => {
-    const fetchMock = mockFetch(() => page);
+    const requests: string[] = [];
+
+    server.use(
+      rest.get("*/api/files", (req, res, ctx) => {
+        requests.push(req.url.toString());
+        return res(ctx.json(page));
+      })
+    );
 
     renderTable();
 
     expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=-created");
+    expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=-created");
   });
 
   it("sorts by name and toggles direction", async () => {
-    const fetchMock = mockFetch(() => page);
+    const requests: string[] = [];
+
+    server.use(
+      rest.get("*/api/files", (req, res, ctx) => {
+        requests.push(req.url.toString());
+        return res(ctx.json(page));
+      })
+    );
 
     renderTable();
 
@@ -58,12 +90,12 @@ describe("FileTable", () => {
 
     await userEvent.click(screen.getByText("Name"));
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=name");
+      expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=name");
     });
 
     await userEvent.click(screen.getByText("Name"));
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=-name");
+      expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=-name");
     });
   });
 
@@ -72,7 +104,14 @@ describe("FileTable", () => {
     const sortedPage = new Promise((resolve) => {
       resolveSortedPage = resolve;
     });
-    mockFetch((url) => (url.includes("sort=name") ? sortedPage : pagedPage));
+    server.use(
+      rest.get("*/api/files", (req, res, ctx) => {
+        const sort = req.url.searchParams.get("sort");
+        return sort === "name"
+          ? sortedPage.then((response) => res(ctx.json(response)))
+          : res(ctx.json(pagedPage));
+      })
+    );
 
     renderTable();
 
@@ -93,25 +132,14 @@ function renderTable(): void {
     <SWRConfig
       value={{
         dedupingInterval: 0,
-        fetcher: (url: string) => fetch(url).then((res) => res.json()),
+        fetcher: (url: string) =>
+          fetch(new URL(url, window.location.origin).toString()).then((res) =>
+            res.json()
+          ),
         provider: () => new Map(),
       }}
     >
       <FileTable onFileSelected={jest.fn()} />
     </SWRConfig>
   );
-}
-
-function mockFetch(
-  responseFor: (url: string) => Promise<unknown> | unknown
-): jest.Mock {
-  const fetchMock = jest.fn((input: RequestInfo | URL) =>
-    Promise.resolve({
-      json: () => Promise.resolve(responseFor(input.toString())),
-      ok: true,
-    })
-  );
-
-  global.fetch = fetchMock as unknown as typeof fetch;
-  return fetchMock;
 }

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -5,7 +5,11 @@ import { SWRConfig } from "swr";
 
 import FileTable from "../../../components/file/FileTable";
 
-jest.mock("../../../components/file/CreateFileDialog", () => () => null);
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
 
 const page = {
   cursors: { self: "page-1" },

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -29,6 +29,12 @@ const page = {
   status: 200,
 };
 
+const pagedPage = {
+  cursors: { self: "page-1", next: "page-2" },
+  data: page.data,
+  status: 200,
+};
+
 describe("FileTable", () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -60,6 +66,26 @@ describe("FileTable", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=-name");
     });
   });
+
+  it("disables pagination while a sorted request is loading", async () => {
+    let resolveSortedPage: ((value: unknown) => void) | undefined;
+    const sortedPage = new Promise((resolve) => {
+      resolveSortedPage = resolve;
+    });
+    mockFetch((url) => (url.includes("sort=name") ? sortedPage : pagedPage));
+
+    renderTable();
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go to next page")).toBeEnabled();
+
+    await userEvent.click(screen.getByText("Name"));
+
+    expect(screen.getByLabelText("Go to next page")).toBeDisabled();
+
+    resolveSortedPage?.(page);
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+  });
 });
 
 function renderTable(): void {
@@ -76,7 +102,9 @@ function renderTable(): void {
   );
 }
 
-function mockFetch(responseFor: (url: string) => unknown): jest.Mock {
+function mockFetch(
+  responseFor: (url: string) => Promise<unknown> | unknown
+): jest.Mock {
   const fetchMock = jest.fn((input: RequestInfo | URL) =>
     Promise.resolve({
       json: () => Promise.resolve(responseFor(input.toString())),

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { SWRConfig } from "swr";
+
+import FileTable from "../../../components/file/FileTable";
+
+jest.mock("../../../components/file/CreateFileDialog", () => () => null);
+
+const page = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "file",
+      id: "file-1",
+      attributes: {
+        created: "2026-06-10T15:30:00Z",
+        name: "alpha.jt",
+        status: "completed",
+        suppliedId: "supplied-1",
+        uploaded: "2026-06-10T15:45:00Z",
+      },
+    },
+  ],
+  status: 200,
+};
+
+describe("FileTable", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads files sorted by created descending by default", async () => {
+    const fetchMock = mockFetch(() => page);
+
+    renderTable();
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=-created");
+  });
+
+  it("sorts by name and toggles direction", async () => {
+    const fetchMock = mockFetch(() => page);
+
+    renderTable();
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Name"));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=name");
+    });
+
+    await userEvent.click(screen.getByText("Name"));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/files?pageSize=25&sort=-name");
+    });
+  });
+});
+
+function renderTable(): void {
+  render(
+    <SWRConfig
+      value={{
+        dedupingInterval: 0,
+        fetcher: (url: string) => fetch(url).then((res) => res.json()),
+        provider: () => new Map(),
+      }}
+    >
+      <FileTable onFileSelected={jest.fn()} />
+    </SWRConfig>
+  );
+}
+
+function mockFetch(responseFor: (url: string) => unknown): jest.Mock {
+  const fetchMock = jest.fn((input: RequestInfo | URL) =>
+    Promise.resolve({
+      json: () => Promise.resolve(responseFor(input.toString())),
+      ok: true,
+    })
+  );
+
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}

--- a/src/__tests__/pages/api/files.test.ts
+++ b/src/__tests__/pages/api/files.test.ts
@@ -26,6 +26,8 @@ interface TestRes extends Pick<NextApiResponse, "json" | "status"> {
   readonly statusCode: () => number | undefined;
 }
 
+jest.setTimeout(120_000);
+
 describe("files API route", () => {
   let mockServer: MockServerHarness;
 
@@ -34,7 +36,7 @@ describe("files API route", () => {
   });
 
   afterAll(async () => {
-    await mockServer.stop();
+    await mockServer?.stop();
   });
 
   beforeEach(async () => {

--- a/src/__tests__/pages/api/files.test.ts
+++ b/src/__tests__/pages/api/files.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ */
+import type { NextApiResponse } from "next";
+import type { Session } from "next-iron-session";
+
+import {
+  type MockServerHarness,
+  startMockServer,
+} from "../../../../test/helpers/mockserver";
+import {
+  CredsKey,
+  EnvKey,
+  NetworkConfig as NetworkConfigKey,
+  type NextIronRequest,
+  TokenKey,
+} from "../../../lib/with-session";
+import { handleFiles } from "../../../pages/api/files";
+
+type JsonBody = Record<string, unknown>;
+
+type TestReq = Pick<NextIronRequest, "body" | "method" | "query" | "session">;
+
+interface TestRes extends Pick<NextApiResponse, "json" | "status"> {
+  readonly body: () => unknown;
+  readonly statusCode: () => number | undefined;
+}
+
+describe("files API route", () => {
+  let mockServer: MockServerHarness;
+
+  beforeAll(async () => {
+    mockServer = await startMockServer();
+  });
+
+  afterAll(async () => {
+    await mockServer.stop();
+  });
+
+  beforeEach(async () => {
+    await mockServer.client.reset();
+  });
+
+  it("lists files with sort query parameters", async () => {
+    await mockServer.client.mockAnyResponse({
+      httpRequest: {
+        method: "GET",
+        path: "/files",
+        queryStringParameters: {
+          "page[cursor]": ["cursor-1"],
+          "page[size]": ["50"],
+          sort: ["-created"],
+        },
+      },
+      httpResponse: jsonResponse({
+        data: [fileData("file-1")],
+        links: {
+          next: {
+            href: `${mockServer.apiHost}/files?page[cursor]=next-page`,
+          },
+          self: {
+            href: `${mockServer.apiHost}/files?page[cursor]=self-page`,
+          },
+        },
+      }),
+    });
+
+    const res = await callApi((r, response) => handleFiles(r, response), {
+      method: "GET",
+      query: { cursor: "cursor-1", pageSize: "50", sort: "-created" },
+    });
+
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      cursors: { next: "next-page", self: "self-page" },
+      data: [fileData("file-1")],
+      status: 200,
+    });
+
+    await mockServer.client.verify(
+      {
+        method: "GET",
+        path: "/files",
+        queryStringParameters: {
+          "page[cursor]": ["cursor-1"],
+          "page[size]": ["50"],
+          sort: ["-created"],
+        },
+      },
+      1,
+      1
+    );
+  });
+
+  async function callApi(
+    handler: (req: NextIronRequest, res: NextApiResponse) => Promise<void>,
+    req: {
+      readonly body?: string;
+      readonly method: string;
+      readonly query?: Record<string, string | string[]>;
+    }
+  ): Promise<TestRes> {
+    const res = createRes();
+    await handler(createReq(req), res as unknown as NextApiResponse);
+    return res;
+  }
+
+  function createReq({
+    body,
+    method,
+    query = {},
+  }: {
+    readonly body?: string;
+    readonly method: string;
+    readonly query?: Record<string, string | string[]>;
+  }): NextIronRequest {
+    const req: TestReq = {
+      body,
+      method,
+      query,
+      session: createSession(mockServer.apiHost),
+    };
+    return req as NextIronRequest;
+  }
+});
+
+function createRes(): TestRes {
+  let responseBody: unknown;
+  let responseStatus: number | undefined;
+  const res = {} as TestRes;
+  res.body = () => responseBody;
+  res.statusCode = () => responseStatus;
+  res.status = jest.fn((statusCode: number) => {
+    responseStatus = statusCode;
+    return res;
+  });
+  res.json = jest.fn((body: unknown) => {
+    responseBody = body;
+    return res;
+  });
+  return res;
+}
+
+function fileData(id: string): JsonBody {
+  return {
+    attributes: {
+      created: "2026-06-10T15:30:00Z",
+      name: "alpha.jt",
+      status: "completed",
+      suppliedId: "supplied-1",
+      uploaded: "2026-06-10T15:45:00Z",
+    },
+    id,
+    type: "file",
+  };
+}
+
+function createSession(apiHost: string): Session {
+  const values = new Map<string, unknown>([
+    [CredsKey, { id: "client-id", secret: "client-secret" }],
+    [EnvKey, "custom"],
+    [
+      NetworkConfigKey,
+      {
+        apiHost,
+        name: "mock-server",
+        renderingHost: apiHost,
+        sceneTreeHost: apiHost,
+        sceneViewHost: apiHost,
+      },
+    ],
+    [
+      TokenKey,
+      {
+        expiration: Date.now() + 60 * 60 * 1000,
+        token: {
+          access_token: "test-token",
+          account_id: "account-id",
+          expires_in: 60 * 60,
+          scopes: [],
+          token_type: "Bearer",
+        },
+      },
+    ],
+  ]);
+
+  return {
+    get: (key: string) => values.get(key),
+    set: (key: string, value: unknown) => {
+      values.set(key, value);
+    },
+  } as unknown as Session;
+}
+
+function jsonResponse(body: JsonBody, statusCode = 200): JsonBody {
+  return {
+    body: JSON.stringify(body),
+    headers: { "content-type": ["application/json"] },
+    statusCode,
+  };
+}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -22,7 +22,7 @@ import {
   FileCollection,
   toFileCollectionPage,
 } from "../../lib/file-collections";
-import { SwrProps } from "../../lib/paging";
+import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -37,11 +37,13 @@ export const headCells: readonly HeadCell[] = [
 ];
 
 function useFileCollections({ cursor, pageSize, suppliedId }: SwrProps) {
-  const params = new URLSearchParams({ pageSize: pageSize.toString() });
-  if (cursor != null) params.set("cursor", cursor);
-  if (suppliedId != null) params.set("suppliedId", suppliedId);
-
-  return useSWR(`/api/file-collections?${params.toString()}`);
+  return useSWR(
+    buildQuery("/api/file-collections", {
+      cursor,
+      pageSize,
+      suppliedId,
+    })
+  );
 }
 
 interface Props {
@@ -54,12 +56,9 @@ export default function FileCollectionTable({
   onFileCollectionSelected,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
-  const [curPage, setCurPage] = React.useState(0);
-  const [cursor, setCursor] = React.useState<string | undefined>();
+  const { currentPage, cursor, handlePageChange, resetPaging } =
+    useCursorPagingState();
   const [cursors, setCursors] = React.useState<Cursors | undefined>();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
-  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
@@ -79,12 +78,10 @@ export default function FileCollectionTable({
   const debouncedSetSuppliedIdFilter = React.useMemo(
     () =>
       debounce((value: string) => {
-        setCurPage(0);
-        setCursor(undefined);
-        setPrev({});
+        resetPaging();
         setSuppliedIdFilter(value === "" ? undefined : value);
       }, 300),
-    []
+    [resetPaging]
   );
 
   React.useEffect(() => {
@@ -113,12 +110,7 @@ export default function FileCollectionTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
+    handlePageChange(cursors, num);
   }
 
   async function handleDelete() {
@@ -249,7 +241,7 @@ export default function FileCollectionTable({
           component="div"
           count={-1}
           rowsPerPage={pageSize}
-          page={curPage}
+          page={currentPage}
           onPageChange={handleChangePage}
           nextIconButtonProps={{ disabled: cursors?.next == null }}
         />

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -12,7 +12,6 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Cursors } from "@vertexvis/api-client-node";
 import debounce from "lodash.debounce";
 import React from "react";
 import useSWR from "swr";
@@ -56,9 +55,8 @@ export default function FileCollectionTable({
   onFileCollectionSelected,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
-  const { currentPage, cursor, handlePageChange, resetPaging } =
+  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
     useCursorPagingState();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
@@ -88,7 +86,7 @@ export default function FileCollectionTable({
     if (page == null) return;
 
     setCursors(page.cursors ?? undefined);
-  }, [page]);
+  }, [page, setCursors]);
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
     if (page == null) return;
@@ -110,7 +108,7 @@ export default function FileCollectionTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    handlePageChange(cursors, num);
+    handlePageChange(num);
   }
 
   async function handleDelete() {

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -46,10 +46,11 @@ function useFiles({
   pageSize,
   sort,
   suppliedId,
-}: SwrProps & { readonly sort: string }) {
+}: SwrProps & { readonly sort: SortState }) {
+  const sortParam = sort.order === "desc" ? `-${sort.field}` : sort.field;
   const params = new URLSearchParams({
     pageSize: pageSize.toString(),
-    sort,
+    sort: sortParam,
   });
   if (cursor != null) params.set("cursor", cursor);
   if (suppliedId != null) params.set("suppliedId", suppliedId);
@@ -85,11 +86,10 @@ export default function FilesTable({
   const [showToast, setShowToast] = React.useState(false);
   const [downloadError, setDownloadError] = React.useState<string>();
 
-  const sortParam = sort.order === "desc" ? `-${sort.field}` : sort.field;
   const { data, error, mutate } = useFiles({
     cursor,
     pageSize,
-    sort: sortParam,
+    sort,
     suppliedId,
   });
   const page = data ? toFilePage(data) : undefined;

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -16,7 +16,6 @@ import {
   TextField,
   Tooltip,
 } from "@mui/material";
-import { Cursors } from "@vertexvis/api-client-node";
 import debounce from "lodash.debounce";
 import React from "react";
 import useSWR from "swr";
@@ -72,9 +71,8 @@ export default function FilesTable({
     field: "created",
     order: "desc",
   });
-  const { currentPage, cursor, handlePageChange, resetPaging } =
+  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
     useCursorPagingState();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
   const [suppliedId, setSuppliedIdFilter] = React.useState<
@@ -107,7 +105,7 @@ export default function FilesTable({
     if (page == null) return;
 
     setCursors(page.cursors ?? undefined);
-  }, [page]);
+  }, [page, setCursors]);
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
     if (page == null) return;
@@ -129,7 +127,7 @@ export default function FilesTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    handlePageChange(cursors, num);
+    handlePageChange(num);
   }
 
   function handleSortChange(field: string) {

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -27,26 +27,34 @@ import { SwrProps } from "../../lib/paging";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
-import { HeadCell, TableHead } from "../shared/TableHead";
+import { HeadCell, SortState, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
 import CreateFileDialog from "./CreateFileDialog";
 
 export const headCells: readonly HeadCell[] = [
-  { id: "name", disablePadding: true, label: "Name" },
+  { id: "name", disablePadding: true, label: "Name", sortable: true },
   { id: "supplied-id", label: "Supplied ID" },
   { id: "status", label: "Status" },
   { id: "id", label: "ID" },
-  { id: "created", label: "Created" },
+  { id: "created", label: "Created", sortable: true },
   { id: "uploaded", label: "Uploaded" },
   { id: "download", label: "Download" },
 ];
 
-function useFiles({ cursor, pageSize, suppliedId }: SwrProps) {
-  return useSWR(
-    `/api/files?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ""}${
-      suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
-    }`
-  );
+function useFiles({
+  cursor,
+  pageSize,
+  sort,
+  suppliedId,
+}: SwrProps & { readonly sort: string }) {
+  const params = new URLSearchParams({
+    pageSize: pageSize.toString(),
+    sort,
+  });
+  if (cursor != null) params.set("cursor", cursor);
+  if (suppliedId != null) params.set("suppliedId", suppliedId);
+
+  return useSWR(`/api/files?${params.toString()}`);
 }
 
 interface Props {
@@ -59,6 +67,10 @@ export default function FilesTable({
   onFileSelected,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
+  const [sort, setSort] = React.useState<SortState>({
+    field: "created",
+    order: "desc",
+  });
   const [curPage, setCurPage] = React.useState(0);
   const [cursor, setCursor] = React.useState<string | undefined>();
   const [cursors, setCursors] = React.useState<Cursors | undefined>();
@@ -73,14 +85,26 @@ export default function FilesTable({
   const [showToast, setShowToast] = React.useState(false);
   const [downloadError, setDownloadError] = React.useState<string>();
 
-  const { data, error, mutate } = useFiles({ cursor, pageSize, suppliedId });
+  const sortParam = sort.order === "desc" ? `-${sort.field}` : sort.field;
+  const { data, error, mutate } = useFiles({
+    cursor,
+    pageSize,
+    sort: sortParam,
+    suppliedId,
+  });
   const page = data ? toFilePage(data) : undefined;
   const pageLength = page ? page.items.length : 0;
   const emptyRows =
     cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
-    () => debounce(setSuppliedIdFilter, 300),
+    () =>
+      debounce((value: string) => {
+        setCurPage(0);
+        setCursor(undefined);
+        setPrev({});
+        setSuppliedIdFilter(value === "" ? undefined : value);
+      }, 300),
     []
   );
 
@@ -116,6 +140,21 @@ export default function FilesTable({
     }
     if (curPage > num) setCursor(prev[num]);
     setCurPage(num);
+  }
+
+  function handleSortChange(field: string) {
+    setSort((current) => ({
+      field,
+      order:
+        current.field === field
+          ? current.order === "asc"
+            ? "desc"
+            : "asc"
+          : "asc",
+    }));
+    setCurPage(0);
+    setCursor(undefined);
+    setPrev({});
   }
 
   async function handleDelete() {
@@ -175,7 +214,7 @@ export default function FilesTable({
             label="Supplied ID Filter (exact)"
             type="text"
             onChange={(e) => {
-              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? undefined);
+              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? "");
             }}
             sx={{ mt: 0, width: "20rem" }}
           />
@@ -194,7 +233,9 @@ export default function FilesTable({
               headCells={headCells}
               numSelected={selected.size}
               onSelectAllClick={handleSelectAll}
+              onSortChange={handleSortChange}
               rowCount={pageLength}
+              sort={sort}
             />
             <TableBody>
               {error ? (

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -23,11 +23,12 @@ import useSWR from "swr";
 
 import { toLocaleString } from "../../lib/dates";
 import { File, toFilePage } from "../../lib/files";
-import { SwrProps } from "../../lib/paging";
+import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { SortState, toggleSort,toSortParam } from "../../lib/sorting";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
-import { HeadCell, SortState, TableHead } from "../shared/TableHead";
+import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
 import CreateFileDialog from "./CreateFileDialog";
 
@@ -47,15 +48,14 @@ function useFiles({
   sort,
   suppliedId,
 }: SwrProps & { readonly sort: SortState }) {
-  const sortParam = sort.order === "desc" ? `-${sort.field}` : sort.field;
-  const params = new URLSearchParams({
-    pageSize: pageSize.toString(),
-    sort: sortParam,
-  });
-  if (cursor != null) params.set("cursor", cursor);
-  if (suppliedId != null) params.set("suppliedId", suppliedId);
-
-  return useSWR(`/api/files?${params.toString()}`);
+  return useSWR(
+    buildQuery("/api/files", {
+      cursor,
+      pageSize,
+      sort: toSortParam(sort),
+      suppliedId,
+    })
+  );
 }
 
 interface Props {
@@ -72,12 +72,9 @@ export default function FilesTable({
     field: "created",
     order: "desc",
   });
-  const [curPage, setCurPage] = React.useState(0);
-  const [cursor, setCursor] = React.useState<string | undefined>();
+  const { currentPage, cursor, handlePageChange, resetPaging } =
+    useCursorPagingState();
   const [cursors, setCursors] = React.useState<Cursors | undefined>();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
-  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
   const [suppliedId, setSuppliedIdFilter] = React.useState<
@@ -100,12 +97,10 @@ export default function FilesTable({
   const debouncedSetSuppliedIdFilter = React.useMemo(
     () =>
       debounce((value: string) => {
-        setCurPage(0);
-        setCursor(undefined);
-        setPrev({});
+        resetPaging();
         setSuppliedIdFilter(value === "" ? undefined : value);
       }, 300),
-    []
+    [resetPaging]
   );
 
   React.useEffect(() => {
@@ -134,27 +129,12 @@ export default function FilesTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
+    handlePageChange(cursors, num);
   }
 
   function handleSortChange(field: string) {
-    setSort((current) => ({
-      field,
-      order:
-        current.field === field
-          ? current.order === "asc"
-            ? "desc"
-            : "asc"
-          : "asc",
-    }));
-    setCurPage(0);
-    setCursor(undefined);
-    setPrev({});
+    setSort((current) => toggleSort(current, field));
+    resetPaging();
   }
 
   async function handleDelete() {
@@ -313,7 +293,7 @@ export default function FilesTable({
           component="div"
           count={-1}
           rowsPerPage={pageSize}
-          page={curPage}
+          page={currentPage}
           onPageChange={handleChangePage}
           nextIconButtonProps={{ disabled: cursors?.next == null }}
         />

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -13,7 +13,6 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Cursors } from "@vertexvis/api-client-node";
 import debounce from "lodash.debounce";
 import { useRouter } from "next/router";
 import React from "react";
@@ -65,9 +64,8 @@ export default function PartTable({
 }: Props): JSX.Element {
   const router = useRouter();
   const pageSize = DefaultPageSize;
-  const { currentPage, cursor, handlePageChange, resetPaging } =
+  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
     useCursorPagingState();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showCreatePartDialog, setShowCreatePartDialog] = React.useState(
@@ -100,7 +98,7 @@ export default function PartTable({
     if (page == null) return;
 
     setCursors(page.cursors ?? undefined);
-  }, [page]);
+  }, [page, setCursors]);
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
     if (page == null) return;
@@ -122,7 +120,7 @@ export default function PartTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    handlePageChange(cursors, num);
+    handlePageChange(num);
   }
 
   async function handleDelete() {

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -19,7 +19,7 @@ import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
-import { SwrProps } from "../../lib/paging";
+import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartPage } from "../../lib/parts";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
@@ -41,9 +41,11 @@ const headCells: readonly HeadCell[] = [
 
 function useParts({ cursor, pageSize, suppliedId }: SwrProps) {
   return useSWR(
-    `/api/parts?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ""}${
-      suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
-    }`,
+    buildQuery("/api/parts", {
+      cursor,
+      pageSize,
+      suppliedId,
+    }),
     { refreshInterval: 30000 }
   );
 }
@@ -63,13 +65,10 @@ export default function PartTable({
 }: Props): JSX.Element {
   const router = useRouter();
   const pageSize = DefaultPageSize;
-  const [curPage, setCurPage] = React.useState(0);
-  const [cursor, setCursor] = React.useState<string | undefined>();
+  const { currentPage, cursor, handlePageChange, resetPaging } =
+    useCursorPagingState();
   const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
-  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showCreatePartDialog, setShowCreatePartDialog] = React.useState(
     !!router.query.create
@@ -89,8 +88,12 @@ export default function PartTable({
     cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
-    () => debounce(setSuppliedIdFilter, 300),
-    []
+    () =>
+      debounce((value: string | undefined) => {
+        resetPaging();
+        setSuppliedIdFilter(value);
+      }, 300),
+    [resetPaging]
   );
 
   React.useEffect(() => {
@@ -119,12 +122,7 @@ export default function PartTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
+    handlePageChange(cursors, num);
   }
 
   async function handleDelete() {
@@ -218,7 +216,7 @@ export default function PartTable({
           component="div"
           count={-1}
           rowsPerPage={pageSize}
-          page={curPage}
+          page={currentPage}
           onPageChange={handleChangePage}
           nextIconButtonProps={{ disabled: cursors?.next == null }}
         />

--- a/src/components/shared/TableHead.tsx
+++ b/src/components/shared/TableHead.tsx
@@ -7,6 +7,8 @@ import {
 } from "@mui/material";
 import React from "react";
 
+import { SortState } from "../../lib/sorting";
+
 export interface HeadCell {
   readonly beforeCheckbox?: boolean;
   readonly disablePadding?: boolean;
@@ -14,13 +16,6 @@ export interface HeadCell {
   readonly label: string;
   readonly numeric?: boolean;
   readonly sortable?: boolean;
-}
-
-export type SortOrder = "asc" | "desc";
-
-export interface SortState {
-  readonly field: string;
-  readonly order: SortOrder;
 }
 
 interface Props {

--- a/src/components/shared/TableHead.tsx
+++ b/src/components/shared/TableHead.tsx
@@ -3,6 +3,7 @@ import {
   TableCell,
   TableHead as MuiTableHead,
   TableRow,
+  TableSortLabel,
 } from "@mui/material";
 import React from "react";
 
@@ -12,25 +13,41 @@ export interface HeadCell {
   readonly id: string;
   readonly label: string;
   readonly numeric?: boolean;
+  readonly sortable?: boolean;
+}
+
+export type SortOrder = "asc" | "desc";
+
+export interface SortState {
+  readonly field: string;
+  readonly order: SortOrder;
 }
 
 interface Props {
   readonly headCells: readonly HeadCell[];
   readonly numSelected: number;
   readonly onSelectAllClick: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  readonly onSortChange?: (field: string) => void;
   readonly rowCount: number;
+  readonly sort?: SortState;
 }
 
 export function TableHead({
   headCells,
   onSelectAllClick,
+  onSortChange,
   numSelected,
   rowCount,
+  sort,
 }: Props): JSX.Element {
   return (
     <MuiTableHead>
       <TableRow>
-        {renderHeadCells(headCells.filter((hc) => hc.beforeCheckbox))}
+        {renderHeadCells(
+          headCells.filter((hc) => hc.beforeCheckbox),
+          onSortChange,
+          sort
+        )}
         <TableCell padding="checkbox">
           <Checkbox
             color="primary"
@@ -39,19 +56,37 @@ export function TableHead({
             onChange={onSelectAllClick}
           />
         </TableCell>
-        {renderHeadCells(headCells.filter((hc) => !hc.beforeCheckbox))}
+        {renderHeadCells(
+          headCells.filter((hc) => !hc.beforeCheckbox),
+          onSortChange,
+          sort
+        )}
       </TableRow>
     </MuiTableHead>
   );
 }
-function renderHeadCells(cells: readonly HeadCell[]): JSX.Element[] {
+function renderHeadCells(
+  cells: readonly HeadCell[],
+  onSortChange?: (field: string) => void,
+  sort?: SortState
+): JSX.Element[] {
   return cells.map((hc) => (
     <TableCell
       key={hc.id}
       align={hc.numeric ? "right" : "left"}
       padding={hc.disablePadding ? "none" : "normal"}
     >
-      {hc.label}
+      {hc.sortable && onSortChange != null ? (
+        <TableSortLabel
+          active={sort?.field === hc.id}
+          direction={sort?.field === hc.id ? sort.order : "asc"}
+          onClick={() => onSortChange(hc.id)}
+        >
+          {hc.label}
+        </TableSortLabel>
+      ) : (
+        hc.label
+      )}
     </TableCell>
   ));
 }

--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -16,14 +16,24 @@ export interface SwrProps {
 }
 
 type QueryValue = number | string | undefined;
+const QueryParamOrder = ["pageSize", "cursor", "sort", "suppliedId", "name"];
 
 export function buildQuery(
   path: string,
   params: Record<string, QueryValue>
 ): string {
   const query = new URLSearchParams();
+  const entries = Object.entries(params).sort(([leftKey], [rightKey]) => {
+    const leftIndex = QueryParamOrder.indexOf(leftKey);
+    const rightIndex = QueryParamOrder.indexOf(rightKey);
 
-  Object.entries(params).forEach(([key, value]) => {
+    if (leftIndex === -1 && rightIndex === -1) return leftKey.localeCompare(rightKey);
+    if (leftIndex === -1) return 1;
+    if (rightIndex === -1) return -1;
+    return leftIndex - rightIndex;
+  });
+
+  entries.forEach(([key, value]) => {
     if (value != null && value !== "") {
       query.set(key, value.toString());
     }

--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -1,4 +1,5 @@
 import { Cursors } from "@vertexvis/api-client-node";
+import React from "react";
 
 import { GetRes } from "./api";
 
@@ -12,6 +13,62 @@ export interface SwrProps {
   readonly pageSize: number;
   readonly suppliedId?: string;
   readonly name?: string;
+}
+
+type QueryValue = number | string | undefined;
+
+export function buildQuery(
+  path: string,
+  params: Record<string, QueryValue>
+): string {
+  const query = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value != null && value !== "") {
+      query.set(key, value.toString());
+    }
+  });
+
+  const search = query.toString();
+  return search === "" ? path : `${path}?${search}`;
+}
+
+export function useCursorPagingState(): {
+  readonly currentPage: number;
+  readonly cursor?: string;
+  readonly handlePageChange: (
+    cursors: Cursors | undefined,
+    nextPage: number
+  ) => void;
+  readonly resetPaging: () => void;
+} {
+  const [currentPage, setCurrentPage] = React.useState(0);
+  const [cursor, setCursor] = React.useState<string | undefined>();
+  const [previous, setPrevious] = React.useState<
+    Record<number, string | undefined>
+  >({});
+
+  const resetPaging = React.useCallback(() => {
+    setCurrentPage(0);
+    setCursor(undefined);
+    setPrevious({});
+  }, []);
+
+  const handlePageChange = React.useCallback(
+    (cursors: Cursors | undefined, nextPage: number) => {
+      if (currentPage < nextPage) {
+        setPrevious((current) => ({ ...current, [nextPage - 1]: cursors?.self }));
+        setCursor(cursors?.next);
+      } else if (currentPage > nextPage) {
+        setCursor(previous[nextPage]);
+      }
+
+      setCurrentPage(nextPage);
+    },
+    [currentPage, previous]
+  );
+
+  return { currentPage, cursor, handlePageChange, resetPaging };
 }
 
 export function toPage<T extends { attributes: TA; id: string }, TA>({

--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -46,14 +46,16 @@ export function buildQuery(
 export function useCursorPagingState(): {
   readonly currentPage: number;
   readonly cursor?: string;
+  readonly cursors?: Cursors;
   readonly handlePageChange: (
-    cursors: Cursors | undefined,
     nextPage: number
   ) => void;
   readonly resetPaging: () => void;
+  readonly setCursors: React.Dispatch<React.SetStateAction<Cursors | undefined>>;
 } {
   const [currentPage, setCurrentPage] = React.useState(0);
   const [cursor, setCursor] = React.useState<string | undefined>();
+  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [previous, setPrevious] = React.useState<
     Record<number, string | undefined>
   >({});
@@ -61,11 +63,12 @@ export function useCursorPagingState(): {
   const resetPaging = React.useCallback(() => {
     setCurrentPage(0);
     setCursor(undefined);
+    setCursors(undefined);
     setPrevious({});
   }, []);
 
   const handlePageChange = React.useCallback(
-    (cursors: Cursors | undefined, nextPage: number) => {
+    (nextPage: number) => {
       if (currentPage < nextPage) {
         setPrevious((current) => ({ ...current, [nextPage - 1]: cursors?.self }));
         setCursor(cursors?.next);
@@ -75,10 +78,10 @@ export function useCursorPagingState(): {
 
       setCurrentPage(nextPage);
     },
-    [currentPage, previous]
+    [currentPage, cursors, previous]
   );
 
-  return { currentPage, cursor, handlePageChange, resetPaging };
+  return { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors };
 }
 
 export function toPage<T extends { attributes: TA; id: string }, TA>({

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -1,0 +1,27 @@
+export type SortOrder = "asc" | "desc";
+
+export interface SortState<TField extends string = string> {
+  readonly field: TField;
+  readonly order: SortOrder;
+}
+
+export function toSortParam<TField extends string>(
+  sort: SortState<TField>
+): string {
+  return sort.order === "desc" ? `-${sort.field}` : sort.field;
+}
+
+export function toggleSort<TField extends string>(
+  current: SortState<TField>,
+  field: TField
+): SortState<TField> {
+  return {
+    field,
+    order:
+      current.field === field
+        ? current.order === "asc"
+          ? "desc"
+          : "asc"
+        : "asc",
+  };
+}

--- a/src/pages/api/files.ts
+++ b/src/pages/api/files.ts
@@ -1,11 +1,13 @@
 import {
   CreateFileRequestDataAttributes,
+  FileList,
   FileMetadataData,
   getPage,
   head,
   logError,
   VertexError,
 } from "@vertexvis/api-client-node";
+import { AxiosResponse } from "axios";
 import { NextApiResponse } from "next";
 
 import {
@@ -26,7 +28,7 @@ type CreateFileReq = CreateFileRequestDataAttributes;
 
 export type CreateFileRes = Res & Pick<FileMetadataData, "id">;
 
-export default withSession(async function handle(
+export const handleFiles = async function handle(
   req: NextIronRequest,
   res: NextApiResponse<GetRes<FileMetadataData> | Res | ErrorRes>
 ): Promise<void> {
@@ -46,7 +48,9 @@ export default withSession(async function handle(
   }
 
   return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+};
+
+export default withSession(handleFiles);
 
 async function get(
   req: NextIronRequest
@@ -56,13 +60,21 @@ async function get(
     const ps = head(req.query.pageSize);
     const pc = head(req.query.cursor);
     const sId = head(req.query.suppliedId);
+    const sort = head(req.query.sort);
 
     const { cursors, page } = await getPage(() =>
-      c.files.getFiles({
-        pageCursor: pc,
-        pageSize: ps ? parseInt(ps, 10) : 10,
-        filterSuppliedId: sId,
-      })
+      c.axiosInstance.get<FileList>(`${c.config.basePath}/files`, {
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${c.token.access_token}`,
+        },
+        params: {
+          "filter[suppliedId]": sId,
+          "page[cursor]": pc,
+          "page[size]": ps ? parseInt(ps, 10) : 10,
+          sort,
+        },
+      }) as Promise<AxiosResponse<FileList>>
     );
     return { cursors, data: page.data, status: 200 };
   } catch (error) {

--- a/test/msw/server.ts
+++ b/test/msw/server.ts
@@ -1,0 +1,3 @@
+import { setupServer } from "msw/node";
+
+export const server = setupServer();

--- a/yarn.lock
+++ b/yarn.lock
@@ -809,6 +809,14 @@
   dependencies:
     browser-headers "^0.4.1"
 
+"@inquirer/external-editor@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz#c23988291ee676290fdab3fd306e64010a6d13b8"
+  integrity sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.0"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1095,6 +1103,28 @@
   resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
   integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
+"@mswjs/cookies@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mswjs/cookies/-/cookies-0.2.2.tgz#b4e207bf6989e5d5427539c2443380a33ebb922b"
+  integrity sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
+
+"@mswjs/interceptors@^0.17.10":
+  version "0.17.10"
+  resolved "https://registry.yarnpkg.com/@mswjs/interceptors/-/interceptors-0.17.10.tgz#857b41f30e2b92345ed9a4e2b1d0a08b8b6fcad4"
+  integrity sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/debug" "^4.1.7"
+    "@xmldom/xmldom" "^0.8.3"
+    debug "^4.3.3"
+    headers-polyfill "3.2.5"
+    outvariant "^1.2.1"
+    strict-event-emitter "^0.2.4"
+    web-encoding "^1.1.5"
+
 "@mui/core-downloads-tracker@^5.18.0":
   version "5.18.0"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.18.0.tgz#85019a8704b0f63305fc5600635ee663810f2b66"
@@ -1248,6 +1278,11 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1461,10 +1496,17 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@^0.4.0":
+"@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
   integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/debug@^4.1.7":
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.13.tgz#22d1cc9d542d3593caea764f974306ab36286ee7"
+  integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
+  dependencies:
+    "@types/ms" "*"
 
 "@types/docker-modem@*":
   version "3.0.6"
@@ -1542,6 +1584,11 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
+"@types/js-levenshtein@^1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.3.tgz#a6fd0bdc8255b274e5438e0bfb25f154492d1106"
+  integrity sha512-jd+Q+sD20Qfu9e2aEXogiO3vpOC1PYJOUdyN9gvs4Qrvkg4wF43L5OhqrPeokdv8TL0/mXoYfpkcoGZMNN2pkQ==
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -1577,6 +1624,11 @@
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
   integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/multer@^1.4":
   version "1.4.12"
@@ -1670,6 +1722,13 @@
     "@types/http-errors" "*"
     "@types/node" "*"
     "@types/send" "*"
+
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz#ad3a807d6d921db9720621ea3374c5d92020bcbc"
+  integrity sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ssh2-streams@*":
   version "0.1.13"
@@ -1881,6 +1940,16 @@
   resolved "https://registry.yarnpkg.com/@vertexvis/web-workers/-/web-workers-0.1.0.tgz#7be9cb65309d913cfe760472551cbeb32a60c139"
   integrity sha512-X5in1Zh2z6z1V8prVLIUWB9QHrZXCetbaQixgIBRCOo7T7wIgBbj14Ybq6k7dEAqU6DG5O3JMA78/c8ss0dWPA==
 
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.13.tgz#00d1dd940b218dff2e49309d410d8bb212159225"
+  integrity sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==
+
+"@zxing/text-encoding@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
+  integrity sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==
+
 abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -1996,7 +2065,7 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -2367,7 +2436,12 @@ bcrypt-pbkdf@^1.0.2:
   dependencies:
     tweetnacl "^0.14.3"
 
-bl@^4.0.3:
+binary-extensions@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
+  integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
   integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
@@ -2384,7 +2458,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^3.0.3:
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -2488,6 +2562,14 @@ call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
+call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
 call-bind@^1.0.7, call-bind@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
@@ -2498,6 +2580,16 @@ call-bind@^1.0.7, call-bind@^1.0.8:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.2"
 
+call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
+    set-function-length "^1.2.2"
+
 call-bound@^1.0.2, call-bound@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.3.tgz#41cfd032b593e39176a71533ab4f384aa04fd681"
@@ -2505,6 +2597,14 @@ call-bound@^1.0.2, call-bound@^1.0.3:
   dependencies:
     call-bind-apply-helpers "^1.0.1"
     get-intrinsic "^1.2.6"
+
+call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
@@ -2548,7 +2648,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2560,6 +2660,26 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chardet@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.2.0.tgz#005d664f2cbd4961888d2e2c32c5a69e59d8eec4"
+  integrity sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==
+
+chokidar@^3.4.2:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -2581,6 +2701,23 @@ classnames@^2.3.1:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
+cli-spinners@^2.5.0:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
+  integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -2594,6 +2731,11 @@ cliui@^8.0.1:
     string-width "^4.2.0"
     strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 clone@^2.1.2:
   version "2.1.2"
@@ -2726,7 +2868,7 @@ convert-source-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^0.4.1:
+cookie@^0.4.1, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
@@ -2873,7 +3015,7 @@ date-fns@^2.28.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-debug@4, debug@^4.3.5:
+debug@4, debug@^4.3.3, debug@^4.3.5:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2920,6 +3062,13 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+defaults@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
+  integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
+  dependencies:
+    clone "^1.0.2"
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
@@ -3215,6 +3364,13 @@ es-object-atoms@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.0.0.tgz#ddb55cd47ac2e240701260bc2a8e31ecb643d941"
   integrity sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
   dependencies:
     es-errors "^1.3.0"
 
@@ -3696,6 +3852,13 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
@@ -3754,6 +3917,13 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
+  dependencies:
+    is-callable "^1.2.7"
+
 foreground-child@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
@@ -3794,7 +3964,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -3826,6 +3996,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+generator-function@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
+  integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -3852,6 +4027,22 @@ get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6:
     hasown "^2.0.2"
     math-intrinsics "^1.0.0"
 
+get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -3861,6 +4052,14 @@ get-port@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-7.2.0.tgz#db0d52eb2d89890cdc010ed0e9a6f2d4b78cbbe7"
   integrity sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
@@ -3876,7 +4075,7 @@ get-symbol-description@^1.1.0:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
 
-glob-parent@^5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -3966,6 +4165,11 @@ graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+graphql@^16.8.1:
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.2.tgz#83faf25869e3df727cc855161db5da85b0e5b2c0"
+  integrity sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==
+
 handlebars@^4.7.9:
   version "4.7.9"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
@@ -4033,6 +4237,11 @@ hasown@^2.0.4:
   dependencies:
     function-bind "^1.1.2"
 
+headers-polyfill@3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.2.5.tgz#6e67d392c9d113d37448fe45014e0afdd168faed"
+  integrity sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==
+
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -4097,6 +4306,13 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+iconv-lite@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
@@ -4151,6 +4367,27 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+inquirer@^8.2.0:
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.7.tgz#62f6b931a9b7f8735dc42db927316d8fb6f71de8"
+  integrity sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==
+  dependencies:
+    "@inquirer/external-editor" "^1.0.0"
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^6.0.1"
+
 internal-slot@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
@@ -4172,6 +4409,14 @@ iron-store@^1.3.0:
   dependencies:
     "@hapi/iron" "^6.0.0"
     clone "^2.1.2"
+
+is-arguments@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
 
 is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
   version "3.0.5"
@@ -4205,6 +4450,13 @@ is-bigint@^1.1.0:
   integrity sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==
   dependencies:
     has-bigints "^1.0.2"
+
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
 
 is-boolean-object@^1.2.1:
   version "1.2.1"
@@ -4272,17 +4524,38 @@ is-generator-function@^1.0.10:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
+is-generator-function@^1.0.7:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
+  integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
+  dependencies:
+    call-bound "^1.0.4"
+    generator-function "^2.0.0"
+    get-proto "^1.0.1"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
+
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
   integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
+
+is-node-process@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
+  integrity sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==
 
 is-number-object@^1.1.1:
   version "1.1.1"
@@ -4356,7 +4629,7 @@ is-symbol@^1.0.4, is-symbol@^1.1.1:
     has-symbols "^1.1.0"
     safe-regex-test "^1.1.0"
 
-is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15, is-typed-array@^1.1.3:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
@@ -4367,6 +4640,11 @@ is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
+is-unicode-supported@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
+  integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -4854,6 +5132,11 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5037,10 +5320,18 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==
 
-lodash@^4.17.15:
+lodash@^4.17.15, lodash@^4.17.21:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
+
+log-symbols@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-4.1.0.tgz#3fbdbb95b4683ac9fc785111e792e558d4abd503"
+  integrity sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==
+  dependencies:
+    chalk "^4.1.0"
+    is-unicode-supported "^0.1.0"
 
 long@^5.0.0:
   version "5.2.3"
@@ -5203,6 +5494,31 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msw@1.3.5:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-1.3.5.tgz#708396f33a751d690eb8ee1d08713f5e9a77f27c"
+  integrity sha512-nG3fpmBXxFbKSIdk6miPuL3KjU6WMxgoW4tG1YgnP1M+TRG3Qn7b7R0euKAHq4vpwARHb18ZyfZljSxsTnMX2w==
+  dependencies:
+    "@mswjs/cookies" "^0.2.2"
+    "@mswjs/interceptors" "^0.17.10"
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.1"
+    "@types/js-levenshtein" "^1.1.1"
+    chalk "^4.1.1"
+    chokidar "^3.4.2"
+    cookie "^0.4.2"
+    graphql "^16.8.1"
+    headers-polyfill "3.2.5"
+    inquirer "^8.2.0"
+    is-node-process "^1.2.0"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.7"
+    outvariant "^1.4.0"
+    path-to-regexp "^6.3.0"
+    strict-event-emitter "^0.4.3"
+    type-fest "^2.19.0"
+    yargs "^17.3.1"
+
 multer@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/multer/-/multer-2.1.1.tgz#122d819244fbdfee1efddd9147426691014385b7"
@@ -5220,6 +5536,11 @@ multipipe@^1.0.2:
   dependencies:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
+
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.19.0, nan@^2.23.0:
   version "2.27.0"
@@ -5294,6 +5615,13 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp-build@^4.3.0:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
@@ -5309,7 +5637,7 @@ node-releases@^2.0.19:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
   integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -5408,7 +5736,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -5426,6 +5754,26 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+ora@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
+  integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
+  dependencies:
+    bl "^4.1.0"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.5.0"
+    is-interactive "^1.0.0"
+    is-unicode-supported "^0.1.0"
+    log-symbols "^4.1.0"
+    strip-ansi "^6.0.0"
+    wcwidth "^1.0.1"
+
+outvariant@^1.2.1, outvariant@^1.4.0:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
+  integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -5531,6 +5879,11 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
+
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -5541,7 +5894,7 @@ picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@2.3.2, picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
@@ -5840,6 +6193,13 @@ readdir-glob@^1.1.2:
   dependencies:
     minimatch "^5.1.0"
 
+readdirp@~3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
+  integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
+  dependencies:
+    picomatch "^2.2.1"
+
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -5953,6 +6313,14 @@ resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.4, resolve@^1.2
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -5970,12 +6338,24 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rxjs@^7.5.5:
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
+  dependencies:
+    tslib "^2.1.0"
 
 safe-array-concat@^1.1.3:
   version "1.1.3"
@@ -6045,6 +6425,11 @@ semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-cookie-parser@^2.4.6:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
+  integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -6260,6 +6645,18 @@ streamx@^2.12.5, streamx@^2.15.0, streamx@^2.25.0:
     events-universal "^1.0.0"
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
+
+strict-event-emitter@^0.2.4:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz#b4e768927c67273c14c13d20e19d5e6c934b47ca"
+  integrity sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==
+  dependencies:
+    events "^3.3.0"
+
+strict-event-emitter@^0.4.3:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz#ff347c8162b3e931e3ff5f02cfce6772c3b07eb3"
+  integrity sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -6601,7 +6998,7 @@ through2@~0.4.1:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@^2.3.8:
+through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
@@ -6646,6 +7043,11 @@ tr46@^3.0.0:
   integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
   dependencies:
     punycode "^2.1.1"
+
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 trouter@^3.2.0:
   version "3.2.1"
@@ -6722,6 +7124,11 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 type-fest@^4.41.0:
   version "4.41.0"
@@ -6875,6 +7282,17 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+util@^0.12.3:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
 uuid@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
@@ -6913,10 +7331,31 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
+
 weak-map@^1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/weak-map/-/weak-map-1.0.8.tgz#394c18a9e8262e790544ed8b55c6a4ddad1cb1a3"
   integrity sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==
+
+web-encoding@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
+  dependencies:
+    util "^0.12.3"
+  optionalDependencies:
+    "@zxing/text-encoding" "0.9.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^7.0.0:
   version "7.0.0"
@@ -6954,6 +7393,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
@@ -7007,6 +7454,19 @@ which-typed-array@^1.1.16, which-typed-array@^1.1.18:
     gopd "^1.2.0"
     has-tostringtag "^1.0.2"
 
+which-typed-array@^1.1.2:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -7028,6 +7488,15 @@ wordwrap@^1.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Summary
- add sortable file table headers for `name` and `created`
- default the files page to `created` descending so newest files appear first
- proxy the `sort` query through the dashboard files API route to Vertex API
- add targeted UI and API route coverage for file sorting

## Behavior
- default sort: `GET /files?sort=-created`
- clicking the `Created` header toggles created asc/desc
- clicking the `Name` header switches to name sort and toggles asc/desc
- only one sort column is sent at a time

## Testing
- `yarn test --runTestsByPath src/__tests__/components/file/FileTable.test.tsx src/__tests__/pages/api/files.test.ts`
- `yarn lint`



https://github.com/user-attachments/assets/272f59f4-0942-4b75-99cc-d8292777981d

