### PR TITLE
PLAT-9004 Deep Linking

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -13,12 +13,54 @@ const collectionFilesApiPath = "/api/file-collections/collection-1/files";
 const downloadUrlById = {
   "file-1": "https://example.test/download/file-1",
 } as const;
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  isReady: true,
+  pathname: "/file-collections/[fileCollectionId]",
+  push: mockPush,
+  query: { fileCollectionId: "collection-1" } as Record<
+    string,
+    string | string[] | undefined
+  >,
+  replace: mockReplace,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+const collectionFilesPage = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "file",
+      id: "file-1",
+      attributes: {
+        name: "File One",
+        status: "complete",
+        suppliedId: "supplied-file-1",
+        created: "2026-06-12T15:30:00Z",
+        uploaded: "2026-06-12T15:31:00Z",
+      },
+    },
+  ],
+  status: 200,
+};
+
+const pagedCollectionFilesPage = {
+  ...collectionFilesPage,
+  cursors: { self: "page-1", next: "page-2" },
+};
 
 describe("FileCollectionFilesTable", () => {
   installJsdomMockServer();
 
   afterEach(() => {
     jest.restoreAllMocks();
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockRouter.query = { fileCollectionId: "collection-1" };
   });
 
   it("loads collection files while keeping row interactions", async () => {
@@ -231,6 +273,73 @@ describe("FileCollectionFilesTable", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "Error loading data."
     );
+  });
+
+  it("loads cursor paging from the URL", async () => {
+    mockRouter.query = {
+      fileCollectionId: "collection-1",
+      fileCursor: "cursor-2",
+      filePage: "2",
+      filePreviousCursors: JSON.stringify({ 0: "page-1", 1: "page-2" }),
+    };
+    const listCollectionFiles = jest.fn(() =>
+      HttpResponse.json(collectionFilesPage)
+    );
+    mockFileCollectionFilesApi({ listCollectionFiles });
+
+    renderTable();
+
+    expect(await screen.findByText("File One")).toBeInTheDocument();
+    expect(listCollectionFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          url: "http://localhost/api/file-collections/collection-1/files?pageSize=25&cursor=cursor-2",
+        }),
+      })
+    );
+  });
+
+  it("stores cursor paging state in the URL when the page changes", async () => {
+    const listCollectionFiles = jest.fn(({ request }) =>
+      HttpResponse.json(
+        request.url.includes("cursor=page-2")
+          ? collectionFilesPage
+          : pagedCollectionFilesPage
+      )
+    );
+    mockFileCollectionFilesApi({ listCollectionFiles });
+
+    renderTable();
+
+    expect(await screen.findByText("File One")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Go to next page"));
+
+    await waitFor(() => {
+      expect(listCollectionFiles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            url: "http://localhost/api/file-collections/collection-1/files?pageSize=25&cursor=page-2",
+          }),
+        })
+      );
+      expect(mockReplace).toHaveBeenCalledWith(
+        {
+          pathname: "/file-collections/[fileCollectionId]",
+          query: {
+            fileCollectionId: "collection-1",
+            fileCursor: "page-2",
+            filePage: "1",
+            filePreviousCursors: JSON.stringify({ 0: "page-1" }),
+          },
+        },
+        undefined,
+        {
+          scroll: false,
+          shallow: true,
+        }
+      );
+    });
   });
 });
 

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -530,8 +530,38 @@ describe("FileCollectionTable", () => {
       "/file-collections/collection-1"
     );
   });
+
+  it("does not select a file collection locally when cmd-clicking its link", async () => {
+    const onFileCollectionSelected = jest.fn();
+    server.use(
+      http.get("*/api/file-collections", () => {
+        return HttpResponse.json(firstPage);
+      })
+    );
+
+    renderTable({ onFileCollectionSelected });
+
+    const link = await screen.findByRole("link", {
+      name: "Open Collection One",
+    });
+    link.setAttribute("href", "#");
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(onFileCollectionSelected).not.toHaveBeenCalled();
+  });
 });
 
-function renderTable(): void {
-  renderWithSWR(<FileCollectionTable />);
+function renderTable(
+  props: React.ComponentProps<typeof FileCollectionTable> = {}
+): void {
+  renderWithSWR(<FileCollectionTable {...props} />);
 }

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -12,6 +12,20 @@ import { server } from "../../../../test/msw/server";
 import { renderWithSWR } from "../../../../test/render/renderWithSWR";
 import FileCollectionTable from "../../../components/file-collection/FileCollectionTable";
 
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  isReady: true,
+  pathname: "/file-collections",
+  push: mockPush,
+  query: {} as Record<string, string | string[] | undefined>,
+  replace: mockReplace,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
 const firstPage = fileCollectionsPage({
   data: [
     fileCollection({
@@ -59,6 +73,12 @@ const emptyCollectionPage = fileCollectionsPage({ data: [] });
 
 describe("FileCollectionTable", () => {
   installJsdomMockServer();
+
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockRouter.query = {};
+  });
 
   it("paginates file collections using the next cursor", async () => {
     const requests: string[] = [];

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -8,10 +8,18 @@ import { server } from "../../../../test/msw/server";
 import { renderWithSWR } from "../../../../test/render/renderWithSWR";
 import FileTable from "../../../components/file/FileTable";
 
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  isReady: true,
+  pathname: "/files",
+  push: mockPush,
+  query: {} as Record<string, string | string[] | undefined>,
+  replace: mockReplace,
+};
+
 jest.mock("next/router", () => ({
-  useRouter: () => ({
-    push: jest.fn(),
-  }),
+  useRouter: () => mockRouter,
 }));
 
 const page = {
@@ -47,6 +55,9 @@ describe("FileTable", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockRouter.query = {};
   });
 
   it("loads files sorted by created descending by default", async () => {
@@ -142,6 +153,74 @@ describe("FileTable", () => {
 
     resolveSortedPage?.();
     expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+  });
+
+  it("loads filters, sort, and cursor paging from the URL", async () => {
+    const requests: string[] = [];
+    mockRouter.query = {
+      fileCursor: "cursor-2",
+      fileFilterId: "file-filter",
+      fileName: "alpha",
+      filePage: "2",
+      filePreviousCursors: JSON.stringify({ 0: "page-1", 1: "page-2" }),
+      fileSort: "name",
+      fileSuppliedId: "supplied-1",
+    };
+
+    server.use(
+      http.get("*/api/files", ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("alpha");
+    expect(screen.getByLabelText("File ID")).toHaveValue("file-filter");
+    expect(screen.getByLabelText("Supplied ID")).toHaveValue("supplied-1");
+    const request = new URL(requests[0]);
+    expect(request.searchParams.get("pageSize")).toBe("25");
+    expect(request.searchParams.get("cursor")).toBe("cursor-2");
+    expect(request.searchParams.get("sort")).toBe("name");
+    expect(request.searchParams.get("fileId")).toBe("file-filter");
+    expect(request.searchParams.get("name")).toBe("alpha");
+    expect(request.searchParams.get("suppliedId")).toBe("supplied-1");
+  });
+
+  it("stores cursor paging state in the URL when the page changes", async () => {
+    server.use(
+      http.get("*/api/files", ({ request }) =>
+        HttpResponse.json(
+          request.url.includes("cursor=page-2") ? page : pagedPage
+        )
+      )
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Go to next page"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        {
+          pathname: "/files",
+          query: {
+            fileCursor: "page-2",
+            filePage: "1",
+            filePreviousCursors: JSON.stringify({ 0: "page-1" }),
+          },
+        },
+        undefined,
+        {
+          scroll: false,
+          shallow: true,
+        }
+      );
+    });
   });
 
   it("preserves the selected local created dates in the inline filters", async () => {

--- a/src/__tests__/components/part/PartRow.test.tsx
+++ b/src/__tests__/components/part/PartRow.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import PartRow from "../../../components/part/PartRow";
+
+const part = {
+  id: "part-1",
+  created: "2026-06-10T15:30:00Z",
+  name: "Part One",
+  suppliedId: "supplied-part-1",
+};
+
+const revisionsPage = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "part-revision",
+      id: "revision-1",
+      attributes: {
+        created: "2026-06-11T15:30:00Z",
+        name: "Revision One",
+        suppliedId: "supplied-revision-1",
+        suppliedIterationId: "iteration-1",
+      },
+    },
+  ],
+  status: 200,
+};
+
+describe("PartRow", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("opens the active part and selects revisions with their parent part ID", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve(revisionsPage),
+    }) as unknown as typeof fetch;
+    const onRevisionSelected = jest.fn();
+
+    renderPartRow({
+      activePartId: "part-1",
+      activeRevisionId: "revision-1",
+      onRevisionSelected,
+    });
+
+    expect(await screen.findByText("Revision One")).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/part-revisions?partId=part-1"
+    );
+
+    await userEvent.click(screen.getByText("Revision One"));
+
+    expect(onRevisionSelected).toHaveBeenCalledWith(
+      {
+        created: "2026-06-11T15:30:00Z",
+        id: "revision-1",
+        name: "Revision One",
+        suppliedId: "supplied-revision-1",
+        suppliedIterationId: "iteration-1",
+      },
+      "part-1"
+    );
+  });
+
+  it("keeps part checkbox selection separate from revision selection", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve(revisionsPage),
+    }) as unknown as typeof fetch;
+    const onSelected = jest.fn();
+    const onRevisionSelected = jest.fn();
+
+    renderPartRow({
+      onRevisionSelected,
+      onSelected,
+    });
+
+    await userEvent.click(screen.getByLabelText("Select Part One"));
+
+    expect(onSelected).toHaveBeenCalledWith("part-1");
+    expect(onRevisionSelected).not.toHaveBeenCalled();
+  });
+});
+
+function renderPartRow(
+  props: Partial<React.ComponentProps<typeof PartRow>> = {}
+): void {
+  render(
+    <table>
+      <tbody>
+        <PartRow
+          isSelected={false}
+          onCreteSceneFromRevision={jest.fn()}
+          onRevisionSelected={jest.fn()}
+          onSelected={jest.fn()}
+          part={part}
+          {...props}
+        />
+      </tbody>
+    </table>
+  );
+}

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -10,9 +10,17 @@ import SceneTable from "../../../components/scene/SceneTable";
 import { Scene } from "../../../lib/scenes";
 
 const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  isReady: true,
+  pathname: "/",
+  push: mockPush,
+  query: {} as Record<string, string | string[] | undefined>,
+  replace: mockReplace,
+};
 
 jest.mock("next/router", () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => mockRouter,
 }));
 
 const scene: Scene = {
@@ -58,12 +66,48 @@ const page = {
   status: 200,
 };
 
+const firstPage = {
+  cursors: { self: "scene-page-1", next: "scene-page-2" },
+  data: [
+    {
+      type: "scene",
+      id: "scene-1",
+      attributes: {
+        created: "2026-06-10T15:30:00Z",
+        name: "Scene One",
+        state: "ready",
+        suppliedId: "supplied-1",
+      },
+    },
+  ],
+  status: 200,
+};
+
+const secondPage = {
+  cursors: { self: "scene-page-2" },
+  data: [
+    {
+      type: "scene",
+      id: "scene-2",
+      attributes: {
+        created: "2026-06-11T15:30:00Z",
+        name: "Scene Two",
+        state: "ready",
+        suppliedId: "supplied-2",
+      },
+    },
+  ],
+  status: 200,
+};
+
 describe("SceneTable", () => {
   installJsdomMockServer();
 
   afterEach(() => {
     jest.restoreAllMocks();
     mockPush.mockClear();
+    mockReplace.mockClear();
+    mockRouter.query = {};
   });
 
   it("preserves the active scene highlight after the drawer scene clears", async () => {
@@ -78,9 +122,7 @@ describe("SceneTable", () => {
     await waitFor(() => {
       expect(getSceneRow()).toHaveClass("Mui-selected");
     });
-
     rerender(renderTableElement(undefined));
-
     await waitFor(() => {
       expect(getSceneRow()).toHaveClass("Mui-selected");
     });
@@ -92,15 +134,12 @@ describe("SceneTable", () => {
         return HttpResponse.json(page);
       })
     );
-
     renderTable(scene);
 
     await waitFor(() => {
       expect(getSceneRow("Scene One")).toHaveClass("Mui-selected");
     });
-
     await userEvent.click(getSceneRow("Scene Two"));
-
     await waitFor(() => {
       expect(getSceneRow("Scene Two")).toHaveClass("Mui-selected");
     });

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -66,40 +66,6 @@ const page = {
   status: 200,
 };
 
-const firstPage = {
-  cursors: { self: "scene-page-1", next: "scene-page-2" },
-  data: [
-    {
-      type: "scene",
-      id: "scene-1",
-      attributes: {
-        created: "2026-06-10T15:30:00Z",
-        name: "Scene One",
-        state: "ready",
-        suppliedId: "supplied-1",
-      },
-    },
-  ],
-  status: 200,
-};
-
-const secondPage = {
-  cursors: { self: "scene-page-2" },
-  data: [
-    {
-      type: "scene",
-      id: "scene-2",
-      attributes: {
-        created: "2026-06-11T15:30:00Z",
-        name: "Scene Two",
-        state: "ready",
-        suppliedId: "supplied-2",
-      },
-    },
-  ],
-  status: 200,
-};
-
 describe("SceneTable", () => {
   installJsdomMockServer();
 

--- a/src/__tests__/components/shared/AppLink.test.tsx
+++ b/src/__tests__/components/shared/AppLink.test.tsx
@@ -127,4 +127,34 @@ describe("ResourceLink", () => {
     expect(defaultAllowed).toBe(true);
     expect(onPrimaryAction).not.toHaveBeenCalled();
   });
+
+  it("does not bubble browser-handled clicks to row handlers", () => {
+    const onPrimaryAction = jest.fn();
+    const onRowClick = jest.fn();
+    render(
+      <div onClick={onRowClick}>
+        <ResourceLink
+          href="#"
+          onPrimaryAction={onPrimaryAction}
+          primaryActionLabel="Open file collection"
+        >
+          Collection One
+        </ResourceLink>
+      </div>
+    );
+
+    const link = screen.getByRole("link", { name: "Open file collection" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(onPrimaryAction).not.toHaveBeenCalled();
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/components/shared/AppLink.test.tsx
+++ b/src/__tests__/components/shared/AppLink.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { AppLink } from "../../../components/shared/AppLink";
+import { ResourceLink } from "../../../components/shared/ResourceLink";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  push: mockPush,
+  replace: mockReplace,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+describe("AppLink", () => {
+  afterEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+  });
+
+  it("uses app navigation for a plain left click", () => {
+    render(<AppLink href="/files">Files</AppLink>);
+
+    const link = screen.getByRole("link", { name: "Files" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(false);
+    expect(mockPush).toHaveBeenCalledWith("/files", undefined, {
+      locale: undefined,
+      scroll: undefined,
+      shallow: undefined,
+    });
+  });
+
+  it("allows the browser to handle cmd-click", () => {
+    render(<AppLink href="/files">Files</AppLink>);
+
+    const link = screen.getByRole("link", { name: "Files" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("allows the browser to handle ctrl-click", () => {
+    render(<AppLink href="/files">Files</AppLink>);
+
+    const link = screen.getByRole("link", { name: "Files" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        ctrlKey: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+describe("ResourceLink", () => {
+  it("uses the primary action for a plain left click", () => {
+    const onPrimaryAction = jest.fn();
+    render(
+      <ResourceLink
+        href="/files?fileId=file-1"
+        onPrimaryAction={onPrimaryAction}
+        primaryActionLabel="Open file"
+      >
+        File One
+      </ResourceLink>
+    );
+
+    const link = screen.getByRole("link", { name: "Open file" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(false);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the browser to handle cmd-click", () => {
+    const onPrimaryAction = jest.fn();
+    render(
+      <ResourceLink
+        href="/files?fileId=file-1"
+        onPrimaryAction={onPrimaryAction}
+        primaryActionLabel="Open file"
+      >
+        File One
+      </ResourceLink>
+    );
+
+    const link = screen.getByRole("link", { name: "Open file" });
+    const defaultAllowed = link.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+
+    expect(defaultAllowed).toBe(true);
+    expect(onPrimaryAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/lib/url-state.test.ts
+++ b/src/__tests__/lib/url-state.test.ts
@@ -1,0 +1,60 @@
+import { NextRouter } from "next/router";
+
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
+
+describe("url-state", () => {
+  it("reads the first value from a Next query param", () => {
+    expect(queryParamValue("file-1")).toBe("file-1");
+    expect(queryParamValue(["file-1", "file-2"])).toBe("file-1");
+    expect(queryParamValue(undefined)).toBeUndefined();
+  });
+
+  it("updates query params while preserving the rest of the URL state", async () => {
+    const push = jest.fn().mockResolvedValue(true);
+    const replace = jest.fn().mockResolvedValue(true);
+    const router = {
+      pathname: "/file-collections/[fileCollectionId]",
+      push,
+      query: {
+        fileCollectionId: "collection-1",
+        page: "2",
+      },
+      replace,
+    } as unknown as NextRouter;
+
+    await updateRouterQuery(router, { fileId: "file-1" });
+
+    expect(push).toHaveBeenCalledWith(
+      {
+        pathname: "/file-collections/[fileCollectionId]",
+        query: {
+          fileCollectionId: "collection-1",
+          fileId: "file-1",
+          page: "2",
+        },
+      },
+      undefined,
+      {
+        scroll: false,
+        shallow: true,
+      }
+    );
+
+    await updateRouterQuery(router, { fileId: undefined }, "replace");
+
+    expect(replace).toHaveBeenCalledWith(
+      {
+        pathname: "/file-collections/[fileCollectionId]",
+        query: {
+          fileCollectionId: "collection-1",
+          page: "2",
+        },
+      },
+      undefined,
+      {
+        scroll: false,
+        shallow: true,
+      }
+    );
+  });
+});

--- a/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
+++ b/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
@@ -22,6 +22,15 @@ import FileCollectionDetails, {
 const mockGetClientFromSession = jest.fn();
 const mockGetFileCollectionsApi = jest.fn();
 const mockGetFileCollection = jest.fn();
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockRouter = {
+  isReady: true,
+  pathname: "/file-collections/[fileCollectionId]",
+  push: mockPush,
+  query: { fileCollectionId: "collection-1" },
+  replace: mockReplace,
+};
 const mockFileCollectionFilesTable = jest.fn(
   ({ apiPath }: { readonly apiPath: string }) => (
     <div data-api-path={apiPath} data-testid="file-collection-files-table">
@@ -33,6 +42,10 @@ const originalFetch = global.fetch;
 
 jest.mock("../../../components/shared/Layout", () => ({
   Layout: ({ main }: { readonly main: unknown }) => main,
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
 }));
 
 jest.mock(
@@ -67,6 +80,9 @@ describe("FileCollectionDetails", () => {
         status: 200,
       })
     );
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockRouter.query = { fileCollectionId: "collection-1" };
     mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
     mockGetFileCollectionsApi.mockReturnValue({
       getFileCollection: mockGetFileCollection,

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -11,6 +11,7 @@ import {
   TablePagination,
   TableRow,
 } from "@mui/material";
+import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
@@ -23,7 +24,14 @@ import {
   normalizeFileStatus,
   toFilePage,
 } from "../../lib/files";
-import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import {
+  buildQuery,
+  cursorPagingStateFromQuery,
+  cursorPagingStateToQuery,
+  SwrProps,
+  useCursorPagingState,
+} from "../../lib/paging";
+import { updateRouterQuery } from "../../lib/url-state";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
@@ -51,6 +59,8 @@ const headCells = [
   { id: "uploaded", label: "Uploaded" },
   { id: "actions", label: "Actions" },
 ] as const;
+
+const UrlStatePrefix = "file";
 
 function useCollectionFiles({
   apiPath,
@@ -94,10 +104,22 @@ export default function FileCollectionFilesTable({
   apiPath,
   onFileSelected,
 }: Props): JSX.Element {
+  const router = useRouter();
+  const routerReady = router.isReady !== false;
   const pageSize = DefaultPageSize;
-  const { currentPage, cursor, cursors, handlePageChange, setCursors } =
-    useCursorPagingState();
+  const {
+    currentPage,
+    cursor,
+    cursors,
+    getPageStateForChange,
+    handlePageChange,
+    setCursors,
+    setPagingState,
+  } = useCursorPagingState(
+    cursorPagingStateFromQuery(router.query, UrlStatePrefix)
+  );
   const [downloadError, setDownloadError] = React.useState<string>();
+  const initializedFromQuery = React.useRef(false);
 
   const { data, error } = useCollectionFiles({
     apiPath,
@@ -119,11 +141,26 @@ export default function FileCollectionFilesTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
+  React.useEffect(() => {
+    if (!routerReady || initializedFromQuery.current) return;
+
+    initializedFromQuery.current = true;
+    setPagingState(cursorPagingStateFromQuery(router.query, UrlStatePrefix));
+  }, [router.query, routerReady, setPagingState]);
+
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
+    const nextPagingState = getPageStateForChange(num);
     handlePageChange(num);
+    if (routerReady) {
+      updateRouterQuery(
+        router,
+        cursorPagingStateToQuery(UrlStatePrefix, nextPagingState),
+        "replace"
+      );
+    }
   }
 
   async function handleDownload(id: string) {

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -65,6 +65,33 @@ interface UseFileCollectionsProps extends SwrProps {
 
 type FileCollectionSortField = "created" | "name";
 
+function isFileCollectionSortField(
+  field: string
+): field is FileCollectionSortField {
+  return field === "created" || field === "name";
+}
+
+function toFileCollectionSortState(
+  value?: string
+): SortState<FileCollectionSortField> | undefined {
+  switch (value) {
+    case "name":
+      return { field: "name", order: "asc" };
+    case "-name":
+      return { field: "name", order: "desc" };
+    case "created":
+      return { field: "created", order: "asc" };
+    case "-created":
+      return { field: "created", order: "desc" };
+    default:
+      return undefined;
+  }
+}
+
+function fileCollectionPath(fileCollectionId: string): string {
+  return `/file-collections/${encodeURIComponent(fileCollectionId)}`;
+}
+
 function useFileCollections({
   createdAtEnd,
   createdAtStart,
@@ -114,7 +141,9 @@ export default function FileCollectionTable({
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [sort, setSort] = React.useState<
     SortState<FileCollectionSortField> | undefined
-  >();
+  >(() =>
+    toFileCollectionSortState(queryParamValue(router.query.fileCollectionSort))
+  );
   const [name, setName] = React.useState<string | undefined>(() =>
     queryParamValue(router.query.fileCollectionName)
   );
@@ -208,6 +237,11 @@ export default function FileCollectionTable({
     if (!routerReady || initializedFromQuery.current) return;
 
     initializedFromQuery.current = true;
+    setSort(
+      toFileCollectionSortState(
+        queryParamValue(router.query.fileCollectionSort)
+      )
+    );
     const nextName = queryParamValue(router.query.fileCollectionName);
     const nextSuppliedId = queryParamValue(
       router.query.fileCollectionSuppliedId
@@ -257,11 +291,17 @@ export default function FileCollectionTable({
   }
 
   function handleSortChange(field: string) {
-    if (field !== "created" && field !== "name") return;
+    if (!isFileCollectionSortField(field)) return;
 
-    setSort((current) =>
-      current == null ? { field, order: "asc" } : toggleSort(current, field)
-    );
+    setSort((current) => {
+      const nextSort: SortState<FileCollectionSortField> =
+        current == null ? { field, order: "asc" } : toggleSort(current, field);
+      updateFileCollectionTableQuery({
+        fileCollectionSort: toSortParam(nextSort),
+        ...clearPagingQuery(),
+      });
+      return nextSort;
+    });
     resetPaging();
   }
 
@@ -314,6 +354,10 @@ export default function FileCollectionTable({
     mutate();
   }
 
+  function handleOpenFileCollection(fileCollectionId: string) {
+    router.push(fileCollectionPath(fileCollectionId));
+  }
+
   let tableRows: React.ReactNode;
   if (error) {
     tableRows = <DataLoadError colSpan={headCells.length + 1} />;
@@ -358,7 +402,8 @@ export default function FileCollectionTable({
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
-              href={`/file-collections/${encodeURIComponent(row.id)}`}
+              href={fileCollectionPath(row.id)}
+              onPrimaryAction={() => handleOpenFileCollection(row.id)}
               primaryActionLabel={`Open ${row.name}`}
             >
               {row.name}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -17,7 +17,11 @@ import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
-import { toLocaleString, toLocalDayBoundaryIso } from "../../lib/dates";
+import {
+  toLocalDateInputValue,
+  toLocaleString,
+  toLocalDayBoundaryIso,
+} from "../../lib/dates";
 import {
   FileCollection,
   toFileCollectionPage,
@@ -239,8 +243,8 @@ export default function FileCollectionTable({
 
   function handleCreatedAtChange(filters: CreatedAtDateRange) {
     resetPaging();
-    const createdAtStartDate = filters.createdAtStart?.slice(0, 10) ?? "";
-    const createdAtEndDate = filters.createdAtEnd?.slice(0, 10) ?? "";
+    const createdAtStartDate = toLocalDateInputValue(filters.createdAtStart);
+    const createdAtEndDate = toLocalDateInputValue(filters.createdAtEnd);
     setCreatedAtStart(filters.createdAtStart);
     setCreatedAtStartDate(createdAtStartDate);
     setCreatedAtEnd(filters.createdAtEnd);
@@ -487,5 +491,3 @@ export default function FileCollectionTable({
     </>
   );
 }
-    setName(nextName);
-    setNameInput(nextName ?? "");

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -19,8 +19,8 @@ import useSWR from "swr";
 
 import {
   toLocalDateInputValue,
-  toLocaleString,
   toLocalDayBoundaryIso,
+  toLocaleString,
 } from "../../lib/dates";
 import {
   FileCollection,

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -13,16 +13,24 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
+import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
-import { toLocaleString } from "../../lib/dates";
+import { toLocaleString, toLocalDayBoundaryIso } from "../../lib/dates";
 import {
   FileCollection,
   toFileCollectionPage,
 } from "../../lib/file-collections";
-import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import {
+  buildQuery,
+  cursorPagingStateFromQuery,
+  cursorPagingStateToQuery,
+  SwrProps,
+  useCursorPagingState,
+} from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import {
   CreatedAtDateRange,
   CreatedAtDateRangeFilter,
@@ -42,10 +50,13 @@ export const headCells: readonly HeadCell[] = [
   { id: "created", label: "Created At", sortable: true },
 ];
 
+const UrlStatePrefix = "fileCollection";
+
 interface UseFileCollectionsProps extends SwrProps {
   readonly createdAtEnd?: string;
   readonly createdAtStart?: string;
   readonly sort?: SortState<FileCollectionSortField>;
+  readonly name?: string;
 }
 
 type FileCollectionSortField = "created" | "name";
@@ -81,28 +92,61 @@ export default function FileCollectionTable({
   activeFileCollectionId,
   onFileCollectionSelected,
 }: Props): JSX.Element {
+  const router = useRouter();
+  const routerReady = router.isReady !== false;
   const pageSize = DefaultPageSize;
   const {
     currentPage,
     cursor,
     cursors,
+    getPageStateForChange,
     handlePageChange,
     resetPaging,
     setCursors,
-  } = useCursorPagingState();
+    setPagingState,
+  } = useCursorPagingState(
+    cursorPagingStateFromQuery(router.query, UrlStatePrefix)
+  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
-  const [name, setName] = React.useState<string | undefined>();
   const [sort, setSort] = React.useState<
     SortState<FileCollectionSortField> | undefined
   >();
-  const [suppliedId, setSuppliedId] = React.useState<string | undefined>();
-  const [createdAtFilters, setCreatedAtFilters] =
-    React.useState<CreatedAtDateRange>({});
+  const [name, setName] = React.useState<string | undefined>(() =>
+    queryParamValue(router.query.fileCollectionName)
+  );
+  const [nameInput, setNameInput] = React.useState(
+    () => queryParamValue(router.query.fileCollectionName) ?? ""
+  );
+  const [suppliedId, setSuppliedId] = React.useState<string | undefined>(() =>
+    queryParamValue(router.query.fileCollectionSuppliedId)
+  );
+  const [suppliedIdInput, setSuppliedIdInput] = React.useState(
+    () => queryParamValue(router.query.fileCollectionSuppliedId) ?? ""
+  );
+  const [createdAtStartDate, setCreatedAtStartDate] = React.useState(
+    () => queryParamValue(router.query.fileCollectionCreatedAtStart) ?? ""
+  );
+  const [createdAtEndDate, setCreatedAtEndDate] = React.useState(
+    () => queryParamValue(router.query.fileCollectionCreatedAtEnd) ?? ""
+  );
+  const [createdAtStart, setCreatedAtStart] = React.useState<
+    string | undefined
+  >(() => {
+    const value = queryParamValue(router.query.fileCollectionCreatedAtStart);
+    return value != null ? toLocalDayBoundaryIso(value, "start") : undefined;
+  });
+  const [createdAtEnd, setCreatedAtEnd] = React.useState<string | undefined>(
+    () => {
+      const value = queryParamValue(router.query.fileCollectionCreatedAtEnd);
+      return value != null ? toLocalDayBoundaryIso(value, "end") : undefined;
+    }
+  );
   const [deleteError, setDeleteError] = React.useState<string>();
+  const initializedFromQuery = React.useRef(false);
 
   const { data, error, mutate } = useFileCollections({
-    createdAtEnd: createdAtFilters.createdAtEnd,
-    createdAtStart: createdAtFilters.createdAtStart,
+    createdAtEnd,
+    createdAtStart,
     cursor,
     name,
     pageSize,
@@ -114,23 +158,78 @@ export default function FileCollectionTable({
   const emptyRows =
     cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
 
+  const updateFileCollectionTableQuery = React.useCallback(
+    (updates: Record<string, string | undefined>) => {
+      if (!routerReady) return;
+
+      updateRouterQuery(router, updates, "replace");
+    },
+    [router, routerReady]
+  );
+
+  const clearPagingQuery = React.useCallback(
+    () => cursorPagingStateToQuery(UrlStatePrefix),
+    []
+  );
+
   const debouncedSetNameFilter = React.useMemo(
     () =>
       debounce((value: string) => {
+        const nextValue = value === "" ? undefined : value;
         resetPaging();
-        setName(value === "" ? undefined : value);
+        setName(nextValue);
+        updateFileCollectionTableQuery({
+          fileCollectionName: nextValue,
+          ...clearPagingQuery(),
+        });
       }, 300),
-    [resetPaging]
+    [clearPagingQuery, resetPaging, updateFileCollectionTableQuery]
   );
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
     () =>
       debounce((value: string) => {
+        const nextValue = value === "" ? undefined : value;
         resetPaging();
-        setSuppliedId(value === "" ? undefined : value);
+        setSuppliedId(nextValue);
+        updateFileCollectionTableQuery({
+          fileCollectionSuppliedId: nextValue,
+          ...clearPagingQuery(),
+        });
       }, 300),
-    [resetPaging]
+    [clearPagingQuery, resetPaging, updateFileCollectionTableQuery]
   );
+
+  React.useEffect(() => {
+    if (!routerReady || initializedFromQuery.current) return;
+
+    initializedFromQuery.current = true;
+    const nextName = queryParamValue(router.query.fileCollectionName);
+    const nextSuppliedId = queryParamValue(
+      router.query.fileCollectionSuppliedId
+    );
+    setName(nextName);
+    setNameInput(nextName ?? "");
+    setSuppliedId(nextSuppliedId);
+    setSuppliedIdInput(nextSuppliedId ?? "");
+    const nextCreatedAtStart =
+      queryParamValue(router.query.fileCollectionCreatedAtStart) ?? "";
+    const nextCreatedAtEnd =
+      queryParamValue(router.query.fileCollectionCreatedAtEnd) ?? "";
+    setCreatedAtStartDate(nextCreatedAtStart);
+    setCreatedAtEndDate(nextCreatedAtEnd);
+    setCreatedAtStart(
+      nextCreatedAtStart !== ""
+        ? toLocalDayBoundaryIso(nextCreatedAtStart, "start")
+        : undefined
+    );
+    setCreatedAtEnd(
+      nextCreatedAtEnd !== ""
+        ? toLocalDayBoundaryIso(nextCreatedAtEnd, "end")
+        : undefined
+    );
+    setPagingState(cursorPagingStateFromQuery(router.query, UrlStatePrefix));
+  }, [router.query, routerReady, setPagingState]);
 
   React.useEffect(() => {
     if (page == null) return;
@@ -140,7 +239,17 @@ export default function FileCollectionTable({
 
   function handleCreatedAtChange(filters: CreatedAtDateRange) {
     resetPaging();
-    setCreatedAtFilters(filters);
+    const createdAtStartDate = filters.createdAtStart?.slice(0, 10) ?? "";
+    const createdAtEndDate = filters.createdAtEnd?.slice(0, 10) ?? "";
+    setCreatedAtStart(filters.createdAtStart);
+    setCreatedAtStartDate(createdAtStartDate);
+    setCreatedAtEnd(filters.createdAtEnd);
+    setCreatedAtEndDate(createdAtEndDate);
+    updateFileCollectionTableQuery({
+      fileCollectionCreatedAtEnd: createdAtEndDate || undefined,
+      fileCollectionCreatedAtStart: createdAtStartDate || undefined,
+      ...clearPagingQuery(),
+    });
   }
 
   function handleSortChange(field: string) {
@@ -172,7 +281,11 @@ export default function FileCollectionTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
+    const nextPagingState = getPageStateForChange(num);
     handlePageChange(num);
+    updateFileCollectionTableQuery(
+      cursorPagingStateToQuery(UrlStatePrefix, nextPagingState)
+    );
   }
 
   async function handleDelete() {
@@ -281,8 +394,11 @@ export default function FileCollectionTable({
               id="nameFilter"
               label="Name"
               type="text"
+              value={nameInput}
               onChange={(e) => {
-                debouncedSetNameFilter(e.target.value?.trim() ?? "");
+                const value = e.target.value ?? "";
+                setNameInput(value);
+                debouncedSetNameFilter(value.trim());
               }}
               sx={{ mt: 0, width: "16rem" }}
             />
@@ -293,14 +409,23 @@ export default function FileCollectionTable({
               id="suppliedIdFilter"
               label="Supplied ID"
               type="text"
+              value={suppliedIdInput}
               onChange={(e) => {
-                debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? "");
+                const value = e.target.value ?? "";
+                setSuppliedIdInput(value);
+                debouncedSetSuppliedIdFilter(value.trim());
               }}
               sx={{ mt: 0, width: "16rem" }}
             />
           </Box>
         </Box>
-        <CreatedAtDateRangeFilter onChange={handleCreatedAtChange} />
+        <CreatedAtDateRangeFilter
+          onChange={handleCreatedAtChange}
+          value={{
+            createdAtEnd: createdAtEndDate,
+            createdAtStart: createdAtStartDate,
+          }}
+        />
         <TableContainer>
           <Table>
             <TableHead
@@ -362,3 +487,5 @@ export default function FileCollectionTable({
     </>
   );
 }
+    setName(nextName);
+    setNameInput(nextName ?? "");

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -16,6 +16,7 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
+import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
@@ -28,13 +29,20 @@ import {
   normalizeFileStatus,
   toFilePage,
 } from "../../lib/files";
-import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import {
+  buildQuery,
+  cursorPagingStateFromQuery,
+  cursorPagingStateToQuery,
+  SwrProps,
+  useCursorPagingState,
+} from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import {
   CreatedAtDateRange,
   CreatedAtDateRangeFilter,
 } from "../shared/CreatedAtDateRangeFilter";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { ResourceLink } from "../shared/ResourceLink";
@@ -53,6 +61,9 @@ export const headCells: readonly HeadCell[] = [
   { id: "uploaded", label: "Uploaded" },
   { id: "actions", label: "Actions" },
 ];
+
+const UrlStatePrefix = "file";
+const DefaultSort: SortState = { field: "created", order: "desc" };
 
 interface UseFilesProps extends SwrProps {
   readonly createdAtEnd?: string;
@@ -119,17 +130,47 @@ interface Props {
 type SetOptionalString = React.Dispatch<
   React.SetStateAction<string | undefined>
 >;
+type DateBoundary = "start" | "end";
+
+function toLocalDayIso(value: string, boundary: DateBoundary): string {
+  const [year, month, day] = value.split("-").map(Number);
+  const date =
+    boundary === "start"
+      ? new Date(year, month - 1, day, 0, 0, 0, 0)
+      : new Date(year, month - 1, day, 23, 59, 59, 999);
+
+  return date.toISOString();
+}
+
+function toSortState(value?: string): SortState {
+  switch (value) {
+    case "name":
+      return { field: "name", order: "asc" };
+    case "-name":
+      return { field: "name", order: "desc" };
+    case "created":
+      return { field: "created", order: "asc" };
+    case "-created":
+      return { field: "created", order: "desc" };
+    default:
+      return DefaultSort;
+  }
+}
+
 function useDebouncedFilter(
   setFilter: SetOptionalString,
-  resetPaging: () => void
+  resetPaging: () => void,
+  onFilterChanged: (value: string | undefined) => void
 ): (value: string) => void {
   return React.useMemo(
     () =>
       debounce((value: string) => {
+        const nextValue = value === "" ? undefined : value;
         resetPaging();
-        setFilter(value === "" ? undefined : value);
+        setFilter(nextValue);
+        onFilterChanged(nextValue);
       }, 300),
-    [resetPaging, setFilter]
+    [onFilterChanged, resetPaging, setFilter]
   );
 }
 
@@ -137,34 +178,69 @@ export default function FileTable({
   activeFileId,
   onFileSelected,
 }: Props): JSX.Element {
+  const router = useRouter();
+  const routerReady = router.isReady !== false;
   const pageSize = DefaultPageSize;
-  const [sort, setSort] = React.useState<SortState>({
-    field: "created",
-    order: "desc",
-  });
+  const [sort, setSort] = React.useState<SortState>(() =>
+    toSortState(queryParamValue(router.query.fileSort))
+  );
   const {
     currentPage,
     cursor,
     cursors,
+    getPageStateForChange,
     handlePageChange,
     resetPaging,
     setCursors,
-  } = useCursorPagingState();
+    setPagingState,
+  } = useCursorPagingState(
+    cursorPagingStateFromQuery(router.query, UrlStatePrefix)
+  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
-  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
-  const [fileIdFilter, setFileIdFilter] = React.useState<string | undefined>();
-  const [suppliedIdFilter, setSuppliedIdFilter] = React.useState<
+  const [nameFilter, setNameFilter] = React.useState<string | undefined>(() =>
+    queryParamValue(router.query.fileName)
+  );
+  const [nameInput, setNameInput] = React.useState(
+    () => queryParamValue(router.query.fileName) ?? ""
+  );
+  const [fileIdFilter, setFileIdFilter] = React.useState<string | undefined>(() =>
+    queryParamValue(router.query.fileFilterId)
+  );
+  const [fileIdInput, setFileIdInput] = React.useState(
+    () => queryParamValue(router.query.fileFilterId) ?? ""
+  );
+  const [suppliedIdFilter, setSuppliedIdFilter] = React.useState<string | undefined>(
+    () => queryParamValue(router.query.fileSuppliedId)
+  );
+  const [suppliedIdInput, setSuppliedIdInput] = React.useState(
+    () => queryParamValue(router.query.fileSuppliedId) ?? ""
+  );
+  const [createdAtStartDate, setCreatedAtStartDate] = React.useState(
+    () => queryParamValue(router.query.fileCreatedAtStart) ?? ""
+  );
+  const [createdAtEndDate, setCreatedAtEndDate] = React.useState(
+    () => queryParamValue(router.query.fileCreatedAtEnd) ?? ""
+  );
+  const [createdAtStart, setCreatedAtStart] = React.useState<
     string | undefined
-  >();
-  const [createdAtFilters, setCreatedAtFilters] =
-    React.useState<CreatedAtDateRange>({});
+  >(() => {
+    const value = queryParamValue(router.query.fileCreatedAtStart);
+    return value != null ? toLocalDayIso(value, "start") : undefined;
+  });
+  const [createdAtEnd, setCreatedAtEnd] = React.useState<string | undefined>(
+    () => {
+      const value = queryParamValue(router.query.fileCreatedAtEnd);
+      return value != null ? toLocalDayIso(value, "end") : undefined;
+    }
+  );
   const [showToast, setShowToast] = React.useState(false);
   const [downloadError, setDownloadError] = React.useState<string>();
+  const initializedFromQuery = React.useRef(false);
 
   const { data, error, mutate } = useFiles({
-    createdAtEnd: createdAtFilters.createdAtEnd,
-    createdAtStart: createdAtFilters.createdAtStart,
+    createdAtEnd,
+    createdAtStart,
     cursor,
     fileId: fileIdFilter,
     name: nameFilter,
@@ -182,15 +258,81 @@ export default function FileTable({
       ? 0
       : pageSize - pageLength;
 
-  const debouncedSetNameFilter = useDebouncedFilter(setNameFilter, resetPaging);
+  const updateFileTableQuery = React.useCallback(
+    (updates: Record<string, string | undefined>) => {
+      if (!routerReady) return;
+
+      updateRouterQuery(router, updates, "replace");
+    },
+    [router, routerReady]
+  );
+
+  const clearPagingQuery = React.useCallback(
+    () => cursorPagingStateToQuery(UrlStatePrefix),
+    []
+  );
+
+  const debouncedSetNameFilter = useDebouncedFilter(
+    setNameFilter,
+    resetPaging,
+    (value) =>
+      updateFileTableQuery({
+        fileName: value,
+        ...clearPagingQuery(),
+      })
+  );
   const debouncedSetFileIdFilter = useDebouncedFilter(
     setFileIdFilter,
-    resetPaging
+    resetPaging,
+    (value) =>
+      updateFileTableQuery({
+        fileFilterId: value,
+        ...clearPagingQuery(),
+      })
   );
   const debouncedSetSuppliedIdFilter = useDebouncedFilter(
     setSuppliedIdFilter,
-    resetPaging
+    resetPaging,
+    (value) =>
+      updateFileTableQuery({
+        fileSuppliedId: value,
+        ...clearPagingQuery(),
+      })
   );
+
+  React.useEffect(() => {
+    if (!routerReady || initializedFromQuery.current) return;
+
+    initializedFromQuery.current = true;
+    setSort(toSortState(queryParamValue(router.query.fileSort)));
+    const nextName = queryParamValue(router.query.fileName);
+    const nextFileId = queryParamValue(router.query.fileFilterId);
+    const nextSuppliedId = queryParamValue(router.query.fileSuppliedId);
+    setNameFilter(nextName);
+    setNameInput(nextName ?? "");
+    setFileIdFilter(nextFileId);
+    setFileIdInput(nextFileId ?? "");
+    setSuppliedIdFilter(nextSuppliedId);
+    setSuppliedIdInput(nextSuppliedId ?? "");
+
+    const nextCreatedAtStart =
+      queryParamValue(router.query.fileCreatedAtStart) ?? "";
+    const nextCreatedAtEnd =
+      queryParamValue(router.query.fileCreatedAtEnd) ?? "";
+    setCreatedAtStartDate(nextCreatedAtStart);
+    setCreatedAtEndDate(nextCreatedAtEnd);
+    setCreatedAtStart(
+      nextCreatedAtStart !== ""
+        ? toLocalDayIso(nextCreatedAtStart, "start")
+        : undefined
+    );
+    setCreatedAtEnd(
+      nextCreatedAtEnd !== ""
+        ? toLocalDayIso(nextCreatedAtEnd, "end")
+        : undefined
+    );
+    setPagingState(cursorPagingStateFromQuery(router.query, UrlStatePrefix));
+  }, [router.query, routerReady, setPagingState]);
 
   React.useEffect(() => {
     if (page == null) return;
@@ -218,17 +360,39 @@ export default function FileTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
+    const nextPagingState = getPageStateForChange(num);
     handlePageChange(num);
+    updateFileTableQuery(
+      cursorPagingStateToQuery(UrlStatePrefix, nextPagingState)
+    );
   }
 
   function handleSortChange(field: string) {
-    setSort((current) => toggleSort(current, field));
+    setSort((current) => {
+      const nextSort = toggleSort(current, field);
+      updateFileTableQuery({
+        fileSort: toSortParam(nextSort),
+        ...clearPagingQuery(),
+      });
+      return nextSort;
+    });
     resetPaging();
   }
 
   function handleCreatedAtChange(filters: CreatedAtDateRange) {
     resetPaging();
-    setCreatedAtFilters(filters);
+    const createdAtStartDate = filters.createdAtStart?.slice(0, 10) ?? "";
+    const createdAtEndDate = filters.createdAtEnd?.slice(0, 10) ?? "";
+
+    setCreatedAtStart(filters.createdAtStart);
+    setCreatedAtStartDate(createdAtStartDate);
+    setCreatedAtEnd(filters.createdAtEnd);
+    setCreatedAtEndDate(createdAtEndDate);
+    updateFileTableQuery({
+      fileCreatedAtEnd: createdAtEndDate || undefined,
+      fileCreatedAtStart: createdAtStartDate || undefined,
+      ...clearPagingQuery(),
+    });
   }
 
   async function handleDelete() {
@@ -393,8 +557,11 @@ export default function FileTable({
               id="nameFilter"
               label="Name"
               type="text"
+              value={nameInput}
               onChange={(e) => {
-                debouncedSetNameFilter(e.target.value?.trim() ?? "");
+                const value = e.target.value ?? "";
+                setNameInput(value);
+                debouncedSetNameFilter(value.trim());
               }}
               sx={{ mt: 0, width: "16rem" }}
             />
@@ -405,8 +572,11 @@ export default function FileTable({
               id="fileIdFilter"
               label="File ID"
               type="text"
+              value={fileIdInput}
               onChange={(e) => {
-                debouncedSetFileIdFilter(e.target.value?.trim() ?? "");
+                const value = e.target.value ?? "";
+                setFileIdInput(value);
+                debouncedSetFileIdFilter(value.trim());
               }}
               sx={{ mt: 0, width: "16rem" }}
             />
@@ -417,14 +587,23 @@ export default function FileTable({
               id="suppliedIdFilter"
               label="Supplied ID"
               type="text"
+              value={suppliedIdInput}
               onChange={(e) => {
-                debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? "");
+                const value = e.target.value ?? "";
+                setSuppliedIdInput(value);
+                debouncedSetSuppliedIdFilter(value.trim());
               }}
               sx={{ mt: 0, width: "16rem" }}
             />
           </Box>
         </Box>
-        <CreatedAtDateRangeFilter onChange={handleCreatedAtChange} />
+        <CreatedAtDateRangeFilter
+          onChange={handleCreatedAtChange}
+          value={{
+            createdAtEnd: createdAtEndDate,
+            createdAtStart: createdAtStartDate,
+          }}
+        />
         <TableContainer>
           <Table>
             <TableHead

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -37,12 +37,12 @@ import {
   useCursorPagingState,
 } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import {
   CreatedAtDateRange,
   CreatedAtDateRangeFilter,
 } from "../shared/CreatedAtDateRangeFilter";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
-import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { ResourceLink } from "../shared/ResourceLink";

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -21,7 +21,7 @@ import React from "react";
 import useSWR from "swr";
 
 import { isErrorRes } from "../../lib/api";
-import { toLocaleString } from "../../lib/dates";
+import { toLocalDateInputValue, toLocaleString } from "../../lib/dates";
 import {
   File,
   FileStatusComplete,
@@ -381,8 +381,8 @@ export default function FileTable({
 
   function handleCreatedAtChange(filters: CreatedAtDateRange) {
     resetPaging();
-    const createdAtStartDate = filters.createdAtStart?.slice(0, 10) ?? "";
-    const createdAtEndDate = filters.createdAtEnd?.slice(0, 10) ?? "";
+    const createdAtStartDate = toLocalDateInputValue(filters.createdAtStart);
+    const createdAtEndDate = toLocalDateInputValue(filters.createdAtEnd);
 
     setCreatedAtStart(filters.createdAtStart);
     setCreatedAtStartDate(createdAtStartDate);

--- a/src/components/part/PartRow.tsx
+++ b/src/components/part/PartRow.tsx
@@ -20,15 +20,17 @@ import { Part } from "../../lib/parts";
 import { RowActionsMenu } from "../shared/RowActionsMenu";
 
 interface PartRowProps {
+  readonly activePartId?: string;
   readonly activeRevisionId?: string;
   readonly part: Part;
   readonly isSelected: boolean;
   readonly onSelected: (id: string) => void;
-  readonly onRevisionSelected: (revision: PartRevision) => void;
+  readonly onRevisionSelected: (revision: PartRevision, partId: string) => void;
   readonly onCreteSceneFromRevision: (id: string) => void;
 }
 
 export default function PartRow({
+  activePartId,
   activeRevisionId,
   part,
   isSelected,
@@ -37,7 +39,7 @@ export default function PartRow({
   onCreteSceneFromRevision,
 }: PartRowProps): JSX.Element {
   const row = part;
-  const [open, setOpen] = React.useState<boolean>(false);
+  const [open, setOpen] = React.useState<boolean>(activePartId === part.id);
 
   const [revisions, setRevisions] = React.useState<
     Paged<PartRevision> | undefined
@@ -54,6 +56,12 @@ export default function PartRow({
     }
   }, [part.id, open]);
 
+  React.useEffect(() => {
+    if (activePartId === part.id) {
+      setOpen(true);
+    }
+  }, [activePartId, part.id]);
+
   return (
     <>
       <TableRow
@@ -69,8 +77,20 @@ export default function PartRow({
             {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
           </IconButton>
         </TableCell>
-        <TableCell padding="checkbox" onClick={() => onSelected(row.id)}>
-          <Checkbox color="primary" checked={isSelected} />
+        <TableCell
+          padding="checkbox"
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelected(row.id);
+          }}
+        >
+          <Checkbox
+            color="primary"
+            checked={isSelected}
+            inputProps={{
+              "aria-label": `Select ${row.name ?? row.id}`,
+            }}
+          />
         </TableCell>
         <TableCell>{row.name}</TableCell>
         <TableCell>{row.suppliedId}</TableCell>
@@ -106,7 +126,7 @@ export default function PartRow({
                     <TableRow
                       key={r.id}
                       hover
-                      onClick={() => onRevisionSelected(r)}
+                      onClick={() => onRevisionSelected(r, part.id)}
                       selected={activeRevisionId === r.id}
                       sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                     >

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -21,6 +21,7 @@ import useSWR from "swr";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartPage } from "../../lib/parts";
+import { queryParamValue } from "../../lib/url-state";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -50,16 +51,14 @@ function useParts({ cursor, pageSize, suppliedId }: SwrProps) {
   );
 }
 
-const maybeQueryParam = (
-  target: string | string[] | undefined
-): string | undefined => (Array.isArray(target) ? target[0] : target);
-
 interface Props {
+  readonly activePartId?: string;
   readonly activeRevisionId?: string;
-  readonly onRevisionSelected: (revision: PartRevision) => void;
+  readonly onRevisionSelected: (revision: PartRevision, partId: string) => void;
 }
 
 export default function PartTable({
+  activePartId,
   activeRevisionId,
   onRevisionSelected,
 }: Props): JSX.Element {
@@ -197,6 +196,7 @@ export default function PartTable({
                 page.items.map((row) => {
                   return (
                     <PartRow
+                      activePartId={activePartId}
                       activeRevisionId={activeRevisionId}
                       key={row.id}
                       isSelected={selected.has(row.id)}
@@ -245,8 +245,8 @@ export default function PartTable({
           setToastMsg(`Translation initiated. Job ID: ${id}`);
           setShowCreatePartDialog(false);
         }}
-        targetFileId={maybeQueryParam(router.query.create)}
-        targetFileName={maybeQueryParam(router.query.n)}
+        targetFileId={queryParamValue(router.query.create)}
+        targetFileName={queryParamValue(router.query.n)}
       />
 
       <CreateSceneDialog

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -23,8 +23,15 @@ import useSWR from "swr";
 
 import { ErrorRes, GetRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
-import { SwrProps } from "../../lib/paging";
+import {
+  buildQuery,
+  cursorPagingStateFromQuery,
+  cursorPagingStateToQuery,
+  SwrProps,
+  useCursorPagingState,
+} from "../../lib/paging";
 import { Scene, toScenePage } from "../../lib/scenes";
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -51,11 +58,16 @@ const headCells: readonly HeadCell[] = [
   { id: "actions", label: "Actions" },
 ];
 
+const UrlStatePrefix = "scene";
+
 function useScenes({ cursor, pageSize, suppliedId, name }: SwrProps) {
   return useSWR<GetRes<SceneData>, ErrorRes>(
-    `/api/scenes?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ""}${
-      suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
-    }${name ? `&name=${encodeURIComponent(name)}` : ""}`
+    buildQuery("/api/scenes", {
+      cursor,
+      name,
+      pageSize,
+      suppliedId,
+    })
   );
 }
 
@@ -83,26 +95,43 @@ export default function SceneTable({
   scene,
   invalidationCount,
 }: Props): JSX.Element {
+  const router = useRouter();
+  const routerReady = router.isReady !== false;
   const pageSize = DefaultPageSize;
-  const [curPage, setCurPage] = React.useState(0);
   const [showMergeScene, setShowMergeScene] = React.useState(false);
-  const [cursor, setCursor] = React.useState<string | undefined>();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
+  const {
+    currentPage,
+    cursor,
+    cursors,
+    getPageStateForChange,
+    handlePageChange,
+    resetPaging,
+    setCursors,
+    setPagingState,
+  } = useCursorPagingState(
+    cursorPagingStateFromQuery(router.query, UrlStatePrefix)
+  );
   const [keyLoadingSceneId, setKeyLoadingSceneId] = React.useState<
     string | undefined
   >();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
-  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [activeSceneId, setActiveSceneId] = React.useState<string | undefined>(
     () => scene?.id
   );
-  const [suppliedId, setSuppliedIdFilter] = React.useState<
-    string | undefined
-  >();
-  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
+  const [suppliedId, setSuppliedIdFilter] = React.useState<string | undefined>(
+    () => queryParamValue(router.query.sceneSuppliedId)
+  );
+  const [suppliedIdInput, setSuppliedIdInput] = React.useState(
+    () => queryParamValue(router.query.sceneSuppliedId) ?? ""
+  );
+  const [nameFilter, setNameFilter] = React.useState<string | undefined>(() =>
+    queryParamValue(router.query.sceneName)
+  );
+  const [nameInput, setNameInput] = React.useState(
+    () => queryParamValue(router.query.sceneName) ?? ""
+  );
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
+  const initializedFromQuery = React.useRef(false);
 
   const { data, error, mutate } = useScenes({
     cursor,
@@ -115,27 +144,71 @@ export default function SceneTable({
     mutate();
   }, [invalidationCount, mutate]);
 
-  const router = useRouter();
   const page = data ? toScenePage(data) : undefined;
   const pageLength = page ? page.items.length : 0;
   const emptyRows =
     cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
 
-  const debouncedSetSuppliedIdFilter = React.useMemo(
-    () => debounce(setSuppliedIdFilter, 300),
+  const updateSceneTableQuery = React.useCallback(
+    (updates: Record<string, string | undefined>) => {
+      if (!routerReady) return;
+
+      updateRouterQuery(router, updates, "replace");
+    },
+    [router, routerReady]
+  );
+
+  const clearPagingQuery = React.useCallback(
+    () => cursorPagingStateToQuery(UrlStatePrefix),
     []
   );
 
-  const debouncedSetNameFilter = React.useMemo(
-    () => debounce(setNameFilter, 300),
-    []
+  const debouncedSetSuppliedIdFilter = React.useMemo(
+    () =>
+      debounce((value: string) => {
+        const nextValue = value === "" ? undefined : value;
+        resetPaging();
+        setSuppliedIdFilter(nextValue);
+        updateSceneTableQuery({
+          sceneSuppliedId: nextValue,
+          ...clearPagingQuery(),
+        });
+      }, 300),
+    [clearPagingQuery, resetPaging, updateSceneTableQuery]
   );
+
+  const debouncedSetNameFilter = React.useMemo(
+    () =>
+      debounce((value: string) => {
+        const nextValue = value === "" ? undefined : value;
+        resetPaging();
+        setNameFilter(nextValue);
+        updateSceneTableQuery({
+          sceneName: nextValue,
+          ...clearPagingQuery(),
+        });
+      }, 300),
+    [clearPagingQuery, resetPaging, updateSceneTableQuery]
+  );
+
+  React.useEffect(() => {
+    if (!routerReady || initializedFromQuery.current) return;
+
+    initializedFromQuery.current = true;
+    const nextName = queryParamValue(router.query.sceneName);
+    const nextSuppliedId = queryParamValue(router.query.sceneSuppliedId);
+    setNameFilter(nextName);
+    setNameInput(nextName ?? "");
+    setSuppliedIdFilter(nextSuppliedId);
+    setSuppliedIdInput(nextSuppliedId ?? "");
+    setPagingState(cursorPagingStateFromQuery(router.query, UrlStatePrefix));
+  }, [router.query, routerReady, setPagingState]);
 
   React.useEffect(() => {
     if (page == null) return;
 
     setCursors(page.cursors ?? undefined);
-  }, [page]);
+  }, [page, setCursors]);
 
   React.useEffect(() => {
     if (scene != null) setActiveSceneId(scene.id);
@@ -166,12 +239,11 @@ export default function SceneTable({
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
   ) {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
+    const nextPagingState = getPageStateForChange(num);
+    handlePageChange(num);
+    updateSceneTableQuery(
+      cursorPagingStateToQuery(UrlStatePrefix, nextPagingState)
+    );
   }
 
   async function handleDelete() {
@@ -243,8 +315,11 @@ export default function SceneTable({
             id="nameFilter"
             label="Name Filter"
             type="text"
+            value={nameInput}
             onChange={(e) => {
-              debouncedSetNameFilter(e.target.value?.trim() ?? undefined);
+              const value = e.target.value ?? "";
+              setNameInput(value);
+              debouncedSetNameFilter(value.trim());
             }}
             sx={{ mt: 0, width: "20rem" }}
           />
@@ -255,8 +330,11 @@ export default function SceneTable({
             id="suppliedIdFilter"
             label="Supplied ID Filter"
             type="text"
+            value={suppliedIdInput}
             onChange={(e) => {
-              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? undefined);
+              const value = e.target.value ?? "";
+              setSuppliedIdInput(value);
+              debouncedSetSuppliedIdFilter(value.trim());
             }}
             sx={{ mt: 0, width: "20rem" }}
           />
@@ -368,7 +446,7 @@ export default function SceneTable({
             )
           }
           rowsPerPage={pageSize}
-          page={curPage}
+          page={currentPage}
           onPageChange={handleChangePage}
           slotProps={{
             actions: {

--- a/src/components/shared/AppLink.tsx
+++ b/src/components/shared/AppLink.tsx
@@ -1,12 +1,61 @@
 import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
-import NextLink, { LinkProps as NextLinkProps } from "next/link";
+import { useRouter } from "next/router";
+import React from "react";
 
-export type AppLinkProps = Omit<MuiLinkProps, "href"> &
-  Pick<
-    NextLinkProps,
-    "href" | "locale" | "prefetch" | "replace" | "scroll" | "shallow"
-  >;
+export type AppLinkProps = Omit<MuiLinkProps, "href"> & AppLinkBehaviorProps;
 
 export function AppLink(props: AppLinkProps): JSX.Element {
-  return <MuiLink component={NextLink} {...props} />;
+  return <MuiLink component={AppLinkBehavior} {...props} />;
+}
+
+export interface AppLinkBehaviorProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, "href"> {
+  readonly href: string;
+  readonly locale?: string | false;
+  readonly prefetch?: boolean;
+  readonly replace?: boolean;
+  readonly scroll?: boolean;
+  readonly shallow?: boolean;
+}
+
+export const AppLinkBehavior = React.forwardRef<
+  HTMLAnchorElement,
+  AppLinkBehaviorProps
+>(function AppLinkBehavior(
+  { href, locale, onClick, prefetch, replace, scroll, shallow, ...props },
+  ref
+) {
+  const router = useRouter();
+
+  React.useEffect(() => {
+    if (prefetch === false || !href.startsWith("/")) return;
+    if (typeof router.prefetch !== "function") return;
+
+    router.prefetch(href).catch(() => undefined);
+  }, [href, prefetch, router]);
+
+  function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
+    onClick?.(event);
+
+    if (!shouldHandleWithAppNavigation(event)) return;
+
+    event.preventDefault();
+    if (replace) router.replace(href, undefined, { locale, scroll, shallow });
+    else router.push(href, undefined, { locale, scroll, shallow });
+  }
+
+  return <a ref={ref} href={href} onClick={handleClick} {...props} />;
+});
+
+export function shouldHandleWithAppNavigation(
+  event: React.MouseEvent<HTMLAnchorElement>
+): boolean {
+  if (event.defaultPrevented) return false;
+  if (event.button !== 0) return false;
+  if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+    return false;
+  }
+
+  const target = event.currentTarget.getAttribute("target");
+  return target == null || target === "" || target === "_self";
 }

--- a/src/components/shared/CreatedAtDateRangeFilter.tsx
+++ b/src/components/shared/CreatedAtDateRangeFilter.tsx
@@ -10,15 +10,23 @@ export interface CreatedAtDateRange {
 
 interface Props {
   readonly onChange: (filters: CreatedAtDateRange) => void;
+  readonly value?: CreatedAtDateRange;
 }
 
 function isAfter(left: string, right: string): boolean {
   return left.localeCompare(right) > 0;
 }
 
-export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
-  const [createdAtStartDate, setCreatedAtStartDate] = React.useState("");
-  const [createdAtEndDate, setCreatedAtEndDate] = React.useState("");
+export function CreatedAtDateRangeFilter({
+  onChange,
+  value: selectedValue,
+}: Props): JSX.Element {
+  const [localCreatedAtStartDate, setLocalCreatedAtStartDate] =
+    React.useState("");
+  const [localCreatedAtEndDate, setLocalCreatedAtEndDate] = React.useState("");
+  const createdAtStartDate =
+    selectedValue?.createdAtStart ?? localCreatedAtStartDate;
+  const createdAtEndDate = selectedValue?.createdAtEnd ?? localCreatedAtEndDate;
 
   function handleCreatedAtStartChange(value: string) {
     const nextEndDate =
@@ -28,8 +36,10 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
         ? ""
         : createdAtEndDate;
 
-    setCreatedAtStartDate(value);
-    setCreatedAtEndDate(nextEndDate);
+    if (selectedValue == null) {
+      setLocalCreatedAtStartDate(value);
+      setLocalCreatedAtEndDate(nextEndDate);
+    }
     onChange({
       createdAtEnd: nextEndDate
         ? toLocalDayBoundaryIso(nextEndDate, "end")
@@ -46,8 +56,10 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
         ? ""
         : createdAtStartDate;
 
-    setCreatedAtStartDate(nextStartDate);
-    setCreatedAtEndDate(value);
+    if (selectedValue == null) {
+      setLocalCreatedAtStartDate(nextStartDate);
+      setLocalCreatedAtEndDate(value);
+    }
     onChange({
       createdAtEnd: value ? toLocalDayBoundaryIso(value, "end") : undefined,
       createdAtStart: nextStartDate

--- a/src/components/shared/LeftDrawer.tsx
+++ b/src/components/shared/LeftDrawer.tsx
@@ -17,7 +17,8 @@ import { drawerClasses } from "@mui/material/Drawer";
 import { useRouter } from "next/router";
 import React from "react";
 
-import { LeftDrawerWidth } from "../shared/Layout";
+import { AppLinkBehavior } from "./AppLink";
+import { LeftDrawerWidth } from "./Layout";
 
 export type Content = "settings" | "instructions" | "parts";
 
@@ -41,7 +42,8 @@ export function LeftDrawer(): JSX.Element {
         }}
       >
         <ListItemButton
-          onClick={() => router.push("/")}
+          component={AppLinkBehavior}
+          href="/"
           selected={router.route === "/"}
         >
           <ListItemIcon>
@@ -50,7 +52,8 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Scenes" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/files")}
+          component={AppLinkBehavior}
+          href="/files"
           selected={router.route === "/files"}
         >
           <ListItemIcon>
@@ -59,7 +62,8 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Files" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/file-collections")}
+          component={AppLinkBehavior}
+          href="/file-collections"
           selected={router.route === "/file-collections"}
         >
           <ListItemIcon>
@@ -68,7 +72,8 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="File Collections" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/parts")}
+          component={AppLinkBehavior}
+          href="/parts"
           selected={router.route === "/parts"}
         >
           <ListItemIcon>
@@ -77,7 +82,8 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Parts Library" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/translations")}
+          component={AppLinkBehavior}
+          href="/translations"
           selected={router.route === "/translations"}
         >
           <ListItemIcon>

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -41,15 +41,15 @@ export function ResourceLink({
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
           if (disabled) {
             event.preventDefault();
+            event.stopPropagation();
             return;
           }
-          if (!shouldHandleWithAppNavigation(event)) return;
-
           event.stopPropagation();
-          if (event.button !== 0 || href != null) return;
+          if (!shouldHandleWithAppNavigation(event)) return;
+          if (onPrimaryAction == null) return;
 
           event.preventDefault();
-          onPrimaryAction?.();
+          onPrimaryAction();
         }}
         onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {
           event.stopPropagation();

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -2,8 +2,11 @@ import { Box, BoxProps, Tooltip } from "@mui/material";
 import NextLink from "next/link";
 import React from "react";
 
+import { shouldHandleWithAppNavigation } from "./AppLink";
+
 type ResourceLinkProps = Omit<BoxProps<"a">, "component" | "onClick"> & {
   readonly component?: React.ElementType;
+
   readonly disabled?: boolean;
   readonly href?: string;
   readonly onPrimaryAction?: () => void;
@@ -40,6 +43,7 @@ export function ResourceLink({
             event.preventDefault();
             return;
           }
+          if (!shouldHandleWithAppNavigation(event)) return;
 
           event.stopPropagation();
           if (event.button !== 0 || href != null) return;

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -41,7 +41,6 @@ export function ResourceLink({
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
           if (disabled) {
             event.preventDefault();
-            event.stopPropagation();
             return;
           }
           event.stopPropagation();

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -30,3 +30,17 @@ export function toLocalDayBoundaryIso(
 
   return date.toISOString();
 }
+
+/**
+ * Converts an ISO timestamp to the corresponding local date input value.
+ */
+export function toLocalDateInputValue(value?: string): string {
+  if (value == null) return "";
+
+  const date = new Date(value);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -1,10 +1,15 @@
-import { FileList } from "@vertexvis/api-client-node";
+import { FileList, FileMetadata } from "@vertexvis/api-client-node";
 
 import { GetRes, Res } from "./api";
 import { Paged, toPage } from "./paging";
 
-export type File = FileList["data"][number]["attributes"] &
-  Pick<FileList["data"][number], "id">;
+type FileData = FileList["data"][number] | FileMetadata["data"];
+
+export type File = FileData["attributes"] & Pick<FileData, "id">;
+
+export function toFile(data: FileData): File {
+  return { ...data.attributes, id: data.id };
+}
 
 export interface FileDownloadUrlRes extends Res {
   readonly url: string;

--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -2,6 +2,7 @@ import { Cursors } from "@vertexvis/api-client-node";
 import React from "react";
 
 import { GetRes } from "./api";
+import { queryParamValue } from "./url-state";
 
 export interface Paged<T> {
   readonly cursors: Cursors | null; // Must use null for proper NextJS serialization
@@ -17,6 +18,18 @@ export interface SwrProps {
 
 type QueryValue = number | string | undefined;
 const QueryParamOrder = ["pageSize", "cursor", "sort", "suppliedId", "name"];
+
+export interface CursorPagingState {
+  readonly currentPage: number;
+  readonly cursor?: string;
+  readonly previous: Record<number, string | undefined>;
+}
+
+interface CursorPagingInitialState {
+  readonly currentPage?: number;
+  readonly cursor?: string;
+  readonly previous?: Record<number, string | undefined>;
+}
 
 export function buildQuery(
   path: string,
@@ -44,22 +57,31 @@ export function buildQuery(
   return search === "" ? path : `${path}?${search}`;
 }
 
-export function useCursorPagingState(): {
+export function useCursorPagingState(
+  initialState: CursorPagingInitialState = {}
+): {
   readonly currentPage: number;
   readonly cursor?: string;
   readonly cursors?: Cursors;
+  readonly getPageStateForChange: (nextPage: number) => CursorPagingState;
   readonly handlePageChange: (nextPage: number) => void;
+  readonly previous: Record<number, string | undefined>;
   readonly resetPaging: () => void;
   readonly setCursors: React.Dispatch<
     React.SetStateAction<Cursors | undefined>
   >;
+  readonly setPagingState: (nextState: CursorPagingInitialState) => void;
 } {
-  const [currentPage, setCurrentPage] = React.useState(0);
-  const [cursor, setCursor] = React.useState<string | undefined>();
+  const [currentPage, setCurrentPage] = React.useState(
+    initialState.currentPage ?? 0
+  );
+  const [cursor, setCursor] = React.useState<string | undefined>(
+    initialState.cursor
+  );
   const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [previous, setPrevious] = React.useState<
     Record<number, string | undefined>
-  >({});
+  >(initialState.previous ?? {});
 
   const resetPaging = React.useCallback(() => {
     setCurrentPage(0);
@@ -68,31 +90,129 @@ export function useCursorPagingState(): {
     setPrevious({});
   }, []);
 
-  const handlePageChange = React.useCallback(
-    (nextPage: number) => {
+  const setPagingState = React.useCallback(
+    (nextState: CursorPagingInitialState) => {
+      setCurrentPage(nextState.currentPage ?? 0);
+      setCursor(nextState.cursor);
+      setPrevious(nextState.previous ?? {});
+      setCursors(undefined);
+    },
+    []
+  );
+
+  const getPageStateForChange = React.useCallback(
+    (nextPage: number): CursorPagingState => {
       if (currentPage < nextPage) {
-        setPrevious((current) => ({
-          ...current,
-          [nextPage - 1]: cursors?.self,
-        }));
-        setCursor(cursors?.next);
+        return {
+          currentPage: nextPage,
+          cursor: cursors?.next,
+          previous: {
+            ...previous,
+            [nextPage - 1]: cursors?.self,
+          },
+        };
       } else if (currentPage > nextPage) {
-        setCursor(previous[nextPage]);
+        return {
+          currentPage: nextPage,
+          cursor: previous[nextPage],
+          previous,
+        };
       }
 
-      setCurrentPage(nextPage);
+      return { currentPage, cursor, previous };
     },
-    [currentPage, cursors, previous]
+    [currentPage, cursor, cursors, previous]
+  );
+
+  const handlePageChange = React.useCallback(
+    (nextPage: number) => {
+      const nextState = getPageStateForChange(nextPage);
+      setCurrentPage(nextState.currentPage);
+      setCursor(nextState.cursor);
+      setPrevious(nextState.previous);
+    },
+    [getPageStateForChange]
   );
 
   return {
     currentPage,
     cursor,
     cursors,
+    getPageStateForChange,
     handlePageChange,
+    previous,
     resetPaging,
     setCursors,
+    setPagingState,
   };
+}
+
+export function cursorPagingStateFromQuery(
+  query: Record<string, string | string[] | undefined>,
+  prefix: string
+): CursorPagingInitialState {
+  return {
+    currentPage: parsePositiveInteger(queryParamValue(query[`${prefix}Page`])),
+    cursor: queryParamValue(query[`${prefix}Cursor`]),
+    previous: decodePreviousCursors(
+      queryParamValue(query[`${prefix}PreviousCursors`])
+    ),
+  };
+}
+
+export function cursorPagingStateToQuery(
+  prefix: string,
+  state?: CursorPagingInitialState
+): Record<string, string | undefined> {
+  return {
+    [`${prefix}Page`]:
+      state?.currentPage != null && state.currentPage > 0
+        ? state.currentPage.toString()
+        : undefined,
+    [`${prefix}Cursor`]: state?.cursor,
+    [`${prefix}PreviousCursors`]: encodePreviousCursors(state?.previous),
+  };
+}
+
+function parsePositiveInteger(value?: string): number | undefined {
+  if (value == null || !/^\d+$/.test(value)) return undefined;
+
+  const parsed = Number.parseInt(value, 10);
+  return parsed > 0 ? parsed : undefined;
+}
+
+function decodePreviousCursors(
+  value?: string
+): Record<number, string | undefined> | undefined {
+  if (value == null) return undefined;
+
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    return Object.entries(parsed).reduce<Record<number, string | undefined>>(
+      (acc, [key, cursor]) => {
+        if (/^\d+$/.test(key) && typeof cursor === "string") {
+          acc[Number.parseInt(key, 10)] = cursor;
+        }
+        return acc;
+      },
+      {}
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+function encodePreviousCursors(
+  previous?: Record<number, string | undefined>
+): string | undefined {
+  if (previous == null) return undefined;
+
+  const entries = Object.entries(previous).filter(
+    ([, cursor]) => cursor != null
+  );
+  return entries.length === 0
+    ? undefined
+    : JSON.stringify(Object.fromEntries(entries));
 }
 
 export function toPage<T extends { attributes: TA; id: string }, TA>({

--- a/src/lib/scenes.ts
+++ b/src/lib/scenes.ts
@@ -5,6 +5,10 @@ import { Paged, toPage } from "./paging";
 
 export type Scene = Pick<SceneData, "id"> & SceneDataAttributes;
 
+export function toScene(data: SceneData): Scene {
+  return { ...data.attributes, id: data.id };
+}
+
 export function toScenePage(res: GetRes<SceneData>): Paged<Scene> {
   return toPage<SceneData, SceneDataAttributes>(res);
 }

--- a/src/lib/url-state.ts
+++ b/src/lib/url-state.ts
@@ -1,0 +1,31 @@
+import { NextRouter } from "next/router";
+
+export type QueryParamValue = string | string[] | undefined;
+
+export function queryParamValue(value: QueryParamValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export function updateRouterQuery(
+  router: NextRouter,
+  updates: Record<string, string | undefined>,
+  method: "push" | "replace" = "push"
+): Promise<boolean> {
+  const query = { ...router.query };
+
+  for (const [key, value] of Object.entries(updates)) {
+    if (value == null || value === "") delete query[key];
+    else query[key] = value;
+  }
+
+  const navigate = method === "replace" ? router.replace : router.push;
+  return navigate.call(
+    router,
+    { pathname: router.pathname, query },
+    undefined,
+    {
+      scroll: false,
+      shallow: true,
+    }
+  );
+}

--- a/src/pages/api/files/[id]/index.ts
+++ b/src/pages/api/files/[id]/index.ts
@@ -1,7 +1,7 @@
 import {
+  FileMetadata,
   head,
   logError,
-  PartRevisionData,
   VertexError,
 } from "@vertexvis/api-client-node";
 import { NextApiResponse } from "next";
@@ -11,23 +11,27 @@ import {
   MethodNotAllowed,
   ServerError,
   toErrorRes,
-} from "../../../lib/api";
-import { getClientFromSession } from "../../../lib/vertex-api";
-import withSession, { NextIronRequest } from "../../../lib/with-session";
+} from "../../../../lib/api";
+import { getClientFromSession } from "../../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../../lib/with-session";
+
+type FileData = FileMetadata["data"];
 
 export default withSession(async function handle(
   req: NextIronRequest,
-  res: NextApiResponse<PartRevisionData | ErrorRes>
+  res: NextApiResponse<FileData | ErrorRes>
 ): Promise<void> {
   if (req.method === "GET") {
     const r = await get(req);
-    return res.status(200).json(r);
+    return "status" in r
+      ? res.status(r.status).json(r)
+      : res.status(200).json(r);
   }
 
   return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
 });
 
-async function get(req: NextIronRequest): Promise<ErrorRes | PartRevisionData> {
+async function get(req: NextIronRequest): Promise<ErrorRes | FileData> {
   try {
     const c = await getClientFromSession(req.session);
     const id = head(req.query.id);
@@ -35,12 +39,7 @@ async function get(req: NextIronRequest): Promise<ErrorRes | PartRevisionData> {
       throw new Error("ID not set and is required");
     }
 
-    const item = await c.partRevisions.getPartRevision({
-      id,
-      fieldsPartRevision:
-        "created,name,suppliedId,suppliedIterationId,metadata",
-    });
-
+    const item = await c.files.getFile({ id });
     return item.data.data;
   } catch (error) {
     const e = error as VertexError;

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -12,8 +12,10 @@ import {
 import { head } from "@vertexvis/api-client-node";
 import { GetServerSidePropsResult } from "next";
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import { withIronSession } from "next-iron-session";
 import React from "react";
+import useSWR from "swr";
 
 import { FileDetailsDrawer } from "../../components/file/FileDetailsDrawer";
 import { FileCollectionMetadataTable } from "../../components/file-collection/FileCollectionMetadataTable";
@@ -32,7 +34,8 @@ import {
   toFileCollection,
 } from "../../lib/file-collections";
 import { FileJobRes } from "../../lib/file-jobs";
-import { File, FileDownloadUrlRes } from "../../lib/files";
+import { File, FileDownloadUrlRes, toFile } from "../../lib/files";
+import { queryParamValue, updateRouterQuery } from "../../lib/url-state";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import {
   CommonProps,
@@ -307,7 +310,14 @@ export default function FileCollectionDetails({
   fileCollection,
 }: Props): JSX.Element {
   const fileCollectionIdRef = React.useRef(fileCollection.id);
+  const router = useRouter();
   const [file, setFile] = React.useState<File | undefined>();
+  const fileId = queryParamValue(router.query.fileId);
+  const { data: selectedFile } = useSWR(
+    router.isReady && fileId != null
+      ? `/api/files/${encodeURIComponent(fileId)}`
+      : null
+  );
   const [exportStateCollectionId, setExportStateCollectionId] = React.useState(
     fileCollection.id
   );
@@ -606,6 +616,29 @@ export default function FileCollectionDetails({
     setJobStatus("idle");
   }
 
+  React.useEffect(() => {
+    if (!router.isReady) return;
+
+    if (fileId == null) {
+      setFile(undefined);
+      return;
+    }
+
+    if (selectedFile != null && !isErrorRes(selectedFile)) {
+      setFile(toFile(selectedFile));
+    }
+  }, [fileId, router.isReady, selectedFile]);
+
+  function handleFileSelected(selected: File) {
+    setFile(selected);
+    updateRouterQuery(router, { fileId: selected.id });
+  }
+
+  function handleClose() {
+    setFile(undefined);
+    updateRouterQuery(router, { fileId: undefined });
+  }
+
   return (
     <Layout
       main={
@@ -662,14 +695,14 @@ export default function FileCollectionDetails({
           <FileCollectionFilesTable
             activeFileId={file?.id}
             apiPath={filesApiPath}
-            onFileSelected={setFile}
+            onFileSelected={handleFileSelected}
           />
         </Box>
       }
       rightDrawer={
         <FileDetailsDrawer
           file={file}
-          onClose={() => setFile(undefined)}
+          onClose={handleClose}
           open={drawerOpen}
         />
       }

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -1,9 +1,13 @@
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import React from "react";
+import useSWR from "swr";
 
 import { FileDetailsDrawer } from "../components/file/FileDetailsDrawer";
 import { Layout } from "../components/shared/Layout";
-import { File } from "../lib/files";
+import { isErrorRes } from "../lib/api";
+import { File, toFile } from "../lib/files";
+import { queryParamValue, updateRouterQuery } from "../lib/url-state";
 import { defaultServerSideProps } from "../lib/with-session";
 
 const FileTable = dynamic(() => import("../components/file/FileTable"), {
@@ -11,16 +15,51 @@ const FileTable = dynamic(() => import("../components/file/FileTable"), {
 });
 
 export default function Files(): JSX.Element {
+  const router = useRouter();
   const [file, setFile] = React.useState<File | undefined>();
+  const fileId = queryParamValue(router.query.fileId);
+  const { data: selectedFile } = useSWR(
+    router.isReady && fileId != null
+      ? `/api/files/${encodeURIComponent(fileId)}`
+      : null
+  );
   const drawerOpen = Boolean(file);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+
+    if (fileId == null) {
+      setFile(undefined);
+      return;
+    }
+
+    if (selectedFile != null && !isErrorRes(selectedFile)) {
+      setFile(toFile(selectedFile));
+    }
+  }, [fileId, router.isReady, selectedFile]);
+
+  function handleFileSelected(selected: File) {
+    setFile(selected);
+    updateRouterQuery(router, { fileId: selected.id });
+  }
+
+  function handleClose() {
+    setFile(undefined);
+    updateRouterQuery(router, { fileId: undefined });
+  }
 
   return (
     <Layout
-      main={<FileTable activeFileId={file?.id} onFileSelected={setFile} />}
+      main={
+        <FileTable
+          activeFileId={file?.id}
+          onFileSelected={handleFileSelected}
+        />
+      }
       rightDrawer={
         <FileDetailsDrawer
           file={file}
-          onClose={() => setFile(undefined)}
+          onClose={handleClose}
           open={drawerOpen}
         />
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,13 @@
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import React, { useCallback } from "react";
+import useSWR from "swr";
 
 import { SceneDrawer } from "../components/scene/SceneDrawer";
 import { Layout } from "../components/shared/Layout";
-import { Scene } from "../lib/scenes";
+import { isErrorRes } from "../lib/api";
+import { Scene, toScene } from "../lib/scenes";
+import { queryParamValue, updateRouterQuery } from "../lib/url-state";
 import { defaultServerSideProps } from "../lib/with-session";
 
 const SceneTable = dynamic(() => import("../components/scene/SceneTable"), {
@@ -11,26 +15,52 @@ const SceneTable = dynamic(() => import("../components/scene/SceneTable"), {
 });
 
 export default function Home(): JSX.Element {
+  const router = useRouter();
   const [editing, setEditing] = React.useState<boolean>(false);
   const [scene, setScene] = React.useState<Scene | undefined>();
+  const sceneId = queryParamValue(router.query.sceneId);
+  const editingQueryParam = queryParamValue(router.query.editing);
+  const { data: selectedScene } = useSWR(
+    router.isReady && sceneId != null
+      ? `/api/scenes/${encodeURIComponent(sceneId)}`
+      : null
+  );
   const drawerOpen = Boolean(scene);
   const [invalidationCount, setInvalidationCount] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+
+    if (sceneId == null) {
+      setScene(undefined);
+      setEditing(false);
+      return;
+    }
+
+    if (selectedScene != null && !isErrorRes(selectedScene)) {
+      setScene(toScene(selectedScene));
+      setEditing(editingQueryParam === "true");
+    }
+  }, [editingQueryParam, router.isReady, sceneId, selectedScene]);
 
   function handleClick(s: Scene) {
     setScene(s);
     setEditing(false);
+    updateRouterQuery(router, { editing: undefined, sceneId: s.id });
   }
 
   function handleEditClick(s: Scene) {
     setScene(s);
     setEditing(true);
+    updateRouterQuery(router, { editing: "true", sceneId: s.id });
   }
 
   const handleClose = useCallback(() => {
     setScene(undefined);
     setEditing(false);
-    setInvalidationCount(invalidationCount + 1);
-  }, [invalidationCount]);
+    setInvalidationCount((current) => current + 1);
+    updateRouterQuery(router, { editing: undefined, sceneId: undefined });
+  }, [router]);
 
   return (
     <Layout

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -37,9 +37,10 @@ export default function Home(): JSX.Element {
       return;
     }
 
-    if (selectedScene != null && !isErrorRes(selectedScene)) {
-      setScene(toScene(selectedScene));
-      setEditing(editingQueryParam === "true");
+    if (selectedScene != null) {
+      const isErr = isErrorRes(selectedScene);
+      setScene(isErr ? undefined : toScene(selectedScene));
+      setEditing(!isErr && editingQueryParam === "true");
     }
   }, [editingQueryParam, router.isReady, sceneId, selectedScene]);
 

--- a/src/pages/parts.tsx
+++ b/src/pages/parts.tsx
@@ -1,9 +1,13 @@
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import React from "react";
+import useSWR from "swr";
 
 import { PartRevisionDetailsDrawer } from "../components/part/PartRevisionDetailsDrawer";
 import { Layout } from "../components/shared/Layout";
-import { PartRevision } from "../lib/part-revisions";
+import { isErrorRes } from "../lib/api";
+import { PartRevision, toPartRevision } from "../lib/part-revisions";
+import { queryParamValue, updateRouterQuery } from "../lib/url-state";
 import { defaultServerSideProps } from "../lib/with-session";
 
 const PartTable = dynamic(() => import("../components/part/PartTable"), {
@@ -11,22 +15,60 @@ const PartTable = dynamic(() => import("../components/part/PartTable"), {
 });
 
 export default function Parts(): JSX.Element {
+  const router = useRouter();
   const [revision, setRevision] = React.useState<PartRevision | undefined>();
+  const partId = queryParamValue(router.query.partId);
+  const revisionId = queryParamValue(router.query.revisionId);
+  const { data: selectedRevision } = useSWR(
+    router.isReady && revisionId != null
+      ? `/api/part-revisions/${encodeURIComponent(revisionId)}`
+      : null
+  );
   const drawerOpen = Boolean(revision);
+
+  React.useEffect(() => {
+    if (!router.isReady) return;
+
+    if (revisionId == null) {
+      setRevision(undefined);
+      return;
+    }
+
+    if (selectedRevision != null && !isErrorRes(selectedRevision)) {
+      setRevision(toPartRevision(selectedRevision));
+    }
+  }, [revisionId, router.isReady, selectedRevision]);
+
+  function handleRevisionSelected(
+    selected: PartRevision,
+    selectedPartId: string
+  ) {
+    setRevision(selected);
+    updateRouterQuery(router, {
+      partId: selectedPartId,
+      revisionId: selected.id,
+    });
+  }
+
+  function handleClose() {
+    setRevision(undefined);
+    updateRouterQuery(router, { partId: undefined, revisionId: undefined });
+  }
 
   return (
     <Layout
       main={
         <PartTable
+          activePartId={partId}
           activeRevisionId={revision?.id}
-          onRevisionSelected={setRevision}
+          onRevisionSelected={handleRevisionSelected}
         />
       }
       rightDrawer={
         <PartRevisionDetailsDrawer
           open={drawerOpen}
           partRevision={revision}
-          onClose={() => setRevision(undefined)}
+          onClose={handleClose}
         />
       }
       rightDrawerOpen={drawerOpen}


### PR DESCRIPTION
## Summary

- Adds the shared `AppLink` wrapper and uses it for internal app links that should behave like normal navigable URLs.
- Adds shared URL query-state helpers for preserving and updating detail selection state.
- Deep-links scene, file, file-collection file, and part revision drawers so copied URLs can reopen the same content.
- Persists file table sort, filter, and cursor pagination state in the URL so pasted file drawer links can restore the surrounding table context instead of returning to page one.
- Persists scene and file collection list filter/cursor pagination state in the URL as well.
- Preserves browser link gestures for `AppLink`, resource links, and left-nav links: plain left-click stays in-app, while cmd/ctrl-click and other modified clicks use browser-default behavior.
- Adds a file-by-ID API route used to restore file drawer state from pasted URLs.
- Fixes nested part revision selection by carrying `partId` alongside `revisionId`, auto-opening the matching part row, and keeping part checkbox selection separate from revision selection.

## Validation

- `yarn install --frozen-lockfile`
- `npm test -- --runTestsByPath src/__tests__/components/shared/AppLink.test.tsx src/__tests__/components/scene/SceneTable.test.tsx`
- `npm run lint`
- `npm run build`

Note: local `node_modules` in the nested worktree can make Next infer duplicate ESLint plugin roots. I cleared ignored generated folders before the final lint/build run.