### PR TITLE
[PLAT-8769] Use Next navigation for app links

### DIFF
--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -4,7 +4,6 @@ import {
   CircularProgress,
   Drawer,
   IconButton,
-  Link,
   Table,
   TableBody,
   TableCell,
@@ -17,9 +16,13 @@ import {
 import React from "react";
 
 import { toLocaleString } from "../../lib/dates";
-import { FileCollection, toFileCollectionPage } from "../../lib/file-collections";
+import {
+  FileCollection,
+  toFileCollectionPage,
+} from "../../lib/file-collections";
 import { File } from "../../lib/files";
 import { toDisplayValue, toFileSizeDisplay } from "../../lib/formatting";
+import { AppLink } from "../shared/AppLink";
 import { DefaultPageSize, RightDrawerWidth } from "../shared/Layout";
 
 interface Props {
@@ -100,9 +103,9 @@ function useFileCollections({
   readonly fileCollections: FileCollection[];
   readonly loading: boolean;
 } {
-  const [fileCollections, setFileCollections] = React.useState<FileCollection[]>(
-    []
-  );
+  const [fileCollections, setFileCollections] = React.useState<
+    FileCollection[]
+  >([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string>();
 
@@ -296,9 +299,7 @@ function FileCollectionIdsRow({
       <TableCell>
         <Typography variant="subtitle2">File Collections</Typography>
         {loading ? (
-          <Box
-            sx={{ alignItems: "center", display: "flex", gap: 1, mt: 1 }}
-          >
+          <Box sx={{ alignItems: "center", display: "flex", gap: 1, mt: 1 }}>
             <CircularProgress size={16} />
             <Typography variant="body2">Loading collections...</Typography>
           </Box>
@@ -315,7 +316,7 @@ function FileCollectionIdsRow({
               {fileCollections.map((collection) => (
                 <TableRow key={collection.id}>
                   <TableCell sx={{ px: 0, py: 0.75, verticalAlign: "top" }}>
-                    <Link
+                    <AppLink
                       href={`/file-collections/${encodeURIComponent(
                         collection.id
                       )}`}
@@ -327,7 +328,7 @@ function FileCollectionIdsRow({
                       >
                         {toDisplayValue(collection.name ?? collection.id)}
                       </Typography>
-                    </Link>
+                    </AppLink>
                     <Box
                       sx={{
                         alignItems: "center",
@@ -337,7 +338,7 @@ function FileCollectionIdsRow({
                         mt: 0.5,
                       }}
                     >
-                      <Link
+                      <AppLink
                         href={`/file-collections/${encodeURIComponent(
                           collection.id
                         )}`}
@@ -358,7 +359,7 @@ function FileCollectionIdsRow({
                         >
                           {collection.id}
                         </Typography>
-                      </Link>
+                      </AppLink>
                       <Tooltip title="Copy file collection ID">
                         <IconButton
                           aria-label={`Copy ${collection.id}`}

--- a/src/components/shared/AppLink.tsx
+++ b/src/components/shared/AppLink.tsx
@@ -1,0 +1,12 @@
+import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
+import NextLink, { LinkProps as NextLinkProps } from "next/link";
+
+export type AppLinkProps = Omit<MuiLinkProps, "href"> &
+  Pick<
+    NextLinkProps,
+    "href" | "locale" | "prefetch" | "replace" | "scroll" | "shallow"
+  >;
+
+export function AppLink(props: AppLinkProps): JSX.Element {
+  return <MuiLink component={NextLink} {...props} />;
+}

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -1,7 +1,9 @@
 /* @jsx jsx */ /** @jsxRuntime classic */ import { jsx } from "@emotion/react";
-import { Box, Button, Link } from "@mui/material";
+import { Box, Button } from "@mui/material";
 import Image from "next/image";
 import { useRouter } from "next/router";
+
+import { AppLink } from "./AppLink";
 
 export function Header(): JSX.Element {
   const router = useRouter();
@@ -22,9 +24,9 @@ export function Header(): JSX.Element {
       }}
     >
       <Box sx={{ alignItems: "center", display: "flex" }}>
-        <Link href="/" paddingRight={"16px"}>
+        <AppLink href="/" paddingRight={"16px"}>
           <Image src="/vertex-logo.svg" alt="Vertex" width="29" height="28" />
-        </Link>
+        </AppLink>
         <p>Vertex Developer Dashboard</p>
       </Box>
       <Box sx={{ ml: "auto" }}>

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -1,4 +1,4 @@
-import { Box, Breadcrumbs, Link, Paper, Typography } from "@mui/material";
+import { Box, Breadcrumbs, Paper, Typography } from "@mui/material";
 import { head } from "@vertexvis/api-client-node";
 import { GetServerSidePropsResult } from "next";
 import dynamic from "next/dynamic";
@@ -7,6 +7,7 @@ import React from "react";
 
 import { FileDetailsDrawer } from "../../components/file/FileDetailsDrawer";
 import { FileCollectionMetadataTable } from "../../components/file-collection/FileCollectionMetadataTable";
+import { AppLink } from "../../components/shared/AppLink";
 import { Layout } from "../../components/shared/Layout";
 import { isErrorFailure, toErrorRes } from "../../lib/api";
 import {
@@ -57,9 +58,9 @@ export default function FileCollectionDetails({
       main={
         <Box sx={{ p: 2 }}>
           <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2 }}>
-            <Link href="/file-collections" underline="hover">
+            <AppLink href="/file-collections" underline="hover">
               File Collections
-            </Link>
+            </AppLink>
             <Typography color="text.primary">
               {fileCollection.name ?? fileCollection.id}
             </Typography>


### PR DESCRIPTION
## Summary

- Add a shared AppLink component that combines MUI link styling with Next.js client-side navigation.
- Replace internal MUI Link usages with AppLink so route-change events fire consistently.

## Validation

- Formatted touched files with Prettier.
- Ran `next lint` successfully.
