### PR TITLE
[PLAT-8937] Highlight selected scene

### DIFF
--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { rest } from "msw";
+import nodeFetch, { Headers, Request, Response } from "node-fetch";
+import React from "react";
+import { SWRConfig } from "swr";
+
+import { server } from "../../../../test/msw/server";
+import SceneTable from "../../../components/scene/SceneTable";
+import { Scene } from "../../../lib/scenes";
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+const scene: Scene = {
+  id: "scene-1",
+  created: "2026-07-01T15:30:00Z",
+  name: "Scene One",
+  state: "ready",
+  suppliedId: "supplied-scene-1",
+};
+
+const page = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "scene",
+      id: scene.id,
+      attributes: {
+        created: scene.created,
+        name: scene.name,
+        state: scene.state,
+        suppliedId: scene.suppliedId,
+      },
+    },
+  ],
+  status: 200,
+};
+
+describe("SceneTable", () => {
+  beforeAll(() => {
+    Object.assign(global, {
+      Headers,
+      Request,
+      Response,
+      fetch: nodeFetch,
+    });
+    server.listen({ onUnhandledRequest: "error" });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+    Object.assign(global, { fetch: nodeFetch });
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it("preserves the active scene highlight after the drawer scene clears", async () => {
+    server.use(
+      rest.get("*/api/scenes", (_req, res, ctx) => {
+        return res(ctx.json(page));
+      })
+    );
+
+    const { rerender } = renderTable(scene);
+
+    await waitFor(() => {
+      expect(getSceneRow()).toHaveClass("Mui-selected");
+    });
+
+    rerender(renderTableElement(undefined));
+
+    await waitFor(() => {
+      expect(getSceneRow()).toHaveClass("Mui-selected");
+    });
+  });
+});
+
+function getSceneRow(): HTMLTableRowElement {
+  const row = screen.getByText("Scene One").closest("tr");
+  if (row == null) throw new Error("Could not find scene row.");
+
+  return row;
+}
+
+function renderTable(scene?: Scene) {
+  return render(renderTableElement(scene));
+}
+
+function renderTableElement(scene?: Scene): JSX.Element {
+  return (
+    <SWRConfig
+      value={{
+        dedupingInterval: 0,
+        fetcher: (url: string) =>
+          (global.fetch as typeof nodeFetch)(
+            new URL(url, window.location.origin).toString()
+          ).then((res) => res.json()),
+        provider: () => new Map(),
+      }}
+    >
+      <SceneTable
+        clientId="client-id"
+        invalidationCount={0}
+        onClick={jest.fn()}
+        onEditClick={jest.fn()}
+        scene={scene}
+        vertexEnv="platdev"
+      />
+    </SWRConfig>
+  );
+}

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import nodeFetch, { Headers, Request, Response } from "node-fetch";
 import React from "react";
@@ -22,6 +23,14 @@ const scene: Scene = {
   suppliedId: "supplied-scene-1",
 };
 
+const secondScene: Scene = {
+  id: "scene-2",
+  created: "2026-07-02T15:30:00Z",
+  name: "Scene Two",
+  state: "ready",
+  suppliedId: "supplied-scene-2",
+};
+
 const page = {
   cursors: { self: "page-1" },
   data: [
@@ -33,6 +42,16 @@ const page = {
         name: scene.name,
         state: scene.state,
         suppliedId: scene.suppliedId,
+      },
+    },
+    {
+      type: "scene",
+      id: secondScene.id,
+      attributes: {
+        created: secondScene.created,
+        name: secondScene.name,
+        state: secondScene.state,
+        suppliedId: secondScene.suppliedId,
       },
     },
   ],
@@ -79,10 +98,31 @@ describe("SceneTable", () => {
       expect(getSceneRow()).toHaveClass("Mui-selected");
     });
   });
+
+  it("updates the active highlight immediately when another scene is clicked", async () => {
+    server.use(
+      rest.get("*/api/scenes", (_req, res, ctx) => {
+        return res(ctx.json(page));
+      })
+    );
+
+    renderTable(scene);
+
+    await waitFor(() => {
+      expect(getSceneRow("Scene One")).toHaveClass("Mui-selected");
+    });
+
+    await userEvent.click(screen.getByText("Scene Two"));
+
+    await waitFor(() => {
+      expect(getSceneRow("Scene Two")).toHaveClass("Mui-selected");
+    });
+    expect(getSceneRow("Scene One")).not.toHaveClass("Mui-selected");
+  });
 });
 
-function getSceneRow(): HTMLTableRowElement {
-  const row = screen.getByText("Scene One").closest("tr");
+function getSceneRow(name = "Scene One"): HTMLTableRowElement {
+  const row = screen.getByText(name).closest("tr");
   if (row == null) throw new Error("Could not find scene row.");
 
   return row;

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -9,6 +9,7 @@ import { server } from "../../../../test/msw/server";
 import SceneTable from "../../../components/scene/SceneTable";
 import { Scene } from "../../../lib/scenes";
 
+// todo:PLAT-8812
 jest.mock("next/router", () => ({
   useRouter: () => ({
     push: jest.fn(),

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -90,6 +90,7 @@ export default function SceneTable({
   clientId,
   onClick,
   onEditClick,
+  scene,
   vertexEnv,
   invalidationCount,
 }: Props): JSX.Element {
@@ -296,6 +297,7 @@ export default function SceneTable({
               ) : (
                 page.items.map((row) => {
                   const isSel = selected.has(row.id);
+                  const isActive = scene?.id === row.id;
 
                   return (
                     <TableRow
@@ -303,7 +305,7 @@ export default function SceneTable({
                       role="checkbox"
                       tabIndex={-1}
                       key={row.id}
-                      selected={isSel}
+                      selected={isSel || isActive}
                       onClick={() => handleClick(row)}
                     >
                       <TableCell

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -106,6 +106,9 @@ export default function SceneTable({
     {}
   );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [activeSceneId, setActiveSceneId] = React.useState<
+    string | undefined
+  >();
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
   >();
@@ -144,6 +147,10 @@ export default function SceneTable({
 
     setCursors(page.cursors ?? undefined);
   }, [page]);
+
+  React.useEffect(() => {
+    if (scene != null) setActiveSceneId(scene.id);
+  }, [scene]);
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
     if (page == null) return;
@@ -297,7 +304,7 @@ export default function SceneTable({
               ) : (
                 page.items.map((row) => {
                   const isSel = selected.has(row.id);
-                  const isActive = scene?.id === row.id;
+                  const isActive = activeSceneId === row.id;
 
                   return (
                     <TableRow

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -168,6 +168,7 @@ export default function SceneTable({
   }
 
   function handleClick(s: Scene) {
+    setActiveSceneId(s.id);
     onClick(s);
   }
 
@@ -193,6 +194,7 @@ export default function SceneTable({
   }
 
   function handleEditClick(s: Scene) {
+    setActiveSceneId(s.id);
     onEditClick(s);
   }
 

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -105,10 +105,9 @@ export default function SceneTable({
   const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
     {}
   );
-  const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [activeSceneId, setActiveSceneId] = React.useState<
     string | undefined
-  >();
+  >(() => scene?.id);
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
   >();

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -105,9 +105,10 @@ export default function SceneTable({
   const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
     {}
   );
-  const [activeSceneId, setActiveSceneId] = React.useState<
-    string | undefined
-  >(() => scene?.id);
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [activeSceneId, setActiveSceneId] = React.useState<string | undefined>(
+    () => scene?.id
+  );
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
   >();


### PR DESCRIPTION
## Summary
There was a UX discrepancy with scenes: the selected scene row did not keep its highlight after closing the drawer. This keeps the last selected scene highlighted until another scene is selected.

## Test Plan
- Open Dev Dashboard and verify the last selected scene retains highlight until the next scene is selected
- corepack yarn format
- corepack yarn test src/__tests__/components/scene/SceneTable.test.tsx --runInBand
- corepack yarn lint

## Release Notes
Scene shows selected state now

## Possible Regressions
n/a

## Dependencies
none