### PR TITLE
[PLAT-8769] Stop stale file collection drawer requests

### DIFF
--- a/src/__tests__/components/file/FileDetailsDrawer.test.tsx
+++ b/src/__tests__/components/file/FileDetailsDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 
 import { FileDetailsDrawer } from "../../../components/file/FileDetailsDrawer";
@@ -57,12 +57,55 @@ describe("FileDetailsDrawer", () => {
     });
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
-      "/api/files/file-1/file-collections?pageSize=25"
+      "/api/files/file-1/file-collections?pageSize=25",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/api/files/file-1/file-collections?pageSize=25&cursor=next-page"
+      "/api/files/file-1/file-collections?pageSize=25&cursor=next-page",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
     );
+  });
+
+  it("stops following cursors when the drawer closes", async () => {
+    let resolveFirstPage: (body: unknown) => void = () => undefined;
+    const firstPage = new Promise<unknown>((resolve) => {
+      resolveFirstPage = resolve;
+    });
+    const fetchMock = mockFetch((url) =>
+      url.includes("cursor=next-page")
+        ? {
+            cursors: { self: "page-2" },
+            data: [collectionData("collection-2", "supplied-2")],
+            status: 200,
+          }
+        : firstPage
+    );
+
+    const { rerender } = render(
+      <FileDetailsDrawer file={baseFile} onClose={jest.fn()} open={true} />
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(
+      <FileDetailsDrawer file={baseFile} onClose={jest.fn()} open={false} />
+    );
+
+    await act(async () => {
+      resolveFirstPage({
+        cursors: { self: "page-1", next: "next-page" },
+        data: [collectionData("collection-1", "supplied-1")],
+        status: 200,
+      });
+      await firstPage;
+    });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("shows N/A when the file has no associated file collections", async () => {
@@ -72,7 +115,9 @@ describe("FileDetailsDrawer", () => {
       status: 200,
     }));
 
-    render(<FileDetailsDrawer file={baseFile} onClose={jest.fn()} open={true} />);
+    render(
+      <FileDetailsDrawer file={baseFile} onClose={jest.fn()} open={true} />
+    );
 
     expect(await screen.findByText("File Collection IDs")).toBeInTheDocument();
     await waitFor(() => {

--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -97,7 +97,9 @@ function useFileCollectionIds({
   readonly fileCollectionIds: string[];
   readonly loading: boolean;
 } {
-  const [fileCollectionIds, setFileCollectionIds] = React.useState<string[]>([]);
+  const [fileCollectionIds, setFileCollectionIds] = React.useState<string[]>(
+    []
+  );
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string>();
 
@@ -109,18 +111,25 @@ function useFileCollectionIds({
       return;
     }
 
-    let cancelled = false;
+    const controller = new AbortController();
 
     const loadPage = async (nextCursor?: string): Promise<string[]> => {
+      if (controller.signal.aborted) return [];
+
       const params = new URLSearchParams({
         pageSize: DefaultPageSize.toString(),
       });
       if (nextCursor != null) params.set("cursor", nextCursor);
 
       const res = await fetch(
-        `/api/files/${encodeURIComponent(fileId)}/file-collections?${params.toString()}`
+        `/api/files/${encodeURIComponent(
+          fileId
+        )}/file-collections?${params.toString()}`,
+        { signal: controller.signal }
       );
       const body = await res.json();
+
+      if (controller.signal.aborted) return [];
 
       if (!res.ok) {
         throw new Error(
@@ -144,12 +153,12 @@ function useFileCollectionIds({
       try {
         const ids = await loadPage();
 
-        if (!cancelled) {
+        if (!controller.signal.aborted) {
           setFileCollectionIds(ids);
           setLoading(false);
         }
       } catch (err) {
-        if (!cancelled) {
+        if (!controller.signal.aborted) {
           setError(
             err instanceof Error
               ? err.message
@@ -163,7 +172,7 @@ function useFileCollectionIds({
     load();
 
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [fileId, open]);
 


### PR DESCRIPTION
## Summary

- Abort the file collection ID lookup when the file details drawer closes or the selected file changes.
- Stop following stale pagination cursors after cleanup has run.
- Add a regression test that closes the drawer before the first page resolves and verifies the next cursor is not fetched.

## Why

The existing cleanup prevented stale state updates, but the recursive loader could continue requesting every remaining cursor for a file that was no longer selected. That defeated the lazy-load behavior and could add unnecessary API load for files associated with many collections.

## Validation

- `corepack yarn lint --no-cache`
- `corepack yarn test src/__tests__/components/file/FileDetailsDrawer.test.tsx --runInBand --coverage=false`