### PR TITLE
[PLAT-8770] Download File Collections

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -132,7 +132,7 @@ describe("FileCollectionFilesTable", () => {
     );
   });
 
-  it("styles ready file statuses as success", async () => {
+  it("does not style ready file statuses as success", async () => {
     mockFetch(() => ({
       ...collectionFilesPage,
       data: [
@@ -154,7 +154,7 @@ describe("FileCollectionFilesTable", () => {
 
     const statusLabel = await screen.findByText("ready");
     expect(statusLabel.closest(".MuiChip-root")).toHaveClass(
-      "MuiChip-colorSuccess"
+      "MuiChip-colorDefault"
     );
   });
 

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -154,6 +154,53 @@ describe("file collection API routes", () => {
     );
   });
 
+  it("includes export availability when requested", async () => {
+    await mockServer.client.mockAnyResponse({
+      httpRequest: { method: "GET", path: "/file-collections/collection-1" },
+      httpResponse: jsonResponse({
+        data: collectionData("collection-1"),
+        links: {},
+      }),
+    });
+    await mockServer.client.mockAnyResponse({
+      httpRequest: {
+        method: "GET",
+        path: "/file-collections/collection-1/files",
+        queryStringParameters: { "page[size]": ["200"] },
+      },
+      httpResponse: jsonResponse({
+        data: [fileData("file-1", "complete")],
+        links: {},
+      }),
+    });
+
+    const res = await callFileCollectionById("collection-1", {
+      method: "GET",
+      query: { includeExportAvailability: "true" },
+    });
+
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      data: collectionData("collection-1"),
+      export: { enabled: true, fileCount: 1 },
+      status: 200,
+    });
+    await mockServer.client.verify(
+      { method: "GET", path: "/file-collections/collection-1" },
+      1,
+      1
+    );
+    await mockServer.client.verify(
+      {
+        method: "GET",
+        path: "/file-collections/collection-1/files",
+        queryStringParameters: { "page[size]": ["200"] },
+      },
+      1,
+      1
+    );
+  });
+
   it("validates file collection ID requests before calling Vertex", async () => {
     const missingId = await callFileCollectionById(undefined, {
       method: "GET",
@@ -211,11 +258,14 @@ describe("file collection API routes", () => {
 
   function callFileCollectionById(
     id: string | undefined,
-    req: { readonly method: string }
+    req: {
+      readonly method: string;
+      readonly query?: Record<string, string | string[]>;
+    }
   ): Promise<TestRes> {
     return callApi((r, res) => handleFileCollection(r, res), {
       ...req,
-      query: id == null ? {} : { id },
+      query: id == null ? req.query : { ...req.query, id },
     });
   }
 
@@ -331,6 +381,20 @@ function collectionData(id: string): JsonBody {
     },
     id,
     type: "file-collection",
+  };
+}
+
+function fileData(id: string, status: string): JsonBody {
+  return {
+    attributes: {
+      created: "2026-06-12T15:30:00Z",
+      name: `${id}.jt`,
+      status,
+      suppliedId: `${id}-supplied`,
+      uploaded: "2026-06-12T15:31:00Z",
+    },
+    id,
+    type: "file",
   };
 }
 

--- a/src/__tests__/pages/api/file-jobs.test.ts
+++ b/src/__tests__/pages/api/file-jobs.test.ts
@@ -1,0 +1,405 @@
+/**
+ * @jest-environment node
+ */
+import { getPage } from "@vertexvis/api-client-node";
+import type { NextApiResponse } from "next";
+import type { Session } from "next-iron-session";
+
+import type { NextIronRequest } from "../../../lib/with-session";
+import { handleFileJobs } from "../../../pages/api/file-jobs";
+import { handleFileJob } from "../../../pages/api/file-jobs/[id]";
+
+const mockGetClientFromSession = jest.fn();
+const mockGetFileCollectionsApi = jest.fn();
+const mockGetFileJobsApi = jest.fn();
+const mockListFileCollectionFiles = jest.fn();
+const mockCreateFile = jest.fn();
+const mockCreateFileJob = jest.fn();
+const mockGetFileJob = jest.fn();
+const mockGetPage = getPage as jest.Mock;
+
+// todo:PLAT-8812
+jest.mock("@vertexvis/api-client-node", () => {
+  const actual = jest.requireActual("@vertexvis/api-client-node");
+  return {
+    ...actual,
+    getPage: jest.fn(),
+    logError: jest.fn(),
+  };
+});
+
+jest.mock("../../../lib/vertex-api", () => {
+  const actual = jest.requireActual("../../../lib/vertex-api");
+  return {
+    ...actual,
+    getClientFromSession: (...args: unknown[]) =>
+      mockGetClientFromSession(...args),
+  };
+});
+
+jest.mock("../../../lib/file-collections", () => {
+  const actual = jest.requireActual("../../../lib/file-collections");
+  return {
+    ...actual,
+    getFileCollectionsApi: (...args: unknown[]) =>
+      mockGetFileCollectionsApi(...args),
+  };
+});
+
+jest.mock("../../../lib/file-jobs", () => {
+  const actual = jest.requireActual("../../../lib/file-jobs");
+  return {
+    ...actual,
+    getFileJobsApi: (...args: unknown[]) => mockGetFileJobsApi(...args),
+  };
+});
+
+type TestReq = Pick<NextIronRequest, "body" | "method" | "query" | "session">;
+
+interface TestRes extends Pick<NextApiResponse, "json" | "status"> {
+  body: () => unknown;
+  statusCode: () => number | undefined;
+}
+
+describe("file jobs API routes", () => {
+  beforeEach(() => {
+    mockGetClientFromSession.mockResolvedValue({
+      client: "test-client",
+      files: { createFile: mockCreateFile },
+    });
+    mockGetFileCollectionsApi.mockReturnValue({
+      listFileCollectionFiles: mockListFileCollectionFiles,
+    });
+    mockGetFileJobsApi.mockReturnValue({
+      createFileJob: mockCreateFileJob,
+      getFileJob: mockGetFileJob,
+    });
+    mockCreateFileJob.mockResolvedValue({
+      data: queuedJob("job-1", { links: { archive: { href: "https://zip" } } }),
+    });
+    mockCreateFile.mockResolvedValue({
+      data: { data: fileData("archive-file-1", "created") },
+    });
+    mockGetFileJob.mockResolvedValue({
+      data: queuedJob("job-1", {
+        links: { download: { href: "https://zip" } },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates an output file and archive job with every collection file ID", async () => {
+    mockGetPage.mockImplementation(async (apiCall) => {
+      await apiCall();
+      const lastCall =
+        mockListFileCollectionFiles.mock.calls[
+          mockListFileCollectionFiles.mock.calls.length - 1
+        ][0];
+
+      return lastCall.pageCursor == null
+        ? {
+            cursors: { next: "cursor-2", self: "cursor-1" },
+            page: {
+              data: [
+                fileData("file-1", "complete"),
+                fileData("file-2", " COMPLETE "),
+              ],
+            },
+          }
+        : {
+            cursors: { next: undefined, self: "cursor-2" },
+            page: { data: [fileData("file-3", "complete")] },
+          };
+    });
+
+    const res = await callFileJobs({
+      body: JSON.stringify({ fileCollectionId: "collection-1" }),
+      method: "POST",
+    });
+
+    expect(mockListFileCollectionFiles).toHaveBeenCalledTimes(2);
+    expect(mockListFileCollectionFiles).toHaveBeenNthCalledWith(1, {
+      id: "collection-1",
+      pageCursor: undefined,
+      pageSize: 200,
+    });
+    expect(mockListFileCollectionFiles).toHaveBeenNthCalledWith(2, {
+      id: "collection-1",
+      pageCursor: "cursor-2",
+      pageSize: 200,
+    });
+    expect(mockCreateFile).toHaveBeenCalledWith({
+      createFileRequest: {
+        data: {
+          attributes: {
+            expiry: 86400,
+            metadata: { fileCollectionId: "collection-1" },
+            name: "file-collection-collection-1.zip",
+          },
+          type: "file",
+        },
+      },
+    });
+    expect(mockCreateFileJob).toHaveBeenCalledWith({
+      createFileJobRequest: {
+        data: {
+          attributes: {
+            operation: {
+              fileId: "archive-file-1",
+              manifest: [
+                { selector: { id: "file-1", type: "file-by-id" } },
+                { selector: { id: "file-2", type: "file-by-id" } },
+                { selector: { id: "file-3", type: "file-by-id" } },
+              ],
+              type: "file-archive-operation",
+            },
+          },
+          type: "file-job",
+        },
+      },
+    });
+    expect(res.statusCode()).toBe(201);
+    expect(res.body()).toEqual({
+      archiveFileId: "archive-file-1",
+      data: queuedJob("job-1", {
+        links: { archive: { href: "https://zip" } },
+      }).data,
+      status: 201,
+    });
+  });
+
+  it("uses an optional archive name when creating the output file", async () => {
+    mockGetPage.mockImplementation(async (apiCall) => {
+      await apiCall();
+      return {
+        cursors: { next: undefined, self: undefined },
+        page: { data: [fileData("file-1", "complete")] },
+      };
+    });
+
+    const res = await callFileJobs({
+      body: JSON.stringify({
+        archiveName: "Custom collection.zip",
+        fileCollectionId: "collection-1",
+      }),
+      method: "POST",
+    });
+
+    expect(mockCreateFile).toHaveBeenCalledWith({
+      createFileRequest: {
+        data: {
+          attributes: {
+            expiry: 86400,
+            metadata: { fileCollectionId: "collection-1" },
+            name: "Custom collection.zip",
+          },
+          type: "file",
+        },
+      },
+    });
+    expect(res.body()).toMatchObject({
+      archiveFileId: "archive-file-1",
+      status: 201,
+    });
+  });
+
+  it("rejects zero-file collections before creating a job", async () => {
+    mockGetPage.mockImplementation(async (apiCall) => {
+      await apiCall();
+      return {
+        cursors: { next: undefined, self: undefined },
+        page: { data: [] },
+      };
+    });
+
+    const res = await callFileJobs({
+      body: JSON.stringify({ fileCollectionId: "collection-1" }),
+      method: "POST",
+    });
+
+    expect(res.statusCode()).toBe(400);
+    expect(res.body()).toEqual({
+      message: "File collection has no files to export.",
+      status: 400,
+    });
+    expect(mockCreateFile).not.toHaveBeenCalled();
+    expect(mockCreateFileJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects collections containing non-complete files", async () => {
+    mockGetPage.mockImplementation(async (apiCall) => {
+      await apiCall();
+      return {
+        cursors: { next: undefined, self: undefined },
+        page: {
+          data: [fileData("file-1", "completed"), fileData("file-2", "ready")],
+        },
+      };
+    });
+
+    const res = await callFileJobs({
+      body: JSON.stringify({ fileCollectionId: "collection-1" }),
+      method: "POST",
+    });
+
+    expect(res.statusCode()).toBe(400);
+    expect(res.body()).toEqual({
+      message: "File collection contains files that are not ready to export.",
+      status: 400,
+    });
+    expect(mockCreateFile).not.toHaveBeenCalled();
+    expect(mockCreateFileJob).not.toHaveBeenCalled();
+  });
+
+  it("proxies file job reads", async () => {
+    const res = await callFileJobById({
+      method: "GET",
+      query: { id: "job-1" },
+    });
+
+    expect(mockGetFileJob).toHaveBeenCalledWith({ id: "job-1" });
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      data: queuedJob("job-1", {
+        links: { download: { href: "https://zip" } },
+      }).data,
+      status: 200,
+    });
+  });
+
+  it("validates file job requests before calling Vertex", async () => {
+    const missingBody = await callFileJobs({ method: "POST" });
+    const invalidBody = await callFileJobs({
+      body: "{}",
+      method: "POST",
+    });
+    const missingId = await callFileJobById({
+      method: "GET",
+      query: {},
+    });
+    const unsupportedMethod = await callFileJobById({
+      method: "DELETE",
+      query: { id: "job-1" },
+    });
+
+    expect(missingBody.statusCode()).toBe(400);
+    expect(missingBody.body()).toEqual({
+      message: "Body required.",
+      status: 400,
+    });
+    expect(invalidBody.statusCode()).toBe(400);
+    expect(invalidBody.body()).toEqual({
+      message: "Invalid body.",
+      status: 400,
+    });
+    expect(missingId.statusCode()).toBe(400);
+    expect(missingId.body()).toEqual({
+      message: "File Job ID required.",
+      status: 400,
+    });
+    expect(unsupportedMethod.statusCode()).toBe(405);
+    expect(unsupportedMethod.body()).toEqual({
+      message: "Method not allowed.",
+      status: 405,
+    });
+    expect(mockGetClientFromSession).not.toHaveBeenCalled();
+  });
+});
+
+function callFileJobs(req: {
+  readonly body?: string;
+  readonly method: string;
+  readonly query?: Record<string, string | string[]>;
+}): Promise<TestRes> {
+  return callApi((r, res) => handleFileJobs(r, res), req);
+}
+
+function callFileJobById(req: {
+  readonly body?: string;
+  readonly method: string;
+  readonly query?: Record<string, string | string[]>;
+}): Promise<TestRes> {
+  return callApi((r, res) => handleFileJob(r, res), req);
+}
+
+async function callApi(
+  handler: (req: NextIronRequest, res: NextApiResponse) => Promise<void>,
+  req: {
+    readonly body?: string;
+    readonly method: string;
+    readonly query?: Record<string, string | string[]>;
+  }
+): Promise<TestRes> {
+  const res = createRes();
+  await handler(createReq(req), res as unknown as NextApiResponse);
+  return res;
+}
+
+function createReq({
+  body,
+  method,
+  query = {},
+}: {
+  readonly body?: string;
+  readonly method: string;
+  readonly query?: Record<string, string | string[]>;
+}): NextIronRequest {
+  const req: TestReq = {
+    body,
+    method,
+    query,
+    session: {} as Session,
+  };
+  return req as NextIronRequest;
+}
+
+function createRes(): TestRes {
+  let responseBody: unknown;
+  let responseStatus: number | undefined;
+  const res = {} as TestRes;
+  res.body = () => responseBody;
+  res.statusCode = () => responseStatus;
+  res.status = jest.fn((statusCode: number): NextApiResponse => {
+    responseStatus = statusCode;
+    return res as unknown as NextApiResponse;
+  });
+  res.json = jest.fn((body: unknown): NextApiResponse => {
+    responseBody = body;
+    return res as unknown as NextApiResponse;
+  });
+  return res;
+}
+
+function queuedJob(
+  id: string,
+  dataOverrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    data: {
+      attributes: {
+        created: "2026-06-29T15:30:00Z",
+        status: "running",
+      },
+      id,
+      type: "queued-job",
+      ...dataOverrides,
+    },
+  };
+}
+
+function fileData(id: string, status: string): Record<string, unknown> {
+  return {
+    attributes: {
+      created: "2026-06-12T15:30:00Z",
+      name: `${id}.jt`,
+      status,
+      suppliedId: `${id}-supplied`,
+      uploaded: "2026-06-12T15:31:00Z",
+    },
+    id,
+    type: "file",
+  };
+}

--- a/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
+++ b/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { Session } from "next-iron-session";
 import React from "react";
 
@@ -23,6 +29,7 @@ const mockFileCollectionFilesTable = jest.fn(
     </div>
   )
 );
+const originalFetch = global.fetch;
 
 jest.mock("../../../components/shared/Layout", () => ({
   Layout: ({ main }: { readonly main: unknown }) => main,
@@ -54,6 +61,12 @@ jest.mock("../../../lib/file-collections", () => {
 
 describe("FileCollectionDetails", () => {
   beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue(
+      jsonResponse({
+        export: { enabled: true, fileCount: 2 },
+        status: 200,
+      })
+    );
     mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
     mockGetFileCollectionsApi.mockReturnValue({
       getFileCollection: mockGetFileCollection,
@@ -62,10 +75,12 @@ describe("FileCollectionDetails", () => {
   });
 
   afterEach(() => {
+    global.fetch = originalFetch;
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
-  it("renders return navigation and file collection metadata", () => {
+  it("renders return navigation and file collection metadata", async () => {
     render(
       <FileCollectionDetails
         fileCollection={{
@@ -88,6 +103,11 @@ describe("FileCollectionDetails", () => {
     expect(screen.getByText("supplied-1")).toBeInTheDocument();
     expect(screen.getByText("source")).toBeInTheDocument();
     expect(screen.getByText("unit-test")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Export Archive" })
+      ).toBeEnabled()
+    );
   });
 
   it("renders the collection files table below metadata", async () => {
@@ -112,6 +132,392 @@ describe("FileCollectionDetails", () => {
       "data-api-path",
       "/api/file-collections/collection-1/files"
     );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Export Archive" })
+      ).toBeEnabled()
+    );
+  });
+
+  it("disables export and shows the server readiness reason", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      jsonResponse({
+        export: {
+          disabledReason: "File collection has no files to export.",
+          enabled: false,
+          fileCount: 0,
+        },
+        status: 200,
+      })
+    );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const button = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+
+    expect(
+      await screen.findByText("File collection has no files to export.")
+    ).toBeInTheDocument();
+    expect(button).toBeDisabled();
+  });
+
+  it("refreshes export availability after files become ready", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: {
+            disabledReason:
+              "File collection contains files that are not ready to export.",
+            enabled: false,
+            fileCount: 2,
+          },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    expect(exportButton).toBeDisabled();
+    expect(
+      await screen.findByText(
+        "File collection contains files that are not ready to export."
+      )
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh Availability" })
+    );
+
+    await waitFor(() => expect(exportButton).toBeEnabled());
+  });
+
+  it("refreshes export availability after a transient readiness failure", async () => {
+    (global.fetch as jest.Mock)
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    expect(exportButton).toBeDisabled();
+    expect(
+      await screen.findByText("Could not check export availability.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh Availability" })
+    );
+
+    await waitFor(() => expect(exportButton).toBeEnabled());
+  });
+
+  it("keeps polling running archive jobs and shows the download action after completion", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(window, "open").mockReturnValue({} as Window);
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            archiveFileId: "archive-file-1",
+            data: {
+              attributes: { status: "running" },
+              id: "job-1",
+            },
+            status: 201,
+          },
+          201
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            attributes: { status: "running" },
+            id: "job-1",
+          },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            attributes: { status: "complete" },
+            id: "job-1",
+          },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          status: 200,
+          url: "https://example.test/archive.zip",
+        })
+      );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    fireEvent.click(exportButton);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs", {
+        body: JSON.stringify({ fileCollectionId: "collection-1" }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      })
+    );
+    expect(
+      screen.getByRole("button", { name: "Exporting Archive" })
+    ).toBeDisabled();
+    await screen.findByText("Archive job is running.");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+    );
+    expect(
+      screen.getByRole("button", { name: "Exporting Archive" })
+    ).toBeDisabled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+    );
+
+    const download = await screen.findByRole("button", {
+      name: "Download Archive",
+    });
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/files/archive-file-1/download-url",
+      { method: "POST" }
+    );
+    expect(
+      screen.getByText("Archive is ready to download.")
+    ).toBeInTheDocument();
+
+    fireEvent.click(download);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/files/archive-file-1/download-url",
+        { method: "POST" }
+      )
+    );
+    expect(window.open).toHaveBeenCalledWith(
+      "https://example.test/archive.zip",
+      "_blank",
+      "noopener"
+    );
+  });
+
+  it("shows a retryable failure when archive export cannot be started", async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      )
+      .mockRejectedValueOnce(new Error("Network error"));
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    fireEvent.click(exportButton);
+
+    expect(
+      await screen.findByText("Could not start archive export.")
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      screen.getByRole("button", { name: "Export Archive" })
+    ).toBeEnabled();
+  });
+
+  it("shows a failure when the download URL cannot be created", async () => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            archiveFileId: "archive-file-1",
+            data: {
+              attributes: { status: "running" },
+              id: "job-1",
+            },
+            status: 201,
+          },
+          201
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            attributes: { status: "complete" },
+            id: "job-1",
+          },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            message: "Could not create download URL.",
+            status: 500,
+          },
+          500
+        )
+      );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    fireEvent.click(exportButton);
+
+    await screen.findByText("Archive job is running.");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+    );
+
+    const download = await screen.findByRole("button", {
+      name: "Download Archive",
+    });
+
+    fireEvent.click(download);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/files/archive-file-1/download-url",
+        { method: "POST" }
+      )
+    );
+    expect(
+      await screen.findByText("Could not create download URL.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download Archive" })
+    ).toBeEnabled();
+  });
+
+  it("shows failed archive jobs and allows retry from the page", async () => {
+    jest.useFakeTimers();
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          export: { enabled: true, fileCount: 2 },
+          status: 200,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            archiveFileId: "archive-file-1",
+            data: {
+              attributes: { status: "running" },
+              id: "job-1",
+            },
+            status: 201,
+          },
+          201
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          data: {
+            attributes: { status: "error" },
+            id: "job-1",
+          },
+          status: 200,
+        })
+      );
+
+    render(<FileCollectionDetails fileCollection={fileCollection()} />);
+
+    const exportButton = await screen.findByRole("button", {
+      name: "Export Archive",
+    });
+    await waitFor(() => expect(exportButton).toBeEnabled());
+
+    fireEvent.click(exportButton);
+
+    await screen.findByText("Archive job is running.");
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+
+    expect(await screen.findByText("Archive job failed.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      screen.getByRole("button", { name: "Export Archive" })
+    ).toBeEnabled();
   });
 
   it("loads a file collection by URL ID on the server", async () => {
@@ -242,4 +648,23 @@ function createSession({
       values.set(key, value);
     },
   } as unknown as Session;
+}
+
+function fileCollection() {
+  return {
+    id: "collection-1",
+    name: "Collection One",
+    suppliedId: "supplied-1",
+    created: "2026-06-10T15:30:00Z",
+    expiresAt: "2026-07-10T15:30:00Z",
+    metadata: { source: "unit-test" },
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    json: () => Promise.resolve(body),
+    ok: status >= 200 && status < 300,
+    status,
+  } as Response;
 }

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -19,7 +19,13 @@ import useSWR from "swr";
 
 import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
-import { File, toFilePage } from "../../lib/files";
+import {
+  File,
+  FileStatusComplete,
+  isCompleteFileStatus,
+  normalizeFileStatus,
+  toFilePage,
+} from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -61,7 +67,7 @@ function useCollectionFiles({
 }
 
 function isFileAvailable(file: File): boolean {
-  return file.status?.toLowerCase() === "complete";
+  return isCompleteFileStatus(file.status);
 }
 
 function statusLabel(status?: string): string {
@@ -71,9 +77,8 @@ function statusLabel(status?: string): string {
 function statusColor(
   status?: string
 ): "default" | "success" | "warning" | "error" {
-  switch (status?.toLowerCase()) {
-    case "complete":
-    case "ready":
+  switch (normalizeFileStatus(status)) {
+    case FileStatusComplete:
       return "success";
     case "pending":
       return "warning";

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -164,9 +164,9 @@ export default function FileTable({
   } = useCursorPagingState();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
-  const [name, setNameFilter] = React.useState<string | undefined>();
-  const [fileId, setFileIdFilter] = React.useState<string | undefined>();
-  const [suppliedId, setSuppliedIdFilter] = React.useState<
+  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
+  const [fileIdFilter, setFileIdFilter] = React.useState<string | undefined>();
+  const [suppliedIdFilter, setSuppliedIdFilter] = React.useState<
     string | undefined
   >();
   const [createdAtStartDate, setCreatedAtStartDate] = React.useState("");
@@ -182,11 +182,11 @@ export default function FileTable({
     createdAtEnd,
     createdAtStart,
     cursor,
-    fileId,
-    name,
+    fileId: fileIdFilter,
+    name: nameFilter,
     pageSize,
     sort,
-    suppliedId,
+    suppliedId: suppliedIdFilter,
   });
   const loadError = error ?? (isErrorRes(data) ? data : undefined);
   const page = data && !isErrorRes(data) ? toFilePage(data) : undefined;

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -23,7 +23,13 @@ import useSWR from "swr";
 
 import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
-import { File, toFilePage } from "../../lib/files";
+import {
+  File,
+  FileStatusComplete,
+  isCompleteFileStatus,
+  normalizeFileStatus,
+  toFilePage,
+} from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
@@ -78,13 +84,7 @@ function useFiles({
 }
 
 function isFileAvailable(file: File): boolean {
-  const status = normalizeStatus(file.status);
-
-  return status === "complete";
-}
-
-function normalizeStatus(status?: string): string | undefined {
-  return status?.toLowerCase();
+  return isCompleteFileStatus(file.status);
 }
 
 function statusLabel(status?: string): string {
@@ -94,9 +94,8 @@ function statusLabel(status?: string): string {
 function statusColor(
   status?: string
 ): "default" | "success" | "warning" | "error" {
-  switch (normalizeStatus(status)) {
-    case "complete":
-    case "ready":
+  switch (normalizeFileStatus(status)) {
+    case FileStatusComplete:
       return "success";
     case "pending":
       return "warning";

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -20,10 +20,10 @@ export interface FileCollectionExportAvailability {
   readonly fileCount: number;
 }
 
-export type GetFileCollectionRes = Res &
-  Pick<FileCollectionMetadata, "data"> & {
-    readonly export?: FileCollectionExportAvailability;
-  };
+export type GetFileCollectionRes = Res & {
+  readonly data: FileCollectionMetadataData;
+  readonly export?: FileCollectionExportAvailability;
+};
 
 export function toFileCollection(
   data: FileCollectionMetadataData

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -2,14 +2,28 @@ import {
   FileCollectionList,
   FileCollectionMetadataData,
   FileCollectionsApi,
+  FileMetadataData,
+  getPage,
   VertexClient,
 } from "@vertexvis/api-client-node";
 
-import { GetRes } from "./api";
+import { GetRes, Res } from "./api";
+import { isCompleteFileStatus } from "./files";
 import { Paged, toPage } from "./paging";
 
 export type FileCollection = FileCollectionList["data"][number]["attributes"] &
   Pick<FileCollectionList["data"][number], "id">;
+
+export interface FileCollectionExportAvailability {
+  readonly disabledReason?: string;
+  readonly enabled: boolean;
+  readonly fileCount: number;
+}
+
+export type GetFileCollectionRes = Res &
+  Pick<FileCollectionMetadata, "data"> & {
+    readonly export?: FileCollectionExportAvailability;
+  };
 
 export function toFileCollection(
   data: FileCollectionMetadataData
@@ -30,4 +44,58 @@ export function getFileCollectionsApi(
   client: VertexClient
 ): FileCollectionsApi {
   return new FileCollectionsApi(client.config, undefined, client.axiosInstance);
+}
+
+export async function fetchAllFileCollectionFiles(
+  api: FileCollectionsApi,
+  id: string
+): Promise<FileMetadataData[]> {
+  const files: FileMetadataData[] = [];
+  let cursor: string | undefined;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    // Each request depends on the cursor returned by the previous page.
+    // eslint-disable-next-line no-await-in-loop
+    const { cursors, page } = await getPage(() =>
+      api.listFileCollectionFiles({
+        id,
+        pageCursor: cursor,
+        pageSize: 200,
+      })
+    );
+
+    files.push(...page.data);
+    hasNextPage = cursors.next != null;
+    cursor = cursors.next;
+  }
+
+  return files;
+}
+
+export function getFileCollectionExportAvailability(
+  files: FileMetadataData[]
+): FileCollectionExportAvailability {
+  if (files.length === 0) {
+    return {
+      disabledReason: "File collection has no files to export.",
+      enabled: false,
+      fileCount: 0,
+    };
+  }
+
+  const hasIncompleteFiles = files.some(
+    (file) => !isCompleteFileStatus(file.attributes.status)
+  );
+
+  if (hasIncompleteFiles) {
+    return {
+      disabledReason:
+        "File collection contains files that are not ready to export.",
+      enabled: false,
+      fileCount: files.length,
+    };
+  }
+
+  return { enabled: true, fileCount: files.length };
 }

--- a/src/lib/file-jobs.ts
+++ b/src/lib/file-jobs.ts
@@ -1,0 +1,57 @@
+import {
+  CreateFileJobRequest,
+  CreateFileJobRequestDataTypeEnum,
+  FileJobArchiveOperationTypeEnum,
+  FileJobsApi,
+  FileMetadataData,
+  QueuedJob,
+  SelectFileByIdTypeEnum,
+  VertexClient,
+} from "@vertexvis/api-client-node";
+
+import { Res } from "./api";
+
+export interface FileJobRes extends Res {
+  readonly archiveFileId?: string;
+  readonly data: QueuedJob["data"];
+  readonly links?: NonNullable<QueuedJob["links"]>;
+}
+
+export function getFileJobsApi(client: VertexClient): FileJobsApi {
+  return new FileJobsApi(client.config, undefined, client.axiosInstance);
+}
+
+export function buildFileArchiveJobRequest(
+  files: FileMetadataData[],
+  archiveFileId: string
+): CreateFileJobRequest {
+  const fileIds = files.map((file) => file.id);
+
+  return {
+    data: {
+      type: CreateFileJobRequestDataTypeEnum.FileJob,
+      attributes: {
+        operation: {
+          type: FileJobArchiveOperationTypeEnum.FileArchiveOperation,
+          fileId: archiveFileId,
+          manifest: fileIds.map((id) => ({
+            selector: { type: SelectFileByIdTypeEnum.FileById, id },
+          })),
+        },
+      },
+    },
+  };
+}
+
+export function toFileJobRes(
+  job: QueuedJob,
+  status = 200,
+  archiveFileId?: string
+): FileJobRes {
+  return {
+    ...(archiveFileId == null ? {} : { archiveFileId }),
+    ...(job.links == null ? {} : { links: job.links }),
+    data: job.data,
+    status,
+  };
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,10 +1,24 @@
 import { FileList } from "@vertexvis/api-client-node";
 
-import { GetRes } from "./api";
+import { GetRes, Res } from "./api";
 import { Paged, toPage } from "./paging";
 
 export type File = FileList["data"][number]["attributes"] &
   Pick<FileList["data"][number], "id">;
+
+export interface FileDownloadUrlRes extends Res {
+  readonly url: string;
+}
+
+export const FileStatusComplete = "complete";
+
+export function normalizeFileStatus(status?: string): string | undefined {
+  return status?.trim().toLowerCase();
+}
+
+export function isCompleteFileStatus(status?: string): boolean {
+  return normalizeFileStatus(status) === FileStatusComplete;
+}
 
 export function toFilePage(res: GetRes<FileList["data"][number]>): Paged<File> {
   return toPage<

--- a/src/pages/api/file-collections/[id]/index.ts
+++ b/src/pages/api/file-collections/[id]/index.ts
@@ -1,24 +1,21 @@
-import {
-  FileCollectionMetadata,
-  head,
-  logError,
-  VertexError,
-} from "@vertexvis/api-client-node";
+import { head, logError, VertexError } from "@vertexvis/api-client-node";
 import { NextApiResponse } from "next";
 
 import {
   ErrorRes,
   isErrorFailure,
   MethodNotAllowed,
-  Res,
   ServerError,
   toErrorRes,
 } from "../../../../lib/api";
-import { getFileCollectionsApi } from "../../../../lib/file-collections";
+import {
+  fetchAllFileCollectionFiles,
+  getFileCollectionExportAvailability,
+  GetFileCollectionRes,
+  getFileCollectionsApi,
+} from "../../../../lib/file-collections";
 import { getClientFromSession, makeCall } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
-
-type GetFileCollectionRes = Res & Pick<FileCollectionMetadata, "data">;
 
 export async function handleFileCollection(
   req: NextIronRequest,
@@ -45,6 +42,17 @@ async function get(
     const c = getFileCollectionsApi(await getClientFromSession(req.session));
     const res = await makeCall(() => c.getFileCollection({ id }));
     if (isErrorFailure(res)) return toErrorRes({ failure: res });
+
+    if (head(req.query.includeExportAvailability) === "true") {
+      const files = await fetchAllFileCollectionFiles(c, id);
+      const availability = getFileCollectionExportAvailability(files);
+
+      return {
+        data: res.data,
+        export: availability,
+        status: 200,
+      };
+    }
 
     return { data: res.data, status: 200 };
   } catch (error) {

--- a/src/pages/api/file-jobs.ts
+++ b/src/pages/api/file-jobs.ts
@@ -1,0 +1,149 @@
+import { logError, VertexError } from "@vertexvis/api-client-node";
+import { NextApiResponse } from "next";
+
+import {
+  BodyRequired,
+  ErrorRes,
+  InvalidBody,
+  isErrorFailure,
+  MethodNotAllowed,
+  ServerError,
+  toErrorRes,
+} from "../../lib/api";
+import {
+  fetchAllFileCollectionFiles,
+  getFileCollectionExportAvailability,
+  getFileCollectionsApi,
+} from "../../lib/file-collections";
+import {
+  buildFileArchiveJobRequest,
+  FileJobRes,
+  getFileJobsApi,
+  toFileJobRes,
+} from "../../lib/file-jobs";
+import { getClientFromSession, makeCall } from "../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../lib/with-session";
+
+const DefaultArchiveFileExpirySeconds = 24 * 60 * 60;
+
+interface CreateFileJobReq {
+  readonly archiveName?: string;
+  readonly fileCollectionId: string;
+}
+
+interface RawCreateFileJobReq {
+  readonly archiveName?: string;
+  readonly fileCollectionId?: string;
+}
+
+export async function handleFileJobs(
+  req: NextIronRequest,
+  res: NextApiResponse<FileJobRes | ErrorRes>
+): Promise<void> {
+  if (req.method === "POST") {
+    const r = await create(req);
+    return res.status(r.status).json(r);
+  }
+
+  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+}
+
+export default withSession(handleFileJobs);
+
+async function create(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
+  try {
+    if (!req.body) return BodyRequired;
+
+    const body = parseCreateFileJobReq(req.body);
+    if (body == null) return InvalidBody;
+
+    const client = await getClientFromSession(req.session);
+    const { fileCollectionId } = body;
+    const files = await fetchAllFileCollectionFiles(
+      getFileCollectionsApi(client),
+      fileCollectionId
+    );
+
+    const exportAvailability = getFileCollectionExportAvailability(files);
+    if (!exportAvailability.enabled) {
+      return {
+        message:
+          exportAvailability.disabledReason ??
+          "File collection is not exportable.",
+        status: 400,
+      };
+    }
+
+    const archiveFile = await makeCall(() =>
+      client.files.createFile({
+        createFileRequest: {
+          data: {
+            type: "file",
+            attributes: {
+              expiry: DefaultArchiveFileExpirySeconds,
+              metadata: { fileCollectionId },
+              name:
+                body.archiveName ?? buildDefaultArchiveName(fileCollectionId),
+            },
+          },
+        },
+      })
+    );
+    if (isErrorFailure(archiveFile))
+      return toErrorRes({ failure: archiveFile });
+
+    const job = await makeCall(() =>
+      getFileJobsApi(client).createFileJob({
+        createFileJobRequest: buildFileArchiveJobRequest(
+          files,
+          archiveFile.data.id
+        ),
+      })
+    );
+    if (isErrorFailure(job)) return toErrorRes({ failure: job });
+
+    return toFileJobRes(job, 201, archiveFile.data.id);
+  } catch (error) {
+    const e = error as VertexError;
+    logError(e);
+    return e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError?.res })
+      : ServerError;
+  }
+}
+
+function parseCreateFileJobReq(body: unknown): CreateFileJobReq | undefined {
+  try {
+    const parsed =
+      typeof body === "string"
+        ? (JSON.parse(body) as RawCreateFileJobReq)
+        : (body as RawCreateFileJobReq);
+
+    const fileCollectionId = requireStringParam(parsed.fileCollectionId);
+    const archiveName = parseOptionalStringParam(parsed.archiveName);
+
+    return archiveName == null
+      ? { fileCollectionId }
+      : { archiveName, fileCollectionId };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseOptionalStringParam(value: unknown): string | undefined {
+  return value == null ? undefined : requireStringParam(value);
+}
+
+function requireStringParam(value: unknown): string {
+  if (typeof value !== "string") throw new Error("Expected string param.");
+
+  const trimmed = value.trim();
+  if (trimmed === "") throw new Error("Expected non-empty string param.");
+
+  return trimmed;
+}
+
+function buildDefaultArchiveName(fileCollectionId: string): string {
+  const safeFileCollectionId = fileCollectionId.replace(/[^a-z0-9._-]/gi, "-");
+  return `file-collection-${safeFileCollectionId}.zip`;
+}

--- a/src/pages/api/file-jobs/[id].ts
+++ b/src/pages/api/file-jobs/[id].ts
@@ -1,0 +1,50 @@
+import { head, logError, VertexError } from "@vertexvis/api-client-node";
+import { NextApiResponse } from "next";
+
+import {
+  ErrorRes,
+  isErrorFailure,
+  MethodNotAllowed,
+  ServerError,
+  toErrorRes,
+} from "../../../lib/api";
+import {
+  FileJobRes,
+  getFileJobsApi,
+  toFileJobRes,
+} from "../../../lib/file-jobs";
+import { getClientFromSession, makeCall } from "../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../lib/with-session";
+
+export async function handleFileJob(
+  req: NextIronRequest,
+  res: NextApiResponse<FileJobRes | ErrorRes>
+): Promise<void> {
+  if (req.method === "GET") {
+    const r = await get(req);
+    return res.status(r.status).json(r);
+  }
+
+  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+}
+
+export default withSession(handleFileJob);
+
+async function get(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
+  try {
+    const id = head(req.query.id);
+    if (id == null) return { message: "File Job ID required.", status: 400 };
+
+    const client = await getClientFromSession(req.session);
+    const job = await makeCall(() => getFileJobsApi(client).getFileJob({ id }));
+    if (isErrorFailure(job)) return toErrorRes({ failure: job });
+
+    return toFileJobRes(job);
+  } catch (error) {
+    const e = error as VertexError;
+    logError(e);
+    return e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError?.res })
+      : ServerError;
+  }
+}

--- a/src/pages/api/files/[id]/download-url.ts
+++ b/src/pages/api/files/[id]/download-url.ts
@@ -5,22 +5,18 @@ import {
   ErrorRes,
   InvalidBody,
   MethodNotAllowed,
-  Res,
   ServerError,
   toErrorRes,
 } from "../../../../lib/api";
+import { FileDownloadUrlRes } from "../../../../lib/files";
 import { getClientFromSession } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
 const DefaultDownloadExpirySeconds = 30;
 
-interface CreateDownloadUrlRes extends Res {
-  readonly url: string;
-}
-
 export default withSession(async function handle(
   req: NextIronRequest,
-  res: NextApiResponse<CreateDownloadUrlRes | ErrorRes>
+  res: NextApiResponse<FileDownloadUrlRes | ErrorRes>
 ): Promise<void> {
   if (req.method === "POST") {
     const r = await create(req);
@@ -32,7 +28,7 @@ export default withSession(async function handle(
 
 async function create(
   req: NextIronRequest
-): Promise<CreateDownloadUrlRes | ErrorRes> {
+): Promise<FileDownloadUrlRes | ErrorRes> {
   try {
     const id = head(req.query.id);
     if (id == null) return InvalidBody;

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -1,10 +1,10 @@
 import { Download } from "@mui/icons-material";
 import {
-  Alert,
   Box,
   Breadcrumbs,
   Button,
   CircularProgress,
+  Fade,
   Paper,
   Stack,
   Typography,
@@ -82,11 +82,13 @@ interface ExportControlsProps {
   readonly onExport: () => void;
   readonly onRefreshReadiness: () => void;
   readonly onRetry: () => void;
+  readonly archiveReadyMessageVisible: boolean;
   readonly readinessCheckInFlight: boolean;
   readonly readinessLoading: boolean;
 }
 
 function ExportControls({
+  archiveReadyMessageVisible,
   archiveFileId,
   disabledReason,
   downloadInFlight,
@@ -104,7 +106,7 @@ function ExportControls({
   return (
     <Stack
       alignItems={{ xs: "flex-start", sm: "flex-end" }}
-      spacing={1}
+      spacing={0.75}
       sx={{ flexShrink: 0 }}
     >
       <ExportPrimaryButton
@@ -116,25 +118,29 @@ function ExportControls({
         onDownloadArchive={onDownloadArchive}
         onExport={onExport}
       />
-      <ExportAvailabilityStatus
-        disabledReason={disabledReason}
-        exportDisabled={exportDisabled}
-        exportInFlight={exportInFlight}
-        onRefreshReadiness={onRefreshReadiness}
-        readinessCheckInFlight={readinessCheckInFlight}
-        readinessLoading={readinessLoading}
-      />
-      {jobStatus === "running" && (
-        <Typography color="text.secondary" variant="body2">
-          Archive job is running.
-        </Typography>
-      )}
-      <ExportAlerts
-        archiveFileId={archiveFileId}
-        exportError={exportError}
-        jobStatus={jobStatus}
-        onRetry={onRetry}
-      />
+      <Box
+        sx={{
+          alignItems: "flex-start",
+          display: "flex",
+          justifyContent: { xs: "flex-start", sm: "flex-end" },
+          minHeight: 34,
+          width: "100%",
+        }}
+      >
+        <ExportStatusMessage
+          archiveReadyMessageVisible={archiveReadyMessageVisible}
+          archiveFileId={archiveFileId}
+          disabledReason={disabledReason}
+          exportDisabled={exportDisabled}
+          exportError={exportError}
+          exportInFlight={exportInFlight}
+          jobStatus={jobStatus}
+          onRefreshReadiness={onRefreshReadiness}
+          onRetry={onRetry}
+          readinessCheckInFlight={readinessCheckInFlight}
+          readinessLoading={readinessLoading}
+        />
+      </Box>
     </Stack>
   );
 }
@@ -189,23 +195,76 @@ function ExportPrimaryButton({
   );
 }
 
-interface ExportAvailabilityStatusProps {
+interface ExportStatusMessageProps {
+  readonly archiveReadyMessageVisible: boolean;
+  readonly archiveFileId?: string;
   readonly disabledReason?: string;
   readonly exportDisabled: boolean;
+  readonly exportError?: string;
   readonly exportInFlight: boolean;
+  readonly jobStatus: ExportJobStatus;
   readonly onRefreshReadiness: () => void;
+  readonly onRetry: () => void;
   readonly readinessCheckInFlight: boolean;
   readonly readinessLoading: boolean;
 }
 
-function ExportAvailabilityStatus({
+function ExportStatusMessage({
+  archiveReadyMessageVisible,
+  archiveFileId,
   disabledReason,
   exportDisabled,
+  exportError,
   exportInFlight,
+  jobStatus,
   onRefreshReadiness,
+  onRetry,
   readinessCheckInFlight,
   readinessLoading,
-}: ExportAvailabilityStatusProps): JSX.Element | null {
+}: ExportStatusMessageProps): JSX.Element | null {
+  if (exportError != null) {
+    return (
+      <Stack
+        alignItems="center"
+        direction="row"
+        justifyContent={{ sm: "flex-end" }}
+        spacing={1}
+        sx={{ maxWidth: 360 }}
+      >
+        <Typography
+          color="error.main"
+          sx={{ overflowWrap: "anywhere", textAlign: { sm: "right" } }}
+          variant="body2"
+        >
+          {exportError}
+        </Typography>
+        {jobStatus === "error" && (
+          <Button onClick={onRetry} size="small">
+            Retry
+          </Button>
+        )}
+      </Stack>
+    );
+  }
+
+  if (jobStatus === "complete" && archiveFileId != null) {
+    return (
+      <Fade in={archiveReadyMessageVisible} timeout={500} unmountOnExit>
+        <Typography color="success.main" variant="body2">
+          Archive is ready to download.
+        </Typography>
+      </Fade>
+    );
+  }
+
+  if (jobStatus === "running") {
+    return (
+      <Typography color="text.secondary" variant="body2">
+        Archive job is running.
+      </Typography>
+    );
+  }
+
   if (readinessLoading) {
     return (
       <Typography color="text.secondary" variant="body2">
@@ -217,8 +276,18 @@ function ExportAvailabilityStatus({
   if (!exportDisabled || exportInFlight || disabledReason == null) return null;
 
   return (
-    <Stack alignItems={{ sm: "flex-end" }} spacing={0.5}>
-      <Typography color="text.secondary" variant="body2">
+    <Stack
+      alignItems="center"
+      direction="row"
+      justifyContent={{ sm: "flex-end" }}
+      spacing={1}
+      sx={{ maxWidth: 420 }}
+    >
+      <Typography
+        color="text.secondary"
+        sx={{ overflowWrap: "anywhere", textAlign: { sm: "right" } }}
+        variant="body2"
+      >
         {disabledReason}
       </Typography>
       <Button
@@ -231,46 +300,6 @@ function ExportAvailabilityStatus({
           : "Refresh Availability"}
       </Button>
     </Stack>
-  );
-}
-
-interface ExportAlertsProps {
-  readonly archiveFileId?: string;
-  readonly exportError?: string;
-  readonly jobStatus: ExportJobStatus;
-  readonly onRetry: () => void;
-}
-
-function ExportAlerts({
-  archiveFileId,
-  exportError,
-  jobStatus,
-  onRetry,
-}: ExportAlertsProps): JSX.Element | null {
-  if (exportError != null) {
-    return (
-      <Alert
-        action={
-          jobStatus === "error" ? (
-            <Button color="inherit" onClick={onRetry} size="small">
-              Retry
-            </Button>
-          ) : undefined
-        }
-        severity="error"
-        sx={{ maxWidth: 360 }}
-      >
-        {exportError}
-      </Alert>
-    );
-  }
-
-  if (jobStatus !== "complete" || archiveFileId == null) return null;
-
-  return (
-    <Alert severity="success" sx={{ maxWidth: 360 }}>
-      Archive is ready to download.
-    </Alert>
   );
 }
 
@@ -287,6 +316,8 @@ export default function FileCollectionDetails({
   const [readinessRefreshInFlight, setReadinessRefreshInFlight] =
     React.useState(false);
   const [exportError, setExportError] = React.useState<string>();
+  const [archiveReadyMessageVisible, setArchiveReadyMessageVisible] =
+    React.useState(false);
   const [downloadInFlight, setDownloadInFlight] = React.useState(false);
   const [archiveFileId, setArchiveFileId] = React.useState<string>();
   const [jobId, setJobId] = React.useState<string>();
@@ -300,6 +331,8 @@ export default function FileCollectionDetails({
   )}?includeExportAvailability=true`;
   const exportStateIsCurrent = exportStateCollectionId === fileCollection.id;
   const currentArchiveFileId = exportStateIsCurrent ? archiveFileId : undefined;
+  const currentArchiveReadyMessageVisible =
+    exportStateIsCurrent && archiveReadyMessageVisible;
   const currentDownloadInFlight = exportStateIsCurrent && downloadInFlight;
   const currentExportError = exportStateIsCurrent ? exportError : undefined;
   const currentJobStatus = exportStateIsCurrent ? jobStatus : "idle";
@@ -367,6 +400,7 @@ export default function FileCollectionDetails({
     setReadiness(undefined);
     setReadinessError(undefined);
     setReadinessRefreshInFlight(false);
+    setArchiveReadyMessageVisible(false);
     setExportError(undefined);
     setDownloadInFlight(false);
     setArchiveFileId(undefined);
@@ -381,6 +415,22 @@ export default function FileCollectionDetails({
 
     return () => controller.abort();
   }, [loadReadiness]);
+
+  React.useEffect(() => {
+    if (
+      !exportStateIsCurrent ||
+      jobStatus !== "complete" ||
+      !archiveReadyMessageVisible
+    )
+      return;
+
+    const timeout = window.setTimeout(
+      () => setArchiveReadyMessageVisible(false),
+      6000
+    );
+
+    return () => window.clearTimeout(timeout);
+  }, [archiveReadyMessageVisible, exportStateIsCurrent, jobStatus]);
 
   async function handleRefreshReadiness() {
     if (currentReadinessRefreshInFlight || exportInFlight) return;
@@ -423,6 +473,7 @@ export default function FileCollectionDetails({
         const status = body.data?.attributes?.status;
         if (status === "complete") {
           setJobStatus("complete");
+          setArchiveReadyMessageVisible(true);
         } else if (status === "error") {
           setJobStatus("error");
           setExportError("Archive job failed.");
@@ -451,6 +502,7 @@ export default function FileCollectionDetails({
     const currentFileCollectionId = fileCollection.id;
     setExportStateCollectionId(currentFileCollectionId);
     setArchiveFileId(undefined);
+    setArchiveReadyMessageVisible(false);
     setDownloadInFlight(false);
     setExportError(undefined);
     setJobId(undefined);
@@ -508,6 +560,7 @@ export default function FileCollectionDetails({
     if (currentArchiveFileId == null || currentDownloadInFlight) return;
 
     const currentFileCollectionId = fileCollection.id;
+    setArchiveReadyMessageVisible(false);
     setDownloadInFlight(true);
     setExportError(undefined);
 
@@ -546,6 +599,7 @@ export default function FileCollectionDetails({
   function handleRetry() {
     setExportStateCollectionId(fileCollection.id);
     setArchiveFileId(undefined);
+    setArchiveReadyMessageVisible(false);
     setDownloadInFlight(false);
     setExportError(undefined);
     setJobId(undefined);
@@ -585,6 +639,7 @@ export default function FileCollectionDetails({
                 </Typography>
               </Box>
               <ExportControls
+                archiveReadyMessageVisible={currentArchiveReadyMessageVisible}
                 archiveFileId={currentArchiveFileId}
                 disabledReason={disabledReason}
                 downloadInFlight={currentDownloadInFlight}

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -47,6 +47,8 @@ interface ExportReadinessState {
   readonly status: number;
 }
 
+type ExportJobStatus = "idle" | "creating" | "running" | "complete" | "error";
+
 const FileCollectionFilesTable = dynamic(
   () => import("../../components/file-collection/FileCollectionFilesTable"),
   {
@@ -61,6 +63,208 @@ interface ServerSideContext {
     readonly fileCollectionId?: string | string[];
   };
   readonly req: NextIronRequest;
+}
+
+interface ExportControlsProps {
+  readonly archiveFileId?: string;
+  readonly disabledReason?: string;
+  readonly downloadInFlight: boolean;
+  readonly exportDisabled: boolean;
+  readonly exportError?: string;
+  readonly exportInFlight: boolean;
+  readonly jobStatus: ExportJobStatus;
+  readonly onDownloadArchive: () => void;
+  readonly onExport: () => void;
+  readonly onRefreshReadiness: () => void;
+  readonly onRetry: () => void;
+  readonly readinessCheckInFlight: boolean;
+  readonly readinessLoading: boolean;
+}
+
+function ExportControls({
+  archiveFileId,
+  disabledReason,
+  downloadInFlight,
+  exportDisabled,
+  exportError,
+  exportInFlight,
+  jobStatus,
+  onDownloadArchive,
+  onExport,
+  onRefreshReadiness,
+  onRetry,
+  readinessCheckInFlight,
+  readinessLoading,
+}: ExportControlsProps): JSX.Element {
+  return (
+    <>
+      <Stack alignItems={{ sm: "flex-end" }} spacing={1}>
+        <ExportPrimaryButton
+          archiveFileId={archiveFileId}
+          downloadInFlight={downloadInFlight}
+          exportDisabled={exportDisabled}
+          exportInFlight={exportInFlight}
+          jobStatus={jobStatus}
+          onDownloadArchive={onDownloadArchive}
+          onExport={onExport}
+        />
+        <ExportAvailabilityStatus
+          disabledReason={disabledReason}
+          exportDisabled={exportDisabled}
+          exportInFlight={exportInFlight}
+          onRefreshReadiness={onRefreshReadiness}
+          readinessCheckInFlight={readinessCheckInFlight}
+          readinessLoading={readinessLoading}
+        />
+        {jobStatus === "running" && (
+          <Typography color="text.secondary" variant="body2">
+            Archive job is running.
+          </Typography>
+        )}
+      </Stack>
+      <ExportAlerts
+        archiveFileId={archiveFileId}
+        exportError={exportError}
+        jobStatus={jobStatus}
+        onRetry={onRetry}
+      />
+    </>
+  );
+}
+
+interface ExportPrimaryButtonProps {
+  readonly archiveFileId?: string;
+  readonly downloadInFlight: boolean;
+  readonly exportDisabled: boolean;
+  readonly exportInFlight: boolean;
+  readonly jobStatus: ExportJobStatus;
+  readonly onDownloadArchive: () => void;
+  readonly onExport: () => void;
+}
+
+function ExportPrimaryButton({
+  archiveFileId,
+  downloadInFlight,
+  exportDisabled,
+  exportInFlight,
+  jobStatus,
+  onDownloadArchive,
+  onExport,
+}: ExportPrimaryButtonProps): JSX.Element {
+  if (jobStatus === "complete" && archiveFileId != null) {
+    return (
+      <Button
+        disabled={downloadInFlight}
+        onClick={onDownloadArchive}
+        startIcon={<Download />}
+        variant="contained"
+      >
+        {downloadInFlight ? "Opening Archive" : "Download Archive"}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      disabled={exportDisabled}
+      onClick={onExport}
+      startIcon={
+        exportInFlight ? (
+          <CircularProgress color="inherit" size={16} />
+        ) : (
+          <Download />
+        )
+      }
+      variant="contained"
+    >
+      {exportInFlight ? "Exporting Archive" : "Export Archive"}
+    </Button>
+  );
+}
+
+interface ExportAvailabilityStatusProps {
+  readonly disabledReason?: string;
+  readonly exportDisabled: boolean;
+  readonly exportInFlight: boolean;
+  readonly onRefreshReadiness: () => void;
+  readonly readinessCheckInFlight: boolean;
+  readonly readinessLoading: boolean;
+}
+
+function ExportAvailabilityStatus({
+  disabledReason,
+  exportDisabled,
+  exportInFlight,
+  onRefreshReadiness,
+  readinessCheckInFlight,
+  readinessLoading,
+}: ExportAvailabilityStatusProps): JSX.Element | null {
+  if (readinessLoading) {
+    return (
+      <Typography color="text.secondary" variant="body2">
+        Checking export availability.
+      </Typography>
+    );
+  }
+
+  if (!exportDisabled || exportInFlight || disabledReason == null) return null;
+
+  return (
+    <Stack alignItems={{ sm: "flex-end" }} spacing={0.5}>
+      <Typography color="text.secondary" variant="body2">
+        {disabledReason}
+      </Typography>
+      <Button
+        disabled={readinessCheckInFlight}
+        onClick={onRefreshReadiness}
+        size="small"
+      >
+        {readinessCheckInFlight
+          ? "Checking Availability"
+          : "Refresh Availability"}
+      </Button>
+    </Stack>
+  );
+}
+
+interface ExportAlertsProps {
+  readonly archiveFileId?: string;
+  readonly exportError?: string;
+  readonly jobStatus: ExportJobStatus;
+  readonly onRetry: () => void;
+}
+
+function ExportAlerts({
+  archiveFileId,
+  exportError,
+  jobStatus,
+  onRetry,
+}: ExportAlertsProps): JSX.Element | null {
+  if (exportError != null) {
+    return (
+      <Alert
+        action={
+          jobStatus === "error" ? (
+            <Button color="inherit" onClick={onRetry} size="small">
+              Retry
+            </Button>
+          ) : undefined
+        }
+        severity="error"
+        sx={{ mt: 2 }}
+      >
+        {exportError}
+      </Alert>
+    );
+  }
+
+  if (jobStatus !== "complete" || archiveFileId == null) return null;
+
+  return (
+    <Alert severity="success" sx={{ mt: 2 }}>
+      Archive is ready to download.
+    </Alert>
+  );
 }
 
 export default function FileCollectionDetails({
@@ -79,9 +283,7 @@ export default function FileCollectionDetails({
   const [downloadInFlight, setDownloadInFlight] = React.useState(false);
   const [archiveFileId, setArchiveFileId] = React.useState<string>();
   const [jobId, setJobId] = React.useState<string>();
-  const [jobStatus, setJobStatus] = React.useState<
-    "idle" | "creating" | "running" | "complete" | "error"
-  >("idle");
+  const [jobStatus, setJobStatus] = React.useState<ExportJobStatus>("idle");
   const drawerOpen = Boolean(file);
   const filesApiPath = `/api/file-collections/${encodeURIComponent(
     fileCollection.id
@@ -372,84 +574,22 @@ export default function FileCollectionDetails({
                   {fileCollection.id}
                 </Typography>
               </Box>
-              <Stack alignItems={{ sm: "flex-end" }} spacing={1}>
-                {currentJobStatus === "complete" &&
-                currentArchiveFileId != null ? (
-                  <Button
-                    disabled={currentDownloadInFlight}
-                    onClick={handleDownloadArchive}
-                    startIcon={<Download />}
-                    variant="contained"
-                  >
-                    {currentDownloadInFlight
-                      ? "Opening Archive"
-                      : "Download Archive"}
-                  </Button>
-                ) : (
-                  <Button
-                    disabled={exportDisabled}
-                    onClick={handleExport}
-                    startIcon={
-                      exportInFlight ? (
-                        <CircularProgress color="inherit" size={16} />
-                      ) : (
-                        <Download />
-                      )
-                    }
-                    variant="contained"
-                  >
-                    {exportInFlight ? "Exporting Archive" : "Export Archive"}
-                  </Button>
-                )}
-                {readinessLoading && (
-                  <Typography color="text.secondary" variant="body2">
-                    Checking export availability.
-                  </Typography>
-                )}
-                {exportDisabled && !exportInFlight && disabledReason && (
-                  <Stack alignItems={{ sm: "flex-end" }} spacing={0.5}>
-                    <Typography color="text.secondary" variant="body2">
-                      {disabledReason}
-                    </Typography>
-                    <Button
-                      disabled={readinessCheckInFlight}
-                      onClick={handleRefreshReadiness}
-                      size="small"
-                    >
-                      {readinessCheckInFlight
-                        ? "Checking Availability"
-                        : "Refresh Availability"}
-                    </Button>
-                  </Stack>
-                )}
-                {currentJobStatus === "running" && (
-                  <Typography color="text.secondary" variant="body2">
-                    Archive job is running.
-                  </Typography>
-                )}
-              </Stack>
+              <ExportControls
+                archiveFileId={currentArchiveFileId}
+                disabledReason={disabledReason}
+                downloadInFlight={currentDownloadInFlight}
+                exportDisabled={exportDisabled}
+                exportError={currentExportError}
+                exportInFlight={exportInFlight}
+                jobStatus={currentJobStatus}
+                onDownloadArchive={handleDownloadArchive}
+                onExport={handleExport}
+                onRefreshReadiness={handleRefreshReadiness}
+                onRetry={handleRetry}
+                readinessCheckInFlight={readinessCheckInFlight}
+                readinessLoading={readinessLoading}
+              />
             </Box>
-            {currentJobStatus === "complete" &&
-              currentArchiveFileId != null && (
-                <Alert severity="success" sx={{ mt: 2 }}>
-                  Archive is ready to download.
-                </Alert>
-              )}
-            {currentExportError != null && (
-              <Alert
-                action={
-                  currentJobStatus === "error" ? (
-                    <Button color="inherit" onClick={handleRetry} size="small">
-                      Retry
-                    </Button>
-                  ) : undefined
-                }
-                severity="error"
-                sx={{ mt: 2 }}
-              >
-                {currentExportError}
-              </Alert>
-            )}
             <Box sx={{ mt: 2 }}>
               <FileCollectionMetadataTable fileCollection={fileCollection} />
             </Box>

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -1,4 +1,14 @@
-import { Box, Breadcrumbs, Paper, Typography } from "@mui/material";
+import { Download } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  CircularProgress,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { head } from "@vertexvis/api-client-node";
 import { GetServerSidePropsResult } from "next";
 import dynamic from "next/dynamic";
@@ -9,13 +19,15 @@ import { FileDetailsDrawer } from "../../components/file/FileDetailsDrawer";
 import { FileCollectionMetadataTable } from "../../components/file-collection/FileCollectionMetadataTable";
 import { AppLink } from "../../components/shared/AppLink";
 import { Layout } from "../../components/shared/Layout";
-import { isErrorFailure, toErrorRes } from "../../lib/api";
+import { ErrorRes, isErrorFailure, toErrorRes } from "../../lib/api";
 import {
   FileCollection,
+  GetFileCollectionRes,
   getFileCollectionsApi,
   toFileCollection,
 } from "../../lib/file-collections";
-import { File } from "../../lib/files";
+import { FileJobRes } from "../../lib/file-jobs";
+import { File, FileDownloadUrlRes } from "../../lib/files";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import {
   CommonProps,
@@ -26,6 +38,13 @@ import {
 
 interface Props {
   readonly fileCollection: FileCollection;
+}
+
+interface ExportReadinessState {
+  readonly fileCount: number;
+  readonly message?: string;
+  readonly ready: boolean;
+  readonly status: number;
 }
 
 const FileCollectionFilesTable = dynamic(
@@ -47,11 +66,279 @@ interface ServerSideContext {
 export default function FileCollectionDetails({
   fileCollection,
 }: Props): JSX.Element {
+  const fileCollectionIdRef = React.useRef(fileCollection.id);
   const [file, setFile] = React.useState<File | undefined>();
+  const [exportStateCollectionId, setExportStateCollectionId] = React.useState(
+    fileCollection.id
+  );
+  const [readiness, setReadiness] = React.useState<ExportReadinessState>();
+  const [readinessError, setReadinessError] = React.useState<string>();
+  const [readinessRefreshInFlight, setReadinessRefreshInFlight] =
+    React.useState(false);
+  const [exportError, setExportError] = React.useState<string>();
+  const [downloadInFlight, setDownloadInFlight] = React.useState(false);
+  const [archiveFileId, setArchiveFileId] = React.useState<string>();
+  const [jobId, setJobId] = React.useState<string>();
+  const [jobStatus, setJobStatus] = React.useState<
+    "idle" | "creating" | "running" | "complete" | "error"
+  >("idle");
   const drawerOpen = Boolean(file);
   const filesApiPath = `/api/file-collections/${encodeURIComponent(
     fileCollection.id
   )}/files`;
+  const readinessApiPath = `/api/file-collections/${encodeURIComponent(
+    fileCollection.id
+  )}?includeExportAvailability=true`;
+  const exportStateIsCurrent = exportStateCollectionId === fileCollection.id;
+  const currentArchiveFileId = exportStateIsCurrent ? archiveFileId : undefined;
+  const currentDownloadInFlight = exportStateIsCurrent && downloadInFlight;
+  const currentExportError = exportStateIsCurrent ? exportError : undefined;
+  const currentJobStatus = exportStateIsCurrent ? jobStatus : "idle";
+  const currentReadiness = exportStateIsCurrent ? readiness : undefined;
+  const currentReadinessError = exportStateIsCurrent
+    ? readinessError
+    : undefined;
+  const currentReadinessRefreshInFlight =
+    exportStateIsCurrent && readinessRefreshInFlight;
+  const readinessLoading =
+    currentReadiness == null && currentReadinessError == null;
+  const exportInFlight =
+    currentJobStatus === "creating" || currentJobStatus === "running";
+  const readinessCheckInFlight =
+    readinessLoading || currentReadinessRefreshInFlight;
+  const disabledReason = currentReadinessError ?? currentReadiness?.message;
+  const exportDisabled =
+    exportInFlight ||
+    readinessCheckInFlight ||
+    currentReadiness?.ready !== true;
+
+  const loadReadiness = React.useCallback(
+    async (signal?: AbortSignal) => {
+      const currentFileCollectionId = fileCollection.id;
+
+      try {
+        setReadinessError(undefined);
+        const res = await fetch(readinessApiPath, { signal });
+        const body = (await res.json()) as GetFileCollectionRes | ErrorRes;
+
+        if (fileCollectionIdRef.current !== currentFileCollectionId) return;
+
+        if (!res.ok) {
+          setReadiness(undefined);
+          setReadinessError(
+            ("message" in body ? body.message : undefined) ??
+              "Could not check export availability."
+          );
+          return;
+        }
+
+        setReadiness({
+          fileCount: body.export?.fileCount ?? 0,
+          message: body.export?.disabledReason,
+          ready: body.export?.enabled === true,
+          status: body.status,
+        });
+      } catch (error) {
+        if (
+          !signal?.aborted &&
+          fileCollectionIdRef.current === currentFileCollectionId
+        ) {
+          setReadiness(undefined);
+          setReadinessError("Could not check export availability.");
+        }
+      }
+    },
+    [fileCollection.id, readinessApiPath]
+  );
+
+  React.useEffect(() => {
+    fileCollectionIdRef.current = fileCollection.id;
+    setFile(undefined);
+    setExportStateCollectionId(fileCollection.id);
+    setReadiness(undefined);
+    setReadinessError(undefined);
+    setReadinessRefreshInFlight(false);
+    setExportError(undefined);
+    setDownloadInFlight(false);
+    setArchiveFileId(undefined);
+    setJobId(undefined);
+    setJobStatus("idle");
+  }, [fileCollection.id]);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+
+    loadReadiness(controller.signal);
+
+    return () => controller.abort();
+  }, [loadReadiness]);
+
+  async function handleRefreshReadiness() {
+    if (currentReadinessRefreshInFlight || exportInFlight) return;
+
+    setExportStateCollectionId(fileCollection.id);
+    setReadinessRefreshInFlight(true);
+    try {
+      await loadReadiness();
+    } finally {
+      setReadinessRefreshInFlight(false);
+    }
+  }
+
+  React.useEffect(() => {
+    if (!exportStateIsCurrent || jobId == null || jobStatus !== "running")
+      return;
+
+    const currentJobId = jobId;
+    let active = true;
+    let timeout: number | undefined;
+
+    async function pollJob() {
+      try {
+        const res = await fetch(
+          `/api/file-jobs/${encodeURIComponent(currentJobId)}`
+        );
+        const body = (await res.json()) as FileJobRes;
+
+        if (!active) return;
+
+        if (!res.ok) {
+          setJobStatus("error");
+          setExportError(body.message ?? "Archive job failed.");
+          return;
+        }
+
+        const status = body.data?.attributes?.status;
+        if (status === "complete") {
+          setJobStatus("complete");
+        } else if (status === "error") {
+          setJobStatus("error");
+          setExportError("Archive job failed.");
+        } else {
+          timeout = window.setTimeout(pollJob, 1000);
+        }
+      } catch {
+        if (active) {
+          setJobStatus("error");
+          setExportError("Archive job failed.");
+        }
+      }
+    }
+
+    timeout = window.setTimeout(pollJob, 1000);
+
+    return () => {
+      active = false;
+      if (timeout != null) window.clearTimeout(timeout);
+    };
+  }, [exportStateIsCurrent, jobId, jobStatus]);
+
+  async function handleExport() {
+    if (exportDisabled) return;
+
+    const currentFileCollectionId = fileCollection.id;
+    setExportStateCollectionId(currentFileCollectionId);
+    setArchiveFileId(undefined);
+    setDownloadInFlight(false);
+    setExportError(undefined);
+    setJobId(undefined);
+    setJobStatus("creating");
+
+    let res: Response;
+    let body: FileJobRes | ErrorRes;
+    try {
+      res = await fetch("/api/file-jobs", {
+        body: JSON.stringify({ fileCollectionId: fileCollection.id }),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+      body = (await res.json()) as FileJobRes;
+    } catch {
+      if (fileCollectionIdRef.current === currentFileCollectionId) {
+        setJobStatus("error");
+        setExportError("Could not start archive export.");
+      }
+      return;
+    }
+
+    if (fileCollectionIdRef.current !== currentFileCollectionId) return;
+
+    if (
+      !res.ok ||
+      !("data" in body) ||
+      body.data.id == null ||
+      body.archiveFileId == null
+    ) {
+      const message =
+        ("message" in body ? body.message : undefined) ??
+        "Could not start archive export.";
+      setJobStatus("error");
+      setExportError(message);
+      setReadiness((current) =>
+        res.status === 400
+          ? {
+              fileCount: current?.fileCount ?? 0,
+              message,
+              ready: false,
+              status: body.status,
+            }
+          : current
+      );
+      return;
+    }
+
+    setArchiveFileId(body.archiveFileId);
+    setJobId(body.data.id);
+    setJobStatus("running");
+  }
+
+  async function handleDownloadArchive() {
+    if (currentArchiveFileId == null || currentDownloadInFlight) return;
+
+    const currentFileCollectionId = fileCollection.id;
+    setDownloadInFlight(true);
+    setExportError(undefined);
+
+    try {
+      const res = await fetch(
+        `/api/files/${encodeURIComponent(currentArchiveFileId)}/download-url`,
+        { method: "POST" }
+      );
+      const body = (await res.json()) as FileDownloadUrlRes | ErrorRes;
+
+      if (fileCollectionIdRef.current !== currentFileCollectionId) return;
+
+      if (!res.ok || !("url" in body)) {
+        setExportError(
+          ("message" in body ? body.message : undefined) ??
+            "Could not create a download URL for this archive."
+        );
+        return;
+      }
+
+      const opened = window.open(body.url, "_blank", "noopener");
+      if (opened == null) {
+        window.location.assign(body.url);
+      }
+    } catch {
+      if (fileCollectionIdRef.current === currentFileCollectionId) {
+        setExportError("Could not create a download URL for this archive.");
+      }
+    } finally {
+      if (fileCollectionIdRef.current === currentFileCollectionId) {
+        setDownloadInFlight(false);
+      }
+    }
+  }
+
+  function handleRetry() {
+    setExportStateCollectionId(fileCollection.id);
+    setArchiveFileId(undefined);
+    setDownloadInFlight(false);
+    setExportError(undefined);
+    setJobId(undefined);
+    setJobStatus("idle");
+  }
 
   return (
     <Layout
@@ -66,14 +353,103 @@ export default function FileCollectionDetails({
             </Typography>
           </Breadcrumbs>
           <Paper sx={{ p: 2 }}>
-            <Typography variant="h5">File Collection Details</Typography>
-            <Typography
-              color="text.secondary"
-              sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
-              variant="body2"
+            <Box
+              sx={{
+                alignItems: { sm: "flex-start" },
+                display: "flex",
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 2,
+                justifyContent: "space-between",
+              }}
             >
-              {fileCollection.id}
-            </Typography>
+              <Box>
+                <Typography variant="h5">File Collection Details</Typography>
+                <Typography
+                  color="text.secondary"
+                  sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+                  variant="body2"
+                >
+                  {fileCollection.id}
+                </Typography>
+              </Box>
+              <Stack alignItems={{ sm: "flex-end" }} spacing={1}>
+                {currentJobStatus === "complete" &&
+                currentArchiveFileId != null ? (
+                  <Button
+                    disabled={currentDownloadInFlight}
+                    onClick={handleDownloadArchive}
+                    startIcon={<Download />}
+                    variant="contained"
+                  >
+                    {currentDownloadInFlight
+                      ? "Opening Archive"
+                      : "Download Archive"}
+                  </Button>
+                ) : (
+                  <Button
+                    disabled={exportDisabled}
+                    onClick={handleExport}
+                    startIcon={
+                      exportInFlight ? (
+                        <CircularProgress color="inherit" size={16} />
+                      ) : (
+                        <Download />
+                      )
+                    }
+                    variant="contained"
+                  >
+                    {exportInFlight ? "Exporting Archive" : "Export Archive"}
+                  </Button>
+                )}
+                {readinessLoading && (
+                  <Typography color="text.secondary" variant="body2">
+                    Checking export availability.
+                  </Typography>
+                )}
+                {exportDisabled && !exportInFlight && disabledReason && (
+                  <Stack alignItems={{ sm: "flex-end" }} spacing={0.5}>
+                    <Typography color="text.secondary" variant="body2">
+                      {disabledReason}
+                    </Typography>
+                    <Button
+                      disabled={readinessCheckInFlight}
+                      onClick={handleRefreshReadiness}
+                      size="small"
+                    >
+                      {readinessCheckInFlight
+                        ? "Checking Availability"
+                        : "Refresh Availability"}
+                    </Button>
+                  </Stack>
+                )}
+                {currentJobStatus === "running" && (
+                  <Typography color="text.secondary" variant="body2">
+                    Archive job is running.
+                  </Typography>
+                )}
+              </Stack>
+            </Box>
+            {currentJobStatus === "complete" &&
+              currentArchiveFileId != null && (
+                <Alert severity="success" sx={{ mt: 2 }}>
+                  Archive is ready to download.
+                </Alert>
+              )}
+            {currentExportError != null && (
+              <Alert
+                action={
+                  currentJobStatus === "error" ? (
+                    <Button color="inherit" onClick={handleRetry} size="small">
+                      Retry
+                    </Button>
+                  ) : undefined
+                }
+                severity="error"
+                sx={{ mt: 2 }}
+              >
+                {currentExportError}
+              </Alert>
+            )}
             <Box sx={{ mt: 2 }}>
               <FileCollectionMetadataTable fileCollection={fileCollection} />
             </Box>

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -19,7 +19,12 @@ import { FileDetailsDrawer } from "../../components/file/FileDetailsDrawer";
 import { FileCollectionMetadataTable } from "../../components/file-collection/FileCollectionMetadataTable";
 import { AppLink } from "../../components/shared/AppLink";
 import { Layout } from "../../components/shared/Layout";
-import { ErrorRes, isErrorFailure, toErrorRes } from "../../lib/api";
+import {
+  ErrorRes,
+  isErrorFailure,
+  isErrorRes,
+  toErrorRes,
+} from "../../lib/api";
 import {
   FileCollection,
   GetFileCollectionRes,
@@ -325,7 +330,7 @@ export default function FileCollectionDetails({
 
         if (fileCollectionIdRef.current !== currentFileCollectionId) return;
 
-        if (!res.ok) {
+        if (!res.ok || "message" in body) {
           setReadiness(undefined);
           setReadinessError(
             ("message" in body ? body.message : undefined) ??
@@ -400,13 +405,16 @@ export default function FileCollectionDetails({
         const res = await fetch(
           `/api/file-jobs/${encodeURIComponent(currentJobId)}`
         );
-        const body = (await res.json()) as FileJobRes;
+        const body = (await res.json()) as FileJobRes | ErrorRes;
 
         if (!active) return;
 
-        if (!res.ok) {
+        if (!res.ok || "message" in body) {
           setJobStatus("error");
-          setExportError(body.message ?? "Archive job failed.");
+          setExportError(
+            ("message" in body ? body.message : undefined) ??
+              "Archive job failed."
+          );
           return;
         }
 
@@ -454,7 +462,7 @@ export default function FileCollectionDetails({
         headers: { "Content-Type": "application/json" },
         method: "POST",
       });
-      body = (await res.json()) as FileJobRes;
+      body = (await res.json()) as FileJobRes | ErrorRes;
     } catch {
       if (fileCollectionIdRef.current === currentFileCollectionId) {
         setJobStatus("error");
@@ -471,9 +479,9 @@ export default function FileCollectionDetails({
       body.data.id == null ||
       body.archiveFileId == null
     ) {
-      const message =
-        ("message" in body ? body.message : undefined) ??
-        "Could not start archive export.";
+      const message = isErrorRes(body)
+        ? body.message
+        : "Could not start archive export.";
       setJobStatus("error");
       setExportError(message);
       setReadiness((current) =>

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -102,38 +102,40 @@ function ExportControls({
   readinessLoading,
 }: ExportControlsProps): JSX.Element {
   return (
-    <>
-      <Stack alignItems={{ sm: "flex-end" }} spacing={1}>
-        <ExportPrimaryButton
-          archiveFileId={archiveFileId}
-          downloadInFlight={downloadInFlight}
-          exportDisabled={exportDisabled}
-          exportInFlight={exportInFlight}
-          jobStatus={jobStatus}
-          onDownloadArchive={onDownloadArchive}
-          onExport={onExport}
-        />
-        <ExportAvailabilityStatus
-          disabledReason={disabledReason}
-          exportDisabled={exportDisabled}
-          exportInFlight={exportInFlight}
-          onRefreshReadiness={onRefreshReadiness}
-          readinessCheckInFlight={readinessCheckInFlight}
-          readinessLoading={readinessLoading}
-        />
-        {jobStatus === "running" && (
-          <Typography color="text.secondary" variant="body2">
-            Archive job is running.
-          </Typography>
-        )}
-      </Stack>
+    <Stack
+      alignItems={{ xs: "flex-start", sm: "flex-end" }}
+      spacing={1}
+      sx={{ flexShrink: 0 }}
+    >
+      <ExportPrimaryButton
+        archiveFileId={archiveFileId}
+        downloadInFlight={downloadInFlight}
+        exportDisabled={exportDisabled}
+        exportInFlight={exportInFlight}
+        jobStatus={jobStatus}
+        onDownloadArchive={onDownloadArchive}
+        onExport={onExport}
+      />
+      <ExportAvailabilityStatus
+        disabledReason={disabledReason}
+        exportDisabled={exportDisabled}
+        exportInFlight={exportInFlight}
+        onRefreshReadiness={onRefreshReadiness}
+        readinessCheckInFlight={readinessCheckInFlight}
+        readinessLoading={readinessLoading}
+      />
+      {jobStatus === "running" && (
+        <Typography color="text.secondary" variant="body2">
+          Archive job is running.
+        </Typography>
+      )}
       <ExportAlerts
         archiveFileId={archiveFileId}
         exportError={exportError}
         jobStatus={jobStatus}
         onRetry={onRetry}
       />
-    </>
+    </Stack>
   );
 }
 
@@ -256,7 +258,7 @@ function ExportAlerts({
           ) : undefined
         }
         severity="error"
-        sx={{ mt: 2 }}
+        sx={{ maxWidth: 360 }}
       >
         {exportError}
       </Alert>
@@ -266,7 +268,7 @@ function ExportAlerts({
   if (jobStatus !== "complete" || archiveFileId == null) return null;
 
   return (
-    <Alert severity="success" sx={{ mt: 2 }}>
+    <Alert severity="success" sx={{ maxWidth: 360 }}>
       Archive is ready to download.
     </Alert>
   );


### PR DESCRIPTION
## Summary
Allows the easy creation of zip archives of all complete (uploaded or present) Files attached to a FileCollection.

Provides UX over these actions - indicates why an export can't be run, polls for status, and displays link when export ready, displays errors if failure

## Test Plan
Open Dev Dashboard in an account with FileCollections that have complete or present files attached. Download them.

## Release Notes
- As a developer using Dev Dashboard, can now export all files in a file collection as a zip archive

## Possible Regressions
- Low regression risk, adding new front end features built on top of existing APIs
- NOTE: Not a regression but added some simple middleware to perform data shaping for frontend wrt to the exports: I prefer the data shaping pattern since we have next.js ready and at hand and it keeps front end dumber but there is some risk that absolutely enormous file collections could timeout.


## Dependencies
[PLAT-8768](https://vertexvis.atlassian.net/browse/PLAT-8768)

[PLAT-8768]: https://vertexvis.atlassian.net/browse/PLAT-8768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ