### PR TITLE
[PLAT-8942] File Collections: Add sort controls in vertex-dev-dashboard

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -182,9 +182,7 @@ describe("FileCollectionTable", () => {
     await userEvent.click(screen.getByLabelText("Go to next page"));
     expect(await screen.findByText("Collection Two")).toBeInTheDocument();
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Created At" })
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Created At" }));
 
     expect(await screen.findByText("Collection One")).toBeInTheDocument();
     expect(

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -106,6 +106,95 @@ describe("FileCollectionTable", () => {
     ).toBe(true);
   });
 
+  it("keeps the default API sort when no sort control is selected", async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get("*/api/file-collections", ({ request }) => {
+        requests.push(new URL(request.url).search);
+        return HttpResponse.json(firstPage);
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+    expect(
+      requests.some((search) => {
+        const params = new URLSearchParams(search);
+        return params.get("pageSize") === "25" && !params.has("sort");
+      })
+    ).toBe(true);
+  });
+
+  it("sorts by name and toggles the sort direction", async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get("*/api/file-collections", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url.search);
+        return HttpResponse.json(
+          url.searchParams.get("sort") === "name" ? nextPage : firstPage
+        );
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Name" }));
+    expect(await screen.findByText("Collection Two")).toBeInTheDocument();
+    expect(
+      requests.some(
+        (search) => new URLSearchParams(search).get("sort") === "name"
+      )
+    ).toBe(true);
+
+    await userEvent.click(screen.getByRole("button", { name: "Name" }));
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+    expect(
+      requests.some(
+        (search) => new URLSearchParams(search).get("sort") === "-name"
+      )
+    ).toBe(true);
+  });
+
+  it("resets cursor pagination when the sort changes", async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get("*/api/file-collections", ({ request }) => {
+        const url = new URL(request.url);
+        requests.push(url.search);
+        return HttpResponse.json(
+          url.searchParams.get("cursor") === "page-2"
+            ? nextPage
+            : firstPageWithNextCursor
+        );
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Go to next page"));
+    expect(await screen.findByText("Collection Two")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Created At" })
+    );
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+    expect(
+      requests.some((search) => {
+        const params = new URLSearchParams(search);
+        return params.get("sort") === "created" && !params.has("cursor");
+      })
+    ).toBe(true);
+  });
+
   it("clears the selection after deleting a file collection successfully", async () => {
     const deletedIds: string[][] = [];
 
@@ -404,6 +493,24 @@ describe("FileCollectionTable", () => {
 
     expect(createdFrom).toHaveValue("");
     expect(createdTo).toHaveValue("2026-06-10");
+  });
+
+  it("renders an empty sorted result", async () => {
+    server.use(
+      http.get("*/api/file-collections", () => {
+        return HttpResponse.json(
+          fileCollectionsPage({ cursors: { self: "page-1" }, data: [] })
+        );
+      })
+    );
+
+    renderTable();
+
+    await userEvent.click(screen.getByRole("button", { name: "Name" }));
+
+    expect(
+      await screen.findByText("No file collections found.")
+    ).toBeInTheDocument();
   });
 
   it("navigates to the file collection detail route when a row is clicked", async () => {

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -134,7 +134,7 @@ describe("file collection API routes", () => {
     });
   });
 
-  it("passes a selected sort upstream and returns the service page", async () => {
+  it("passes a selected sort upstream and applies it locally", async () => {
     await expectFileCollectionList(
       {
         "page[size]": ["10"],
@@ -154,14 +154,45 @@ describe("file collection API routes", () => {
     expect(res.body()).toEqual({
       cursors: { next: "next-page", self: "self-page" },
       data: [
-        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
         collectionData("collection-2", "2026-06-11T15:30:00Z", "Alpha"),
+        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
       ],
       status: 200,
     });
     await verifyListFileCollections({
       "page[size]": ["10"],
       sort: ["-created"],
+    });
+  });
+
+  it("sorts file collections by name locally", async () => {
+    await expectFileCollectionList(
+      {
+        "page[size]": ["10"],
+        sort: ["name"],
+      },
+      [
+        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
+        collectionData("collection-2", "2026-06-11T15:30:00Z", "Alpha"),
+      ]
+    );
+    const res = await callFileCollections({
+      method: "GET",
+      query: { sort: "name" },
+    });
+
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      cursors: { next: "next-page", self: "self-page" },
+      data: [
+        collectionData("collection-2", "2026-06-11T15:30:00Z", "Alpha"),
+        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
+      ],
+      status: 200,
+    });
+    await verifyListFileCollections({
+      "page[size]": ["10"],
+      sort: ["name"],
     });
   });
 

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -134,6 +134,37 @@ describe("file collection API routes", () => {
     });
   });
 
+  it("passes a selected sort upstream and returns the service page", async () => {
+    await expectFileCollectionList(
+      {
+        "page[size]": ["10"],
+        sort: ["-created"],
+      },
+      [
+        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
+        collectionData("collection-2", "2026-06-11T15:30:00Z", "Alpha"),
+      ]
+    );
+    const res = await callFileCollections({
+      method: "GET",
+      query: { sort: "-created" },
+    });
+
+    expect(res.statusCode()).toBe(200);
+    expect(res.body()).toEqual({
+      cursors: { next: "next-page", self: "self-page" },
+      data: [
+        collectionData("collection-1", "2026-06-10T15:30:00Z", "Zulu"),
+        collectionData("collection-2", "2026-06-11T15:30:00Z", "Alpha"),
+      ],
+      status: 200,
+    });
+    await verifyListFileCollections({
+      "page[size]": ["10"],
+      sort: ["-created"],
+    });
+  });
+
   it("uses the default page size when one is not supplied", async () => {
     await expectFileCollectionList({ "page[size]": ["10"] });
 
@@ -441,12 +472,13 @@ function createRes(): TestRes {
 
 function collectionData(
   id: string,
-  created = "2026-06-10T15:30:00Z"
+  created = "2026-06-10T15:30:00Z",
+  name = "Collection One"
 ): JsonBody {
   return {
     attributes: {
       created,
-      name: "Collection One",
+      name,
       suppliedId: "supplied-1",
     },
     id,

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -23,6 +23,7 @@ import {
   toFileCollectionPage,
 } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import {
   CreatedAtDateRange,
   CreatedAtDateRangeFilter,
@@ -36,16 +37,19 @@ import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
 
 export const headCells: readonly HeadCell[] = [
-  { id: "name", disablePadding: true, label: "Name" },
+  { id: "name", disablePadding: true, label: "Name", sortable: true },
   { id: "id", label: "ID" },
   { id: "supplied-id", label: "Supplied ID" },
-  { id: "created", label: "Created At" },
+  { id: "created", label: "Created At", sortable: true },
 ];
 
 interface UseFileCollectionsProps extends SwrProps {
   readonly createdAtEnd?: string;
   readonly createdAtStart?: string;
+  readonly sort?: SortState<FileCollectionSortField>;
 }
+
+type FileCollectionSortField = "created" | "name";
 
 function useFileCollections({
   createdAtEnd,
@@ -53,6 +57,7 @@ function useFileCollections({
   cursor,
   name,
   pageSize,
+  sort,
   suppliedId,
 }: UseFileCollectionsProps) {
   return useSWR(
@@ -62,6 +67,7 @@ function useFileCollections({
       cursor,
       name,
       pageSize,
+      sort: sort != null ? toSortParam(sort) : undefined,
       suppliedId,
     })
   );
@@ -88,6 +94,9 @@ export default function FileCollectionTable({
   } = useCursorPagingState();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [name, setName] = React.useState<string | undefined>();
+  const [sort, setSort] = React.useState<
+    SortState<FileCollectionSortField> | undefined
+  >();
   const [suppliedId, setSuppliedId] = React.useState<string | undefined>();
   const [createdAtFilters, setCreatedAtFilters] =
     React.useState<CreatedAtDateRange>({});
@@ -99,6 +108,7 @@ export default function FileCollectionTable({
     cursor,
     name,
     pageSize,
+    sort,
     suppliedId,
   });
   const page = data ? toFileCollectionPage(data) : undefined;
@@ -133,6 +143,15 @@ export default function FileCollectionTable({
   function handleCreatedAtChange(filters: CreatedAtDateRange) {
     resetPaging();
     setCreatedAtFilters(filters);
+  }
+
+  function handleSortChange(field: string) {
+    if (field !== "created" && field !== "name") return;
+
+    setSort((current) =>
+      current == null ? { field, order: "asc" } : toggleSort(current, field)
+    );
+    resetPaging();
   }
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
@@ -294,7 +313,9 @@ export default function FileCollectionTable({
               headCells={headCells}
               numSelected={selected.size}
               onSelectAllClick={handleSelectAll}
+              onSortChange={handleSortChange}
               rowCount={pageLength}
+              sort={sort}
             />
             <TableBody>
               {tableRows}

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -32,6 +32,54 @@ export type GetFileCollectionRes = Res & {
   readonly export?: FileCollectionExportAvailability;
 };
 
+const FileCollectionSortFields = ["created", "name"] as const;
+type FileCollectionSortField = (typeof FileCollectionSortFields)[number];
+
+interface FileCollectionSort {
+  readonly field: FileCollectionSortField;
+  readonly order: "asc" | "desc";
+}
+
+/**
+ * Temporary client-side stand-in for the File Collections API sort contract.
+ *
+ * The dashboard forwards the selected sort upstream, but applies supported
+ * sorts here until the service honors the new query parameter.
+ */
+export function sortFileCollections(
+  fileCollections: FileCollectionList["data"],
+  sort?: string
+): FileCollectionList["data"] {
+  const parsedSort = parseFileCollectionSort(sort);
+  if (parsedSort == null) return fileCollections;
+
+  return [...fileCollections].sort((left, right) => {
+    const comparison = (left.attributes[parsedSort.field] ?? "").localeCompare(
+      right.attributes[parsedSort.field] ?? ""
+    );
+
+    return parsedSort.order === "asc" ? comparison : -comparison;
+  });
+}
+
+function parseFileCollectionSort(
+  sort?: string
+): FileCollectionSort | undefined {
+  if (sort == null) return undefined;
+
+  const order = sort.startsWith("-") ? "desc" : "asc";
+  const field = order === "desc" ? sort.slice(1) : sort;
+  if (!isFileCollectionSortField(field)) return undefined;
+
+  return { field, order };
+}
+
+function isFileCollectionSortField(
+  field: string
+): field is FileCollectionSortField {
+  return FileCollectionSortFields.includes(field as FileCollectionSortField);
+}
+
 export function toFileCollection(
   data: FileCollectionMetadataData
 ): FileCollection {

--- a/src/pages/api/file-collections.ts
+++ b/src/pages/api/file-collections.ts
@@ -22,7 +22,10 @@ import {
   ServerError,
   toErrorRes,
 } from "../../lib/api";
-import { getFileCollectionsApi } from "../../lib/file-collections";
+import {
+  getFileCollectionsApi,
+  sortFileCollections,
+} from "../../lib/file-collections";
 import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
@@ -103,7 +106,7 @@ async function get(
     );
     return {
       cursors,
-      data: page.data,
+      data: sortFileCollections(page.data, sort),
       status: 200,
     };
   } catch (error) {

--- a/src/pages/api/file-collections.ts
+++ b/src/pages/api/file-collections.ts
@@ -58,6 +58,7 @@ async function get(
     const suppliedId = head(req.query.suppliedId);
     const createdAtStart = head(req.query.createdAtStart);
     const createdAtEnd = head(req.query.createdAtEnd);
+    const sort = head(req.query.sort);
 
     const query = new URLSearchParams();
     if (pc != null) query.set("page[cursor]", pc);
@@ -74,6 +75,7 @@ async function get(
         ? ({ contains: suppliedId } satisfies FilterExpression)
         : undefined
     );
+    if (sort != null) query.set("sort", sort);
     setFilterExpression(
       query,
       "createdAt",


### PR DESCRIPTION
## Summary

Implements PLAT-8942, a child task of PLAT-8745, by adding File Collections sorting controls to Dev Dashboard.

- Makes the **Name** and **Created At** headers sortable; selecting a field applies ascending order and selecting it again applies descending order.
- Preserves the API default (creation time descending) by sending no sort parameter until a user selects a sortable header.
- Forwards selected sort parameters through the dashboard API and resets cursor pagination on every sort change.
- Applies the requested sort locally as a temporary compatibility fallback while the upstream File Collections service contract is being delivered.

## Test Plan

- `yarn test src/__tests__/components/file-collection/FileCollectionTable.test.tsx src/__tests__/lib/file-collections.test.ts --runInBand`
- `yarn test src/__tests__/pages/api/file-collections.test.ts --runInBand`
- `yarn lint`
- `yarn build`

## Release Notes

File Collections can now be sorted by name or creation time in either direction.

## Possible Regressions

The dashboard temporarily applies selected sorts locally when the upstream service does not yet honor the sort parameter. Cursor pagination is reset on each sort change to avoid stale cursor results.