### PR TITLE
[PLAT-8768] Clean up file collections dashboard + route progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,16 @@
 .env.production.local
 .env.test.local
 .env
+mise.local.toml
 yarn-error.log*
+tsconfig.tsbuildinfo
 
 /.next
 /coverage
 /node_modules
+/playwright/
+.idea
+.yarnrc.yml
+.yarn
+
+.playwright-mcp

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -5,6 +5,14 @@ import { SWRConfig } from "swr";
 
 import FileCollectionTable from "../../../components/file-collection/FileCollectionTable";
 
+const mockPush = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
 const firstPage = {
   cursors: { self: "page-1", next: "page+2&filter=unexpected#fragment" },
   data: [
@@ -63,6 +71,10 @@ const multiCollectionPage = {
 };
 
 describe("FileCollectionTable", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -171,6 +183,18 @@ describe("FileCollectionTable", () => {
       );
     });
   });
+
+  it("navigates to the file collection detail route when a row is clicked", async () => {
+    mockFetch(() => firstPage);
+
+    renderTable();
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Collection One"));
+
+    expect(mockPush).toHaveBeenCalledWith("/file-collections/collection-1");
+  });
 });
 
 function renderTable(): void {
@@ -182,7 +206,7 @@ function renderTable(): void {
         provider: () => new Map(),
       }}
     >
-      <FileCollectionTable onFileCollectionSelected={jest.fn()} />
+      <FileCollectionTable />
     </SWRConfig>
   );
 }

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
-import fetch, { Headers, Request, Response } from "node-fetch";
+import nodeFetch, { Headers, Request, Response } from "node-fetch";
 import React from "react";
 import { SWRConfig } from "swr";
 
@@ -23,7 +23,7 @@ const page = {
       attributes: {
         created: "2026-06-10T15:30:00Z",
         name: "alpha.jt",
-        status: "completed",
+        status: "complete",
         suppliedId: "supplied-1",
         uploaded: "2026-06-10T15:45:00Z",
       },
@@ -38,13 +38,31 @@ const pagedPage = {
   status: 200,
 };
 
+const collectionFilesPage = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "file",
+      id: "file-1",
+      attributes: {
+        name: "File One",
+        status: "complete",
+        suppliedId: "supplied-file-1",
+        created: "2026-06-12T15:30:00Z",
+        uploaded: "2026-06-12T15:31:00Z",
+      },
+    },
+  ],
+  status: 200,
+};
+
 describe("FileTable", () => {
   beforeAll(() => {
     Object.assign(global, {
       Headers,
       Request,
       Response,
-      fetch,
+      fetch: nodeFetch,
     });
     server.listen({ onUnhandledRequest: "error" });
   });
@@ -52,6 +70,7 @@ describe("FileTable", () => {
   afterEach(() => {
     server.resetHandlers();
     jest.restoreAllMocks();
+    Object.assign(global, { fetch: nodeFetch });
   });
 
   afterAll(() => {
@@ -71,7 +90,9 @@ describe("FileTable", () => {
     renderTable();
 
     expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
-    expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=-created");
+    expect(requests).toContain(
+      "http://localhost/api/files?pageSize=25&sort=-created"
+    );
   });
 
   it("sorts by name and toggles direction", async () => {
@@ -90,12 +111,16 @@ describe("FileTable", () => {
 
     await userEvent.click(screen.getByText("Name"));
     await waitFor(() => {
-      expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=name");
+      expect(requests).toContain(
+        "http://localhost/api/files?pageSize=25&sort=name"
+      );
     });
 
     await userEvent.click(screen.getByText("Name"));
     await waitFor(() => {
-      expect(requests).toContain("http://localhost/api/files?pageSize=25&sort=-name");
+      expect(requests).toContain(
+        "http://localhost/api/files?pageSize=25&sort=-name"
+      );
     });
   });
 
@@ -104,14 +129,16 @@ describe("FileTable", () => {
     const sortedPage = new Promise((resolve) => {
       resolveSortedPage = resolve;
     });
-    server.use(
-      rest.get("*/api/files", (req, res, ctx) => {
-        const sort = req.url.searchParams.get("sort");
-        return sort === "name"
-          ? sortedPage.then((response) => res(ctx.json(response)))
-          : res(ctx.json(pagedPage));
-      })
-    );
+    const fetchMock = jest.fn((input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      return Promise.resolve({
+        json: () =>
+          url.includes("sort=name") ? sortedPage : Promise.resolve(pagedPage),
+        ok: true,
+      });
+    });
+    global.fetch = fetchMock as unknown as typeof nodeFetch;
 
     renderTable();
 
@@ -125,21 +152,254 @@ describe("FileTable", () => {
     resolveSortedPage?.(page);
     expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
   });
+
+  it("loads collection files from a custom API path while keeping row interactions", async () => {
+    const fetchMock = mockFetch(() => collectionFilesPage);
+    const onFileSelected = jest.fn();
+    jest.spyOn(window, "open").mockReturnValue({} as Window);
+
+    renderTable(onFileSelected, {
+      apiPath: "/api/file-collections/collection-1/files",
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    expect(await screen.findByText("File One")).toBeInTheDocument();
+    const statusLabel = screen.getByText("complete");
+    expect(statusLabel.closest(".MuiChip-root")).toHaveStyle({
+      textTransform: "uppercase",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/api/file-collections/collection-1/files?pageSize=25&sort=-created"
+    );
+    expect(
+      screen.queryByLabelText("Supplied ID Filter (exact)")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "New" })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Select File One"));
+
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Delete")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("File One"));
+
+    expect(onFileSelected).toHaveBeenCalledWith({
+      id: "file-1",
+      name: "File One",
+      status: "complete",
+      suppliedId: "supplied-file-1",
+      created: "2026-06-12T15:30:00Z",
+      uploaded: "2026-06-12T15:31:00Z",
+    });
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Download File One" })
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/files/file-1/download-url", {
+        method: "POST",
+      });
+    });
+    expect(window.open).toHaveBeenCalledWith(
+      "https://example.test/download/file-1",
+      "_blank",
+      "noopener"
+    );
+  });
+
+  it("disables download for files that are not complete", async () => {
+    const fetchMock = mockFetch(() => ({
+      ...collectionFilesPage,
+      data: [
+        {
+          type: "file",
+          id: "file-1",
+          attributes: {
+            name: "File One",
+            status: "pending",
+            suppliedId: "supplied-file-1",
+            created: "2026-06-12T15:30:00Z",
+            uploaded: "2026-06-12T15:31:00Z",
+          },
+        },
+      ],
+    }));
+
+    renderTable(jest.fn(), {
+      apiPath: "/api/file-collections/collection-1/files",
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    expect(await screen.findByText("File One")).toBeInTheDocument();
+    expect(screen.getByText("pending")).toBeInTheDocument();
+
+    const download = screen.getByRole("button", { name: "Download File One" });
+    expect(download).toBeDisabled();
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/files/file-1/download-url",
+      {
+        method: "POST",
+      }
+    );
+  });
+
+  it("styles ready file statuses as success", async () => {
+    mockFetch(() => ({
+      ...collectionFilesPage,
+      data: [
+        {
+          type: "file",
+          id: "file-1",
+          attributes: {
+            name: "File One",
+            status: "ready",
+            suppliedId: "supplied-file-1",
+            created: "2026-06-12T15:30:00Z",
+            uploaded: "2026-06-12T15:31:00Z",
+          },
+        },
+      ],
+    }));
+
+    renderTable(jest.fn(), {
+      apiPath: "/api/file-collections/collection-1/files",
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    const statusLabel = await screen.findByText("ready");
+    expect(statusLabel.closest(".MuiChip-root")).toHaveClass(
+      "MuiChip-colorSuccess"
+    );
+  });
+
+  it("does not treat completed as an available file state", async () => {
+    const fetchMock = mockFetch(() => ({
+      ...collectionFilesPage,
+      data: [
+        {
+          type: "file",
+          id: "file-1",
+          attributes: {
+            name: "File One",
+            status: "completed",
+            suppliedId: "supplied-file-1",
+            created: "2026-06-12T15:30:00Z",
+            uploaded: "2026-06-12T15:31:00Z",
+          },
+        },
+      ],
+    }));
+    jest.spyOn(window, "open").mockReturnValue({} as Window);
+
+    renderTable(jest.fn(), {
+      apiPath: "/api/file-collections/collection-1/files",
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    expect(await screen.findByText("completed")).toBeInTheDocument();
+
+    const download = screen.getByRole("button", { name: "Download File One" });
+    expect(download).toBeDisabled();
+
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/api/files/file-1/download-url",
+      {
+        method: "POST",
+      }
+    );
+  });
+
+  it("renders an empty files table for an empty collection", async () => {
+    mockFetch(() => ({ cursors: { self: "page-1" }, data: [], status: 200 }));
+
+    renderTable(jest.fn(), {
+      apiPath: "/api/file-collections/collection-1/files",
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    expect(await screen.findByText("Files")).toBeInTheDocument();
+    expect(screen.queryByText("File One")).not.toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+  });
+
+  it("logs load errors and renders an empty files table when configured", async () => {
+    const error = { message: "Could not load collection files.", status: 500 };
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    mockFetch(() => error);
+
+    renderTable(jest.fn(), {
+      apiPath: "/api/file-collections/collection-1/files",
+      emptyOnLoadError: true,
+      logLoadError: true,
+      showCreateButton: false,
+      showDeleteAction: false,
+      showSuppliedIdFilter: false,
+    });
+
+    expect(await screen.findByText("Files")).toBeInTheDocument();
+    expect(screen.queryByText("Error loading data.")).not.toBeInTheDocument();
+    expect(screen.queryByText("File One")).not.toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(error);
+    });
+  });
 });
 
-function renderTable(): void {
+function renderTable(
+  onFileSelected = jest.fn(),
+  props: Partial<React.ComponentProps<typeof FileTable>> = {}
+): void {
   render(
     <SWRConfig
       value={{
         dedupingInterval: 0,
         fetcher: (url: string) =>
-          fetch(new URL(url, window.location.origin).toString()).then((res) =>
-            res.json()
-          ),
+          (global.fetch as typeof nodeFetch)(
+            new URL(url, window.location.origin).toString()
+          ).then((res) => res.json()),
         provider: () => new Map(),
       }}
     >
-      <FileTable onFileSelected={jest.fn()} />
+      <FileTable onFileSelected={onFileSelected} {...props} />
     </SWRConfig>
   );
+}
+
+function mockFetch(responseFor: (url: string) => unknown): jest.Mock {
+  const fetchMock = jest.fn((input: RequestInfo | URL) => {
+    const url = input.toString();
+
+    if (url.endsWith("/api/files/file-1/download-url")) {
+      return Promise.resolve({
+        json: () =>
+          Promise.resolve({ url: "https://example.test/download/file-1" }),
+        ok: true,
+      });
+    }
+
+    return Promise.resolve({
+      json: () => Promise.resolve(responseFor(url)),
+      ok: true,
+    });
+  });
+
+  global.fetch = fetchMock as unknown as typeof nodeFetch;
+  return fetchMock;
 }

--- a/src/__tests__/lib/file-collections.test.ts
+++ b/src/__tests__/lib/file-collections.test.ts
@@ -1,6 +1,32 @@
-import { toFileCollectionPage } from "../../lib/file-collections";
+import {
+  toFileCollection,
+  toFileCollectionPage,
+} from "../../lib/file-collections";
 
 describe("file collection paging", () => {
+  it("maps file collection metadata into a dashboard detail model", () => {
+    const collection = toFileCollection({
+      type: "file-collection",
+      id: "collection-id",
+      attributes: {
+        name: "Assembly",
+        suppliedId: "plm-123",
+        created: "2026-06-10T15:30:00Z",
+        expiresAt: "2026-07-10T15:30:00Z",
+        metadata: { source: "unit-test" },
+      },
+    });
+
+    expect(collection).toEqual({
+      id: "collection-id",
+      name: "Assembly",
+      suppliedId: "plm-123",
+      created: "2026-06-10T15:30:00Z",
+      expiresAt: "2026-07-10T15:30:00Z",
+      metadata: { source: "unit-test" },
+    });
+  });
+
   it("maps file collection metadata into dashboard rows", () => {
     const page = toFileCollectionPage({
       cursors: { self: "self", next: "next" },

--- a/src/__tests__/pages/api/file-collection-files.test.ts
+++ b/src/__tests__/pages/api/file-collection-files.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ */
+import { getPage } from "@vertexvis/api-client-node";
+import type { NextApiResponse } from "next";
+import type { Session } from "next-iron-session";
+
+import type { NextIronRequest } from "../../../lib/with-session";
+import { handleFileCollectionFiles } from "../../../pages/api/file-collections/[id]/files";
+
+const mockGetClientFromSession = jest.fn();
+const mockGetFileCollectionsApi = jest.fn();
+const mockListFileCollectionFiles = jest.fn();
+const mockGetPage = getPage as jest.Mock;
+
+jest.mock("@vertexvis/api-client-node", () => {
+  const actual = jest.requireActual("@vertexvis/api-client-node");
+  return {
+    ...actual,
+    getPage: jest.fn(),
+    logError: jest.fn(),
+  };
+});
+
+jest.mock("../../../lib/vertex-api", () => {
+  const actual = jest.requireActual("../../../lib/vertex-api");
+  return {
+    ...actual,
+    getClientFromSession: (...args: unknown[]) =>
+      mockGetClientFromSession(...args),
+  };
+});
+
+jest.mock("../../../lib/file-collections", () => {
+  const actual = jest.requireActual("../../../lib/file-collections");
+  return {
+    ...actual,
+    getFileCollectionsApi: (...args: unknown[]) =>
+      mockGetFileCollectionsApi(...args),
+  };
+});
+
+type TestReq = Pick<NextIronRequest, "body" | "method" | "query" | "session">;
+
+interface TestRes extends Pick<NextApiResponse, "json" | "status"> {
+  readonly body: () => unknown;
+  readonly statusCode: () => number | undefined;
+}
+
+describe("file collection files API route", () => {
+  beforeEach(() => {
+    mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
+    mockGetFileCollectionsApi.mockReturnValue({
+      listFileCollectionFiles: mockListFileCollectionFiles,
+    });
+    mockListFileCollectionFiles.mockResolvedValue({ data: {} });
+    mockGetPage.mockImplementation(async (apiCall) => {
+      await apiCall();
+      return {
+        cursors: { next: "next-page", self: "self-page" },
+        page: { data: [fileData("file-1")] },
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("proxies collection file list requests with paging parameters", async () => {
+    const res = await callFileCollectionFiles({
+      method: "GET",
+      query: { id: "collection-1", cursor: "cursor-1", pageSize: "50" },
+    });
+
+    expect(mockGetClientFromSession).toHaveBeenCalled();
+    expect(mockGetFileCollectionsApi).toHaveBeenCalledWith({
+      client: "test-client",
+    });
+    expect(mockListFileCollectionFiles).toHaveBeenCalledWith({
+      id: "collection-1",
+      pageCursor: "cursor-1",
+      pageSize: 50,
+    });
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      cursors: { next: "next-page", self: "self-page" },
+      data: [fileData("file-1")],
+      status: 200,
+    });
+  });
+
+  it("uses the default page size when one is not supplied", async () => {
+    const res = await callFileCollectionFiles({
+      method: "GET",
+      query: { id: "collection-1" },
+    });
+
+    expect(mockListFileCollectionFiles).toHaveBeenCalledWith({
+      id: "collection-1",
+      pageCursor: undefined,
+      pageSize: 10,
+    });
+    expect(res.statusCode()).toBe(200);
+  });
+
+  it("validates requests before calling Vertex", async () => {
+    const missingId = await callFileCollectionFiles({
+      method: "GET",
+      query: {},
+    });
+    const unsupportedMethod = await callFileCollectionFiles({
+      method: "DELETE",
+      query: { id: "collection-1" },
+    });
+
+    expect(missingId.statusCode()).toBe(400);
+    expect(missingId.body()).toEqual({
+      message: "File Collection ID required.",
+      status: 400,
+    });
+    expect(unsupportedMethod.statusCode()).toBe(405);
+    expect(unsupportedMethod.body()).toEqual({
+      message: "Method not allowed.",
+      status: 405,
+    });
+    expect(mockGetClientFromSession).not.toHaveBeenCalled();
+  });
+});
+
+async function callFileCollectionFiles(req: {
+  readonly method: string;
+  readonly query?: Record<string, string | string[]>;
+}): Promise<TestRes> {
+  const res = createRes();
+  await handleFileCollectionFiles(
+    createReq(req),
+    res as unknown as NextApiResponse
+  );
+  return res;
+}
+
+function createReq({
+  method,
+  query = {},
+}: {
+  readonly method: string;
+  readonly query?: Record<string, string | string[]>;
+}): NextIronRequest {
+  const req: TestReq = {
+    method,
+    query,
+    session: {} as Session,
+  };
+  return req as NextIronRequest;
+}
+
+function createRes(): TestRes {
+  let responseBody: unknown;
+  let responseStatus: number | undefined;
+  const res = {} as TestRes;
+  res.body = () => responseBody;
+  res.statusCode = () => responseStatus;
+  res.status = jest.fn((statusCode: number) => {
+    responseStatus = statusCode;
+    return res;
+  });
+  res.json = jest.fn((body: unknown) => {
+    responseBody = body;
+    return res;
+  });
+  return res;
+}
+
+function fileData(id: string): unknown {
+  return {
+    attributes: {
+      created: "2026-06-12T15:30:00Z",
+      name: "File One",
+      status: "uploaded",
+      suppliedId: "file-supplied-1",
+      uploaded: "2026-06-12T15:31:00Z",
+    },
+    id,
+    type: "file",
+  };
+}

--- a/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
+++ b/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen } from "@testing-library/react";
+import type { Session } from "next-iron-session";
+import React from "react";
+
+import {
+  CredsKey,
+  EnvKey,
+  NetworkConfig,
+  NextIronRequest,
+  TokenKey,
+} from "../../../lib/with-session";
+import FileCollectionDetails, {
+  serverSidePropsHandler,
+} from "../../../pages/file-collections/[fileCollectionId]";
+
+const mockGetClientFromSession = jest.fn();
+const mockGetFileCollectionsApi = jest.fn();
+const mockGetFileCollection = jest.fn();
+const mockFileTable = jest.fn(
+  ({
+    apiPath,
+    emptyOnLoadError,
+    logLoadError,
+    showCreateButton,
+    showDeleteAction,
+    showSuppliedIdFilter,
+  }: {
+    readonly apiPath: string;
+    readonly emptyOnLoadError: boolean;
+    readonly logLoadError: boolean;
+    readonly showCreateButton: boolean;
+    readonly showDeleteAction: boolean;
+    readonly showSuppliedIdFilter: boolean;
+  }) => (
+    <div
+      data-api-path={apiPath}
+      data-empty-on-load-error={emptyOnLoadError.toString()}
+      data-log-load-error={logLoadError.toString()}
+      data-show-create-button={showCreateButton.toString()}
+      data-show-delete-action={showDeleteAction.toString()}
+      data-show-supplied-id-filter={showSuppliedIdFilter.toString()}
+      data-testid="files-table"
+    >
+      Files Table
+    </div>
+  )
+);
+
+jest.mock("../../../components/shared/Layout", () => ({
+  Layout: ({ main }: { readonly main: unknown }) => main,
+}));
+
+jest.mock(
+  "next/dynamic",
+  () => () => (props: Record<string, unknown>) => mockFileTable(props)
+);
+
+jest.mock("../../../lib/vertex-api", () => {
+  const actual = jest.requireActual("../../../lib/vertex-api");
+  return {
+    ...actual,
+    getClientFromSession: (...args: unknown[]) =>
+      mockGetClientFromSession(...args),
+  };
+});
+
+jest.mock("../../../lib/file-collections", () => {
+  const actual = jest.requireActual("../../../lib/file-collections");
+  return {
+    ...actual,
+    getFileCollectionsApi: (...args: unknown[]) =>
+      mockGetFileCollectionsApi(...args),
+  };
+});
+
+describe("FileCollectionDetails", () => {
+  beforeEach(() => {
+    mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
+    mockGetFileCollectionsApi.mockReturnValue({
+      getFileCollection: mockGetFileCollection,
+    });
+    mockGetFileCollection.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("renders return navigation and file collection metadata", () => {
+    render(
+      <FileCollectionDetails
+        fileCollection={{
+          id: "collection-1",
+          name: "Collection One",
+          suppliedId: "supplied-1",
+          created: "2026-06-10T15:30:00Z",
+          expiresAt: "2026-07-10T15:30:00Z",
+          metadata: { source: "unit-test" },
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: "File Collections" })
+    ).toHaveAttribute("href", "/file-collections");
+    expect(screen.getByText("File Collection Details")).toBeInTheDocument();
+    expect(screen.getAllByText("Collection One").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("collection-1").length).toBeGreaterThan(0);
+    expect(screen.getByText("supplied-1")).toBeInTheDocument();
+    expect(screen.getByText("source")).toBeInTheDocument();
+    expect(screen.getByText("unit-test")).toBeInTheDocument();
+  });
+
+  it("renders the collection files table below metadata", async () => {
+    render(
+      <FileCollectionDetails
+        fileCollection={{
+          id: "collection-1",
+          name: "Collection One",
+          suppliedId: "supplied-1",
+          created: "2026-06-10T15:30:00Z",
+          expiresAt: "2026-07-10T15:30:00Z",
+          metadata: { source: "unit-test" },
+        }}
+      />
+    );
+
+    const filesTable = await screen.findByTestId("files-table");
+
+    expect(filesTable).toHaveAttribute(
+      "data-api-path",
+      "/api/file-collections/collection-1/files"
+    );
+    expect(filesTable).toHaveAttribute("data-empty-on-load-error", "true");
+    expect(filesTable).toHaveAttribute("data-log-load-error", "true");
+    expect(filesTable).toHaveAttribute("data-show-create-button", "false");
+    expect(filesTable).toHaveAttribute("data-show-delete-action", "false");
+    expect(filesTable).toHaveAttribute("data-show-supplied-id-filter", "false");
+  });
+
+  it("loads a file collection by URL ID on the server", async () => {
+    mockGetFileCollection.mockResolvedValue({
+      data: {
+        data: {
+          type: "file-collection",
+          id: "collection-1",
+          attributes: {
+            name: "Collection One",
+            suppliedId: "supplied-1",
+            created: "2026-06-10T15:30:00Z",
+            expiresAt: "2026-07-10T15:30:00Z",
+            metadata: { source: "unit-test" },
+          },
+        },
+      },
+    });
+
+    const res = await serverSidePropsHandler({
+      query: { fileCollectionId: "collection-1" },
+      req: createReq(createSession()),
+    });
+
+    expect(mockGetFileCollection).toHaveBeenCalledWith({
+      id: "collection-1",
+    });
+    expect(res).toEqual({
+      props: {
+        clientId: "client-id",
+        vertexEnv: "custom",
+        networkConfig: {
+          apiHost: "https://example.test",
+          name: "test",
+          renderingHost: "https://example.test",
+          sceneTreeHost: "https://example.test",
+          sceneViewHost: "https://example.test",
+        },
+        fileCollection: {
+          id: "collection-1",
+          name: "Collection One",
+          suppliedId: "supplied-1",
+          created: "2026-06-10T15:30:00Z",
+          expiresAt: "2026-07-10T15:30:00Z",
+          metadata: { source: "unit-test" },
+        },
+      },
+    });
+  });
+
+  it("redirects unauthenticated direct URL requests to login", async () => {
+    const res = await serverSidePropsHandler({
+      query: { fileCollectionId: "collection-1" },
+      req: createReq(createSession({ authenticated: false })),
+    });
+
+    expect(res).toEqual({
+      redirect: { statusCode: 302, destination: "/login" },
+    });
+    expect(mockGetFileCollection).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound when the route has no file collection ID", async () => {
+    const res = await serverSidePropsHandler({
+      query: {},
+      req: createReq(createSession()),
+    });
+
+    expect(res).toEqual({ notFound: true });
+    expect(mockGetFileCollection).not.toHaveBeenCalled();
+  });
+
+  it("returns notFound for Vertex 404 responses", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    mockGetFileCollection.mockRejectedValue({
+      response: {
+        data: { errors: [{ status: "404", title: "Collection not found." }] },
+      },
+    });
+
+    const res = await serverSidePropsHandler({
+      query: { fileCollectionId: "missing-collection" },
+      req: createReq(createSession()),
+    });
+
+    expect(res).toEqual({ notFound: true });
+  });
+});
+
+function createReq(session: Session): NextIronRequest {
+  return { session } as NextIronRequest;
+}
+
+function createSession({
+  authenticated = true,
+}: { readonly authenticated?: boolean } = {}): Session {
+  const values = new Map<string, unknown>([
+    [EnvKey, "custom"],
+    [
+      NetworkConfig,
+      {
+        apiHost: "https://example.test",
+        name: "test",
+        renderingHost: "https://example.test",
+        sceneTreeHost: "https://example.test",
+        sceneViewHost: "https://example.test",
+      },
+    ],
+  ]);
+
+  if (authenticated) {
+    values.set(CredsKey, { id: "client-id", secret: "client-secret" });
+    values.set(TokenKey, {
+      expiration: Date.now() + 60 * 60 * 1000,
+      token: {
+        access_token: "test-token",
+        account_id: "account-id",
+        expires_in: 60 * 60,
+        scopes: [],
+        token_type: "Bearer",
+      },
+    });
+  }
+
+  return {
+    get: (key: string) => values.get(key),
+    set: (key: string, value: unknown) => {
+      values.set(key, value);
+    },
+  } as unknown as Session;
+}

--- a/src/components/file-collection/FileCollectionMetadataTable.tsx
+++ b/src/components/file-collection/FileCollectionMetadataTable.tsx
@@ -1,8 +1,4 @@
-import { Close } from "@mui/icons-material";
 import {
-  Box,
-  Drawer,
-  IconButton,
   Table,
   TableBody,
   TableCell,
@@ -11,69 +7,37 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import React from "react";
 
 import { toLocaleString } from "../../lib/dates";
 import { FileCollection } from "../../lib/file-collections";
 import { toDisplayValue } from "../../lib/formatting";
-import { RightDrawerWidth } from "../shared/Layout";
 
 interface Props {
-  readonly fileCollection?: FileCollection;
-  readonly onClose: () => void;
-  readonly open: boolean;
+  readonly fileCollection: FileCollection;
 }
 
-export function FileCollectionDetailsDrawer({
+export function FileCollectionMetadataTable({
   fileCollection,
-  onClose,
-  open,
 }: Props): JSX.Element {
   return (
-    <Drawer
-      anchor="right"
-      open={open}
-      sx={{
-        flexShrink: 0,
-        width: RightDrawerWidth,
-        "& .MuiDrawer-paper": { width: RightDrawerWidth },
-      }}
-      variant="persistent"
-    >
-      <Box sx={{ display: "flex", justifyContent: "space-between" }}>
-        <Typography sx={{ my: 2, mx: 2 }} variant="h5">
-          File Collection Details
-        </Typography>
-        <IconButton onClick={onClose} sx={{ mr: 2 }}>
-          <Close />
-        </IconButton>
-      </Box>
-      {fileCollection ? (
-        <TableContainer>
-          <Table size="small" sx={{ whiteSpace: "nowrap" }}>
-            <TableBody>
-              <DetailsRow label="Name" value={fileCollection.name} />
-              <DetailsRow label="ID" value={fileCollection.id} />
-              <DetailsRow
-                label="Supplied ID"
-                value={fileCollection.suppliedId}
-              />
-              <DetailsRow
-                label="Created"
-                value={toLocaleString(fileCollection.created)}
-              />
-              <DetailsRow
-                label="Expires"
-                value={toLocaleString(fileCollection.expiresAt)}
-              />
-              <MetadataRow metadata={fileCollection.metadata} />
-            </TableBody>
-          </Table>
-        </TableContainer>
-      ) : (
-        <></>
-      )}
-    </Drawer>
+    <TableContainer>
+      <Table size="small" sx={{ whiteSpace: "nowrap" }}>
+        <TableBody>
+          <DetailsRow label="Name" value={fileCollection.name} />
+          <DetailsRow label="ID" value={fileCollection.id} />
+          <DetailsRow label="Supplied ID" value={fileCollection.suppliedId} />
+          <DetailsRow
+            label="Created"
+            value={toLocaleString(fileCollection.created)}
+          />
+          <DetailsRow
+            label="Expires"
+            value={toLocaleString(fileCollection.expiresAt)}
+          />
+          <MetadataRow metadata={fileCollection.metadata} />
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 }
 

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -13,14 +13,12 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
+import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
 import { toLocaleString } from "../../lib/dates";
-import {
-  FileCollection,
-  toFileCollectionPage,
-} from "../../lib/file-collections";
+import { toFileCollectionPage } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
@@ -45,22 +43,19 @@ function useFileCollections({ cursor, pageSize, suppliedId }: SwrProps) {
   );
 }
 
-interface Props {
-  readonly activeFileCollectionId?: string;
-  readonly onFileCollectionSelected: (fileCollection: FileCollection) => void;
-}
-
-export default function FileCollectionTable({
-  activeFileCollectionId,
-  onFileCollectionSelected,
-}: Props): JSX.Element {
+export default function FileCollectionTable(): JSX.Element {
+  const router = useRouter();
   const pageSize = DefaultPageSize;
-  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
-    useCursorPagingState();
+  const {
+    currentPage,
+    cursor,
+    cursors,
+    handlePageChange,
+    resetPaging,
+    setCursors,
+  } = useCursorPagingState();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
-  const [suppliedId, setSuppliedIdFilter] = React.useState<
-    string | undefined
-  >();
+  const [suppliedId, setSuppliedId] = React.useState<string | undefined>();
   const [deleteError, setDeleteError] = React.useState<string>();
 
   const { data, error, mutate } = useFileCollections({
@@ -77,7 +72,7 @@ export default function FileCollectionTable({
     () =>
       debounce((value: string) => {
         resetPaging();
-        setSuppliedIdFilter(value === "" ? undefined : value);
+        setSuppliedId(value === "" ? undefined : value);
       }, 300),
     [resetPaging]
   );
@@ -133,6 +128,61 @@ export default function FileCollectionTable({
     mutate();
   }
 
+  function handleViewFiles(fileCollectionId: string) {
+    router.push(`/file-collections/${encodeURIComponent(fileCollectionId)}`);
+  }
+
+  let tableRows: React.ReactNode;
+  if (error) {
+    tableRows = <DataLoadError colSpan={headCells.length + 1} />;
+  } else if (!page) {
+    tableRows = (
+      <SkeletonBody
+        includeCheckbox={true}
+        numCellsPerRow={headCells.length}
+        numRows={pageSize - pageLength}
+        rowHeight={DefaultRowHeight}
+      />
+    );
+  } else {
+    tableRows = page.items.map((row) => {
+      const isSel = selected.has(row.id);
+
+      return (
+        <TableRow
+          hover
+          role="checkbox"
+          tabIndex={-1}
+          key={row.id}
+          selected={isSel}
+          onClick={() => handleViewFiles(row.id)}
+        >
+          <TableCell
+            padding="checkbox"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleCheck(row.id);
+            }}
+          >
+            <Checkbox
+              color="primary"
+              checked={isSel}
+              inputProps={{
+                "aria-label": `Select ${row.name ?? row.id}`,
+              }}
+            />
+          </TableCell>
+          <TableCell component="th" scope="row" padding="none">
+            {row.name}
+          </TableCell>
+          <TableCell>{row.id}</TableCell>
+          <TableCell>{row.suppliedId}</TableCell>
+          <TableCell>{toLocaleString(row.created)}</TableCell>
+        </TableRow>
+      );
+    });
+  }
+
   return (
     <>
       <Paper sx={{ m: 2 }}>
@@ -171,54 +221,7 @@ export default function FileCollectionTable({
               rowCount={pageLength}
             />
             <TableBody>
-              {error ? (
-                <DataLoadError colSpan={headCells.length + 1} />
-              ) : !page ? (
-                <SkeletonBody
-                  includeCheckbox={true}
-                  numCellsPerRow={headCells.length}
-                  numRows={pageSize - pageLength}
-                  rowHeight={DefaultRowHeight}
-                />
-              ) : (
-                page.items.map((row) => {
-                  const isSel = selected.has(row.id);
-                  const isActive = activeFileCollectionId === row.id;
-
-                  return (
-                    <TableRow
-                      hover
-                      role="checkbox"
-                      tabIndex={-1}
-                      key={row.id}
-                      selected={isSel || isActive}
-                      onClick={() => onFileCollectionSelected(row)}
-                    >
-                      <TableCell
-                        padding="checkbox"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCheck(row.id);
-                        }}
-                      >
-                        <Checkbox
-                          color="primary"
-                          checked={isSel}
-                          inputProps={{
-                            "aria-label": `Select ${row.name ?? row.id}`,
-                          }}
-                        />
-                      </TableCell>
-                      <TableCell component="th" scope="row" padding="none">
-                        {row.name}
-                      </TableCell>
-                      <TableCell>{row.id}</TableCell>
-                      <TableCell>{row.suppliedId}</TableCell>
-                      <TableCell>{toLocaleString(row.created)}</TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
+              {tableRows}
               {page?.items.length === 0 && (
                 <TableRow style={{ height: DefaultRowHeight }}>
                   <TableCell colSpan={headCells.length + 1}>
@@ -241,7 +244,11 @@ export default function FileCollectionTable({
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}
-          nextIconButtonProps={{ disabled: cursors?.next == null }}
+          slotProps={{
+            actions: {
+              nextButton: { disabled: cursors?.next == null },
+            },
+          }}
         />
       </Paper>
       <Snackbar

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Chip,
   IconButton,
   Paper,
   Snackbar,
@@ -20,10 +21,11 @@ import debounce from "lodash.debounce";
 import React from "react";
 import useSWR from "swr";
 
+import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
 import { File, toFilePage } from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
-import { SortState, toggleSort,toSortParam } from "../../lib/sorting";
+import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -41,14 +43,20 @@ export const headCells: readonly HeadCell[] = [
   { id: "download", label: "Download" },
 ];
 
+interface UseFilesProps extends SwrProps {
+  readonly apiPath: string;
+  readonly sort: SortState;
+}
+
 function useFiles({
+  apiPath,
   cursor,
   pageSize,
   sort,
   suppliedId,
-}: SwrProps & { readonly sort: SortState }) {
+}: UseFilesProps) {
   return useSWR(
-    buildQuery("/api/files", {
+    buildQuery(apiPath, {
       cursor,
       pageSize,
       sort: toSortParam(sort),
@@ -57,13 +65,58 @@ function useFiles({
   );
 }
 
+function isFileAvailable(file: File): boolean {
+  const status = normalizeStatus(file.status);
+
+  return status === "complete";
+}
+
+function normalizeStatus(status?: string): string | undefined {
+  return status?.toLowerCase();
+}
+
+function statusLabel(status?: string): string {
+  return status ?? "N/A";
+}
+
+function statusColor(
+  status?: string
+): "default" | "success" | "warning" | "error" {
+  switch (normalizeStatus(status)) {
+    case "complete":
+    case "ready":
+      return "success";
+    case "pending":
+      return "warning";
+    case "error":
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
 interface Props {
   readonly activeFileId?: string;
+  readonly apiPath?: string;
+  readonly emptyOnLoadError?: boolean;
+  readonly logLoadError?: boolean;
+  readonly showCreateButton?: boolean;
+  readonly showDeleteAction?: boolean;
+  readonly showSuppliedIdFilter?: boolean;
+  readonly title?: string;
   readonly onFileSelected: (file: File) => void;
 }
 
 export default function FilesTable({
   activeFileId,
+  apiPath = "/api/files",
+  emptyOnLoadError = false,
+  logLoadError = false,
+  showCreateButton = true,
+  showDeleteAction = true,
+  showSuppliedIdFilter = true,
+  title = "Files",
   onFileSelected,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
@@ -71,8 +124,14 @@ export default function FilesTable({
     field: "created",
     order: "desc",
   });
-  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
-    useCursorPagingState();
+  const {
+    currentPage,
+    cursor,
+    cursors,
+    handlePageChange,
+    resetPaging,
+    setCursors,
+  } = useCursorPagingState();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
   const [suppliedId, setSuppliedIdFilter] = React.useState<
@@ -80,17 +139,26 @@ export default function FilesTable({
   >();
   const [showToast, setShowToast] = React.useState(false);
   const [downloadError, setDownloadError] = React.useState<string>();
+  const loggedLoadError = React.useRef<unknown>();
 
   const { data, error, mutate } = useFiles({
+    apiPath,
     cursor,
     pageSize,
     sort,
     suppliedId,
   });
-  const page = data ? toFilePage(data) : undefined;
-  const pageLength = page ? page.items.length : 0;
+  const loadError = error ?? (isErrorRes(data) ? data : undefined);
+  const page = data && !isErrorRes(data) ? toFilePage(data) : undefined;
+  const visiblePage =
+    page ??
+    (loadError && emptyOnLoadError ? { cursors: null, items: [] } : undefined);
+  const pageLength = visiblePage ? visiblePage.items.length : 0;
+  const paginationCursors = visiblePage?.cursors ?? cursors;
   const emptyRows =
-    cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
+    paginationCursors?.next == null && paginationCursors?.self == null
+      ? 0
+      : pageSize - pageLength;
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
     () =>
@@ -107,11 +175,24 @@ export default function FilesTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
+  React.useEffect(() => {
+    if (
+      !logLoadError ||
+      loadError == null ||
+      loggedLoadError.current === loadError
+    ) {
+      return;
+    }
+
+    loggedLoadError.current = loadError;
+    console.error(loadError);
+  }, [loadError, logLoadError]);
+
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
-    if (page == null) return;
+    if (visiblePage == null) return;
 
     const upd = new Set<string>();
-    if (e.target.checked) page.items.map((n) => upd.add(n.id));
+    if (e.target.checked) visiblePage.items.forEach((n) => upd.add(n.id));
     setSelected(upd);
   }
 
@@ -136,8 +217,10 @@ export default function FilesTable({
   }
 
   async function handleDelete() {
+    if (!showDeleteAction) return;
+
     setSelected(new Set());
-    await fetch("/api/files", {
+    await fetch(apiPath, {
       body: JSON.stringify({ ids: [...selected] }),
       method: "DELETE",
     });
@@ -168,43 +251,139 @@ export default function FilesTable({
     }
   }
 
+  let tableRows: React.ReactNode;
+  if (loadError && !emptyOnLoadError) {
+    tableRows = <DataLoadError colSpan={headCells.length + 1} />;
+  } else if (!visiblePage) {
+    tableRows = (
+      <SkeletonBody
+        includeCheckbox={true}
+        numCellsPerRow={8}
+        numRows={pageSize - pageLength}
+        rowHeight={DefaultRowHeight}
+      />
+    );
+  } else {
+    tableRows = visiblePage.items.map((row) => {
+      const isSel = selected.has(row.id);
+      const isActive = activeFileId === row.id;
+      const isAvailable = isFileAvailable(row);
+
+      return (
+        <TableRow
+          hover
+          role="checkbox"
+          tabIndex={-1}
+          key={row.id}
+          selected={isSel || isActive}
+          onClick={() => onFileSelected(row)}
+        >
+          <TableCell
+            padding="checkbox"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleCheck(row.id);
+            }}
+          >
+            <Checkbox
+              color="primary"
+              checked={isSel}
+              inputProps={{
+                "aria-label": `Select ${row.name ?? row.id}`,
+              }}
+            />
+          </TableCell>
+          <TableCell component="th" scope="row" padding="none">
+            {row.name}
+          </TableCell>
+          <TableCell>{row.suppliedId}</TableCell>
+          <TableCell>
+            <Chip
+              color={statusColor(row.status)}
+              label={statusLabel(row.status)}
+              size="small"
+              sx={{ fontWeight: 600, textTransform: "uppercase" }}
+              variant="outlined"
+            />
+          </TableCell>
+          <TableCell>{row.id}</TableCell>
+          <TableCell>{toLocaleString(row.created)}</TableCell>
+          <TableCell>{toLocaleString(row.uploaded)}</TableCell>
+          <TableCell
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <Tooltip
+              title={
+                isAvailable ? "Download file" : "File is not available yet"
+              }
+            >
+              <span>
+                <IconButton
+                  aria-label={`Download ${row.name}`}
+                  disabled={!isAvailable}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isAvailable) handleDownload(row.id);
+                  }}
+                  size="small"
+                >
+                  <Download fontSize="small" />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </TableCell>
+        </TableRow>
+      );
+    });
+  }
+
   return (
     <>
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={handleDelete}
-          title="Files"
+          onDelete={showDeleteAction ? handleDelete : undefined}
+          title={title}
         />
-        <Box
-          sx={{
-            px: { sm: 2 },
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "center",
-          }}
-        >
-          <TextField
-            variant="standard"
-            size="small"
-            margin="normal"
-            id="suppliedIdFilter"
-            label="Supplied ID Filter (exact)"
-            type="text"
-            onChange={(e) => {
-              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? "");
+        {(showSuppliedIdFilter || showCreateButton) && (
+          <Box
+            sx={{
+              px: { sm: 2 },
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
             }}
-            sx={{ mt: 0, width: "20rem" }}
-          />
-          <Button
-            key="upload"
-            variant="contained"
-            startIcon={<Add />}
-            onClick={() => setShowDialog(true)}
           >
-            New
-          </Button>
-        </Box>
+            {showSuppliedIdFilter ? (
+              <TextField
+                variant="standard"
+                size="small"
+                margin="normal"
+                id="suppliedIdFilter"
+                label="Supplied ID Filter (exact)"
+                type="text"
+                onChange={(e) => {
+                  debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? "");
+                }}
+                sx={{ mt: 0, width: "20rem" }}
+              />
+            ) : (
+              <Box />
+            )}
+            {showCreateButton && (
+              <Button
+                key="upload"
+                variant="contained"
+                startIcon={<Add />}
+                onClick={() => setShowDialog(true)}
+              >
+                New
+              </Button>
+            )}
+          </Box>
+        )}
         <TableContainer>
           <Table>
             <TableHead
@@ -216,68 +395,7 @@ export default function FilesTable({
               sort={sort}
             />
             <TableBody>
-              {error ? (
-                <DataLoadError colSpan={headCells.length + 1} />
-              ) : !page ? (
-                <SkeletonBody
-                  includeCheckbox={true}
-                  numCellsPerRow={8}
-                  numRows={pageSize - pageLength}
-                  rowHeight={DefaultRowHeight}
-                />
-              ) : (
-                page.items.map((row) => {
-                  const isSel = selected.has(row.id);
-                  const isActive = activeFileId === row.id;
-
-                  return (
-                    <TableRow
-                      hover
-                      role="checkbox"
-                      tabIndex={-1}
-                      key={row.id}
-                      selected={isSel || isActive}
-                      onClick={() => onFileSelected(row)}
-                    >
-                      <TableCell
-                        padding="checkbox"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleCheck(row.id);
-                        }}
-                      >
-                        <Checkbox color="primary" checked={isSel} />
-                      </TableCell>
-                      <TableCell component="th" scope="row" padding="none">
-                        {row.name}
-                      </TableCell>
-                      <TableCell>{row.suppliedId}</TableCell>
-                      <TableCell>{row.status}</TableCell>
-                      <TableCell>{row.id}</TableCell>
-                      <TableCell>{toLocaleString(row.created)}</TableCell>
-                      <TableCell>{toLocaleString(row.uploaded)}</TableCell>
-                      <TableCell
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                      >
-                        <Tooltip title="Download file">
-                          <IconButton
-                            aria-label={`Download ${row.name}`}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleDownload(row.id);
-                            }}
-                            size="small"
-                          >
-                            <Download fontSize="small" />
-                          </IconButton>
-                        </Tooltip>
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
+              {tableRows}
               {emptyRows > 0 && (
                 <TableRow style={{ height: DefaultRowHeight * emptyRows }}>
                   <TableCell colSpan={headCells.length + 1} />
@@ -293,18 +411,24 @@ export default function FilesTable({
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}
-          nextIconButtonProps={{ disabled: cursors?.next == null }}
+          slotProps={{
+            actions: {
+              nextButton: { disabled: paginationCursors?.next == null },
+            },
+          }}
         />
       </Paper>
-      <CreateFileDialog
-        open={showDialog}
-        onClose={() => setShowDialog(false)}
-        onFileCreated={() => {
-          setShowDialog(false);
-          setShowToast(true);
-          mutate();
-        }}
-      />
+      {showCreateButton && (
+        <CreateFileDialog
+          open={showDialog}
+          onClose={() => setShowDialog(false)}
+          onFileCreated={() => {
+            setShowDialog(false);
+            setShowToast(true);
+            mutate();
+          }}
+        />
+      )}
       <Snackbar
         open={showToast}
         autoHideDuration={6000}

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -9,6 +9,7 @@ import {
   Box,
   Button,
   Checkbox,
+  Chip,
   CircularProgress,
   IconButton,
   Paper,
@@ -65,6 +66,24 @@ function useScenes({ cursor, pageSize, suppliedId, name }: SwrProps) {
       suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
     }${name ? `&name=${encodeURIComponent(name)}` : ""}`
   );
+}
+
+function stateColor(
+  state?: string
+): "default" | "success" | "warning" | "error" {
+  switch (state) {
+    case "commit":
+    case "committed":
+    case "ready":
+      return "success";
+    case "draft":
+      return "warning";
+    case "error":
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
 }
 
 export default function SceneTable({
@@ -300,7 +319,15 @@ export default function SceneTable({
                         {row.name}
                       </TableCell>
                       <TableCell>{row.suppliedId}</TableCell>
-                      <TableCell>{row.state}</TableCell>
+                      <TableCell>
+                        <Chip
+                          color={stateColor(row.state)}
+                          label={row.state ?? "N/A"}
+                          size="small"
+                          sx={{ fontWeight: 600, textTransform: "uppercase" }}
+                          variant="outlined"
+                        />
+                      </TableCell>
                       <TableCell>{row.id}</TableCell>
                       <TableCell>{toLocaleString(row.created)}</TableCell>
                       <TableCell>
@@ -362,7 +389,11 @@ export default function SceneTable({
           rowsPerPage={pageSize}
           page={curPage}
           onPageChange={handleChangePage}
-          nextIconButtonProps={{ disabled: cursors?.next == null }}
+          slotProps={{
+            actions: {
+              nextButton: { disabled: cursors?.next == null },
+            },
+          }}
         />
       </Paper>
       <Snackbar

--- a/src/components/shared/TableToolbar.tsx
+++ b/src/components/shared/TableToolbar.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 interface Props {
   readonly numSelected: number;
-  readonly onDelete: () => void;
+  readonly onDelete?: () => void;
   readonly title: string;
   readonly customActions?: React.ReactNode;
 }
@@ -45,7 +45,7 @@ export const TableToolbar = ({
         </Typography>
       )}
       {numSelected > 1 && !!customActions ? customActions : <></>}
-      {numSelected > 0 && (
+      {numSelected > 0 && onDelete != null && (
         <Tooltip title="Delete">
           <IconButton aria-label="Delete" onClick={() => onDelete()}>
             <Delete />

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -11,6 +11,12 @@ import { Paged, toPage } from "./paging";
 export type FileCollection = Pick<FileCollectionMetadataData, "id"> &
   FileCollectionMetadataDataAttributes;
 
+export function toFileCollection(
+  data: FileCollectionMetadataData
+): FileCollection {
+  return { ...data.attributes, id: data.id };
+}
+
 export function toFileCollectionPage(
   res: GetRes<FileCollectionMetadataData>
 ): Paged<FileCollection> {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import "@vertexvis/viewer/dist/viewer/viewer.css";
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import CssBaseline from "@mui/material/CssBaseline";
+import LinearProgress from "@mui/material/LinearProgress";
 import { ThemeProvider } from "@mui/material/styles";
 import { AppProps } from "next/app";
 import Head from "next/head";
@@ -17,6 +18,7 @@ cache.compat = true;
 
 export default function App({ Component, pageProps }: AppProps): JSX.Element {
   const { events } = useRouter();
+  const [routeLoading, setRouteLoading] = React.useState(false);
 
   React.useEffect(() => {
     function handleChange(url: string) {
@@ -38,6 +40,26 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
     };
   }, [events]);
 
+  React.useEffect(() => {
+    function handleRouteChangeStart() {
+      setRouteLoading(true);
+    }
+
+    function handleRouteChangeEnd() {
+      setRouteLoading(false);
+    }
+
+    events.on("routeChangeStart", handleRouteChangeStart);
+    events.on("routeChangeComplete", handleRouteChangeEnd);
+    events.on("routeChangeError", handleRouteChangeEnd);
+
+    return () => {
+      events.off("routeChangeStart", handleRouteChangeStart);
+      events.off("routeChangeComplete", handleRouteChangeEnd);
+      events.off("routeChangeError", handleRouteChangeEnd);
+    };
+  }, [events]);
+
   return (
     <React.StrictMode>
       <CacheProvider value={cache}>
@@ -55,6 +77,17 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
         </Head>
         <ThemeProvider theme={theme}>
           <CssBaseline />
+          {routeLoading && (
+            <LinearProgress
+              sx={{
+                left: 0,
+                position: "fixed",
+                right: 0,
+                top: 0,
+                zIndex: (theme) => theme.zIndex.tooltip,
+              }}
+            />
+          )}
           <SWRConfig
             value={{ fetcher: (url) => fetch(url).then((res) => res.json()) }}
           >

--- a/src/pages/api/file-collections/[id]/files.ts
+++ b/src/pages/api/file-collections/[id]/files.ts
@@ -1,0 +1,62 @@
+import {
+  FileMetadataData,
+  getPage,
+  head,
+  logError,
+  VertexError,
+} from "@vertexvis/api-client-node";
+import { NextApiResponse } from "next";
+
+import {
+  ErrorRes,
+  GetRes,
+  MethodNotAllowed,
+  ServerError,
+  toErrorRes,
+} from "../../../../lib/api";
+import { getFileCollectionsApi } from "../../../../lib/file-collections";
+import { getClientFromSession } from "../../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../../lib/with-session";
+
+export async function handleFileCollectionFiles(
+  req: NextIronRequest,
+  res: NextApiResponse<GetRes<FileMetadataData> | ErrorRes>
+): Promise<void> {
+  if (req.method === "GET") {
+    const r = await get(req);
+    return res.status(r.status).json(r);
+  }
+
+  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+}
+
+export default withSession(handleFileCollectionFiles);
+
+async function get(
+  req: NextIronRequest
+): Promise<ErrorRes | GetRes<FileMetadataData>> {
+  try {
+    const id = head(req.query.id);
+    if (id == null)
+      return { message: "File Collection ID required.", status: 400 };
+
+    const pageSize = head(req.query.pageSize);
+    const cursor = head(req.query.cursor);
+    const c = getFileCollectionsApi(await getClientFromSession(req.session));
+    const { cursors, page } = await getPage(() =>
+      c.listFileCollectionFiles({
+        id,
+        pageCursor: cursor,
+        pageSize: pageSize ? Number.parseInt(pageSize, 10) : 10,
+      })
+    );
+
+    return { cursors, data: page.data, status: 200 };
+  } catch (error) {
+    const e = error as VertexError;
+    logError(e);
+    return e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError?.res })
+      : ServerError;
+  }
+}

--- a/src/pages/api/file-collections/[id]/index.ts
+++ b/src/pages/api/file-collections/[id]/index.ts
@@ -13,10 +13,10 @@ import {
   Res,
   ServerError,
   toErrorRes,
-} from "../../../lib/api";
-import { getFileCollectionsApi } from "../../../lib/file-collections";
-import { getClientFromSession, makeCall } from "../../../lib/vertex-api";
-import withSession, { NextIronRequest } from "../../../lib/with-session";
+} from "../../../../lib/api";
+import { getFileCollectionsApi } from "../../../../lib/file-collections";
+import { getClientFromSession, makeCall } from "../../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
 interface GetFileCollectionRes extends Res {
   readonly data: FileCollectionMetadataData;

--- a/src/pages/file-collections.tsx
+++ b/src/pages/file-collections.tsx
@@ -1,10 +1,7 @@
 import dynamic from "next/dynamic";
-import React from "react";
 
-import { FileCollectionDetailsDrawer } from "../components/file-collection/FileCollectionDetailsDrawer";
 import { Layout } from "../components/shared/Layout";
-import { FileCollection } from "../lib/file-collections";
-import { defaultServerSideProps } from "../lib/with-session";
+export { defaultServerSideProps as getServerSideProps } from "../lib/with-session";
 
 const FileCollectionsTable = dynamic(
   () => import("../components/file-collection/FileCollectionTable"),
@@ -14,29 +11,5 @@ const FileCollectionsTable = dynamic(
 );
 
 export default function FileCollections(): JSX.Element {
-  const [fileCollection, setFileCollection] = React.useState<
-    FileCollection | undefined
-  >();
-  const drawerOpen = Boolean(fileCollection);
-
-  return (
-    <Layout
-      main={
-        <FileCollectionsTable
-          activeFileCollectionId={fileCollection?.id}
-          onFileCollectionSelected={setFileCollection}
-        />
-      }
-      rightDrawer={
-        <FileCollectionDetailsDrawer
-          fileCollection={fileCollection}
-          onClose={() => setFileCollection(undefined)}
-          open={drawerOpen}
-        />
-      }
-      rightDrawerOpen={drawerOpen}
-    />
-  );
+  return <Layout main={<FileCollectionsTable />} />;
 }
-
-export const getServerSideProps = defaultServerSideProps;

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -1,0 +1,134 @@
+import { Box, Breadcrumbs, Link, Paper, Typography } from "@mui/material";
+import { head } from "@vertexvis/api-client-node";
+import { GetServerSidePropsResult } from "next";
+import dynamic from "next/dynamic";
+import { withIronSession } from "next-iron-session";
+import React from "react";
+
+import { FileDetailsDrawer } from "../../components/file/FileDetailsDrawer";
+import { FileCollectionMetadataTable } from "../../components/file-collection/FileCollectionMetadataTable";
+import { Layout } from "../../components/shared/Layout";
+import { isErrorFailure, toErrorRes } from "../../lib/api";
+import {
+  FileCollection,
+  getFileCollectionsApi,
+  toFileCollection,
+} from "../../lib/file-collections";
+import { File } from "../../lib/files";
+import { getClientFromSession, makeCall } from "../../lib/vertex-api";
+import {
+  CommonProps,
+  CookieAttributes,
+  NextIronRequest,
+  serverSidePropsHandler as commonServerSidePropsHandler,
+} from "../../lib/with-session";
+
+interface Props {
+  readonly fileCollection: FileCollection;
+}
+
+const FilesTable = dynamic(() => import("../../components/file/FileTable"), {
+  ssr: false,
+});
+
+type ServerSideProps = CommonProps & Props;
+
+interface ServerSideContext {
+  readonly query: {
+    readonly fileCollectionId?: string | string[];
+  };
+  readonly req: NextIronRequest;
+}
+
+export default function FileCollectionDetails({
+  fileCollection,
+}: Props): JSX.Element {
+  const [file, setFile] = React.useState<File | undefined>();
+  const drawerOpen = Boolean(file);
+  const filesApiPath = `/api/file-collections/${encodeURIComponent(
+    fileCollection.id
+  )}/files`;
+
+  return (
+    <Layout
+      main={
+        <Box sx={{ p: 2 }}>
+          <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
+            <Link href="/file-collections" underline="hover">
+              File Collections
+            </Link>
+            <Typography color="text.primary">
+              {fileCollection.name ?? fileCollection.id}
+            </Typography>
+          </Breadcrumbs>
+          <Paper sx={{ p: 2 }}>
+            <Typography variant="h5">File Collection Details</Typography>
+            <Typography
+              color="text.secondary"
+              sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+              variant="body2"
+            >
+              {fileCollection.id}
+            </Typography>
+            <Box sx={{ mt: 2 }}>
+              <FileCollectionMetadataTable fileCollection={fileCollection} />
+            </Box>
+          </Paper>
+          <FilesTable
+            activeFileId={file?.id}
+            apiPath={filesApiPath}
+            emptyOnLoadError={true}
+            logLoadError={true}
+            onFileSelected={setFile}
+            showCreateButton={false}
+            showDeleteAction={false}
+            showSuppliedIdFilter={false}
+          />
+        </Box>
+      }
+      rightDrawer={
+        <FileDetailsDrawer
+          file={file}
+          onClose={() => setFile(undefined)}
+          open={drawerOpen}
+        />
+      }
+      rightDrawerOpen={drawerOpen}
+    />
+  );
+}
+
+export const getServerSideProps = withIronSession(
+  serverSidePropsHandler,
+  CookieAttributes
+);
+
+export async function serverSidePropsHandler({
+  query,
+  req,
+}: ServerSideContext): Promise<GetServerSidePropsResult<ServerSideProps>> {
+  const authResult = commonServerSidePropsHandler({ req });
+  if (!("props" in authResult)) return authResult;
+
+  const fileCollectionId = head(query.fileCollectionId);
+  if (fileCollectionId == null) return { notFound: true };
+
+  const api = getFileCollectionsApi(await getClientFromSession(req.session));
+  const res = await makeCall(() =>
+    api.getFileCollection({ id: fileCollectionId })
+  );
+
+  if (isErrorFailure(res)) {
+    const error = toErrorRes({ failure: res });
+    if (error.status === 400 || error.status === 404) return { notFound: true };
+
+    throw new Error(error.message);
+  }
+
+  return {
+    props: {
+      ...(authResult.props as CommonProps),
+      fileCollection: toFileCollection(res.data),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Adds a dedicated File Collection page.

This displays attached files, and has download button present for attached files.

[Jira](https://vertexvis.atlassian.net/browse/PLAT-8768)

Adds a couple UX affordances
- download button is only active if the file has a 'complete' status
- status field for Files and Scenes now display a Chip component for a better visual indicator

## Bonus Improvement
Adds a small Material linear progress indicator during Next route changes. This gives immediate feedback after actions like clicking a File Collection row while the destination page is loading.

Product note: this is included as a bonus UX improvement for product feedback before deciding whether to keep it.

## Test Plan
Go to File Collections
Click on a File Collection, note navigation to focused File Collection view
Attached files display on table
- clicking on a file shows file details on right
- download button is available for individual file when the file is in complete state
- try to move through multiple pages of files
- click between pages/routes and confirm the top progress indicator appears during navigation

## Release Notes
FileCollections have a detail page.

It displays attached files and provides a link to download them.

Bonus: app route changes now show a top progress indicator while navigation is in flight.

## Possible Regressions
n/a

## Dependencies
n/a
