### PR TITLE
PLAT-8768 Add route change progress indicator

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,8 @@ import "@vertexvis/viewer/dist/viewer/viewer.css";
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
 import CssBaseline from "@mui/material/CssBaseline";
+import Fade from "@mui/material/Fade";
+import LinearProgress from "@mui/material/LinearProgress";
 import { ThemeProvider } from "@mui/material/styles";
 import { AppProps } from "next/app";
 import Head from "next/head";
@@ -15,8 +17,14 @@ import theme from "../lib/theme";
 const cache = createCache({ key: "css", prepend: true });
 cache.compat = true;
 
+const RouteProgressDelayMs = 150;
+const RouteProgressFadeInMs = 200;
+const RouteProgressFadeOutMs = 300;
+
 export default function App({ Component, pageProps }: AppProps): JSX.Element {
   const { events } = useRouter();
+  const [showRouteProgress, setShowRouteProgress] = React.useState(false);
+  const routeProgressTimer = React.useRef<number>();
 
   React.useEffect(() => {
     function handleChange(url: string) {
@@ -38,6 +46,37 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
     };
   }, [events]);
 
+  React.useEffect(() => {
+    function handleRouteChangeStart() {
+      routeProgressTimer.current = window.setTimeout(() => {
+        setShowRouteProgress(true);
+      }, RouteProgressDelayMs);
+    }
+
+    function handleRouteChangeEnd() {
+      if (routeProgressTimer.current != null) {
+        window.clearTimeout(routeProgressTimer.current);
+        routeProgressTimer.current = undefined;
+      }
+
+      setShowRouteProgress(false);
+    }
+
+    events.on("routeChangeStart", handleRouteChangeStart);
+    events.on("routeChangeComplete", handleRouteChangeEnd);
+    events.on("routeChangeError", handleRouteChangeEnd);
+
+    return () => {
+      if (routeProgressTimer.current != null) {
+        window.clearTimeout(routeProgressTimer.current);
+      }
+
+      events.off("routeChangeStart", handleRouteChangeStart);
+      events.off("routeChangeComplete", handleRouteChangeEnd);
+      events.off("routeChangeError", handleRouteChangeEnd);
+    };
+  }, [events]);
+
   return (
     <React.StrictMode>
       <CacheProvider value={cache}>
@@ -55,6 +94,23 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
         </Head>
         <ThemeProvider theme={theme}>
           <CssBaseline />
+          <Fade
+            in={showRouteProgress}
+            timeout={{
+              enter: RouteProgressFadeInMs,
+              exit: RouteProgressFadeOutMs,
+            }}
+          >
+            <LinearProgress
+              sx={{
+                left: 0,
+                position: "fixed",
+                right: 0,
+                top: 0,
+                zIndex: (theme) => theme.zIndex.tooltip,
+              }}
+            />
+          </Fade>
           <SWRConfig
             value={{ fetcher: (url) => fetch(url).then((res) => res.json()) }}
           >


### PR DESCRIPTION
## Summary
Adds a small Material linear progress indicator during Next route changes.

This gives immediate feedback after actions like clicking a table row while the destination page is loading.

Broken out for an easier PR merge. Pending UX sign off in thread
https://vertexvis.slack.com/archives/C09MLGZH39V/p1782481888188599

## Product Note
This is a bonus UX improvement split out from the file collections work so Product can evaluate it independently.

## Test Plan
- Navigate between pages/routes and confirm the top progress indicator appears while navigation is in flight.
- Run lint.

## Validation
- `next lint` passed.

## Possible Regressions
n/a

## Dependencies
n/a
