### PR TITLE
[PLAT-8940] Fix cursor pagination footer labels

### DIFF
--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -21,6 +21,7 @@ import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
 import { File, toFilePage } from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -243,6 +244,12 @@ export default function FileCollectionFilesTable({
           rowsPerPageOptions={[]}
           component="div"
           count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(
+              displayedRows,
+              paginationCursors?.next != null
+            )
+          }
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -247,7 +247,9 @@ export default function FileCollectionFilesTable({
           labelDisplayedRows={(displayedRows) =>
             formatCursorPaginationLabel(
               displayedRows,
-              paginationCursors?.next != null
+              paginationCursors?.next != null,
+              pageLength,
+              page != null
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -245,7 +245,12 @@ export default function FileCollectionTable(): JSX.Element {
           component="div"
           count={-1}
           labelDisplayedRows={(displayedRows) =>
-            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+            formatCursorPaginationLabel(
+              displayedRows,
+              cursors?.next != null,
+              pageLength,
+              page != null
+            )
           }
           rowsPerPage={pageSize}
           page={currentPage}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -20,6 +20,7 @@ import useSWR from "swr";
 import { toLocaleString } from "../../lib/dates";
 import { toFileCollectionPage } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -243,6 +244,9 @@ export default function FileCollectionTable(): JSX.Element {
           rowsPerPageOptions={[]}
           component="div"
           count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+          }
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -26,6 +26,7 @@ import { toLocaleString } from "../../lib/dates";
 import { File, toFilePage } from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -529,6 +530,12 @@ export default function FileTable({
           rowsPerPageOptions={[]}
           component="div"
           count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(
+              displayedRows,
+              paginationCursors?.next != null
+            )
+          }
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -533,7 +533,9 @@ export default function FileTable({
           labelDisplayedRows={(displayedRows) =>
             formatCursorPaginationLabel(
               displayedRows,
-              paginationCursors?.next != null
+              paginationCursors?.next != null,
+              pageLength,
+              visiblePage != null
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -22,6 +22,7 @@ import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartPage } from "../../lib/parts";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -219,6 +220,9 @@ export default function PartTable({
           rowsPerPageOptions={[]}
           component="div"
           count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+          }
           rowsPerPage={pageSize}
           page={currentPage}
           onPageChange={handleChangePage}

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -221,7 +221,12 @@ export default function PartTable({
           component="div"
           count={-1}
           labelDisplayedRows={(displayedRows) =>
-            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+            formatCursorPaginationLabel(
+              displayedRows,
+              cursors?.next != null,
+              pageLength,
+              page != null
+            )
           }
           rowsPerPage={pageSize}
           page={currentPage}

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -388,7 +388,12 @@ export default function SceneTable({
           component="div"
           count={-1}
           labelDisplayedRows={(displayedRows) =>
-            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+            formatCursorPaginationLabel(
+              displayedRows,
+              cursors?.next != null,
+              pageLength,
+              page != null
+            )
           }
           rowsPerPage={pageSize}
           page={curPage}

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -36,6 +36,7 @@ import { SwrProps } from "../../lib/paging";
 import { Scene, toScenePage } from "../../lib/scenes";
 import { encodeCreds } from "../../pages/scene-viewer/[sceneId]";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
 import { SkeletonBody } from "../shared/SkeletonBody";
@@ -386,6 +387,9 @@ export default function SceneTable({
           rowsPerPageOptions={[]}
           component="div"
           count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(displayedRows, cursors?.next != null)
+          }
           rowsPerPage={pageSize}
           page={curPage}
           onPageChange={handleChangePage}

--- a/src/components/shared/cursor-pagination.ts
+++ b/src/components/shared/cursor-pagination.ts
@@ -1,0 +1,14 @@
+import { TablePaginationProps } from "@mui/material/TablePagination";
+
+type DisplayedRows = Parameters<
+  NonNullable<TablePaginationProps["labelDisplayedRows"]>
+>[0];
+
+export function formatCursorPaginationLabel(
+  { from, to }: DisplayedRows,
+  hasNextPage: boolean
+): string {
+  const visibleRange = `${from}\u2013${to}`;
+
+  return hasNextPage ? `${visibleRange} of more than ${to}` : visibleRange;
+}

--- a/src/components/shared/cursor-pagination.ts
+++ b/src/components/shared/cursor-pagination.ts
@@ -6,9 +6,17 @@ type DisplayedRows = Parameters<
 
 export function formatCursorPaginationLabel(
   { from, to }: DisplayedRows,
-  hasNextPage: boolean
+  hasNextPage: boolean,
+  visibleRowCount: number,
+  isLoaded: boolean
 ): string {
-  const visibleRange = `${from}\u2013${to}`;
+  if (!isLoaded) return `${from}\u2013${to}`;
+  if (isLoaded && visibleRowCount === 0) return "0–0";
 
-  return hasNextPage ? `${visibleRange} of more than ${to}` : visibleRange;
+  const visibleTo = hasNextPage ? to : from + visibleRowCount - 1;
+  const visibleRange = `${from}\u2013${visibleTo}`;
+
+  return hasNextPage
+    ? `${visibleRange} of more than ${visibleTo}`
+    : visibleRange;
 }


### PR DESCRIPTION
## Summary
- add a shared cursor pagination footer formatter
- show `X–Y` on terminal cursor-paginated pages with no next cursor
- apply the shared footer label behavior across files, file collections, collection files, parts, and scenes tables

## Verification
- `./node_modules/.bin/eslint --no-eslintrc -c .eslintrc.js --ext .ts,.tsx src`
- `yarn test`
- `yarn build`