### PR TITLE
PLAT-8935 Make resource table navigation and row actions consistent

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -83,7 +83,10 @@ describe("FileCollectionFilesTable", () => {
     });
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Download File One" })
+      screen.getByRole("button", { name: "Actions for File One" })
+    );
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Download file" })
     );
 
     await waitFor(() => {
@@ -121,8 +124,12 @@ describe("FileCollectionFilesTable", () => {
     expect(await screen.findByText("File One")).toBeInTheDocument();
     expect(screen.getByText("pending")).toBeInTheDocument();
 
-    const download = screen.getByRole("button", { name: "Download File One" });
-    expect(download).toBeDisabled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Actions for File One" })
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Download file" })
+    ).toHaveAttribute("aria-disabled", "true");
 
     expect(fetchMock).not.toHaveBeenCalledWith(
       "/api/files/file-1/download-url",
@@ -181,8 +188,12 @@ describe("FileCollectionFilesTable", () => {
 
     expect(await screen.findByText("completed")).toBeInTheDocument();
 
-    const download = screen.getByRole("button", { name: "Download File One" });
-    expect(download).toBeDisabled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Actions for File One" })
+    );
+    expect(
+      screen.getByRole("menuitem", { name: "Download file" })
+    ).toHaveAttribute("aria-disabled", "true");
 
     expect(fetchMock).not.toHaveBeenCalledWith(
       "/api/files/file-1/download-url",

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -1,8 +1,6 @@
-import { Download } from "@mui/icons-material";
 import {
   Alert,
   Chip,
-  IconButton,
   Paper,
   Snackbar,
   Table,
@@ -12,7 +10,6 @@ import {
   TableHead,
   TablePagination,
   TableRow,
-  Tooltip,
 } from "@mui/material";
 import React from "react";
 import useSWR from "swr";
@@ -23,6 +20,8 @@ import { File, toFilePage } from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
+import { ResourceLink } from "../shared/ResourceLink";
+import { RowActionsMenu } from "../shared/RowActionsMenu";
 import { SkeletonBody } from "../shared/SkeletonBody";
 import { TableToolbar } from "../shared/TableToolbar";
 
@@ -43,7 +42,7 @@ const headCells = [
   { id: "id", label: "ID" },
   { id: "created", label: "Created" },
   { id: "uploaded", label: "Uploaded" },
-  { id: "download", label: "Download" },
+  { id: "actions", label: "Actions" },
 ] as const;
 
 function useCollectionFiles({
@@ -163,15 +162,11 @@ export default function FileCollectionFilesTable({
       const isAvailable = isFileAvailable(row);
 
       return (
-        <TableRow
-          hover
-          tabIndex={-1}
-          key={row.id}
-          selected={isActive}
-          onClick={() => onFileSelected(row)}
-        >
+        <TableRow hover tabIndex={-1} key={row.id} selected={isActive}>
           <TableCell component="th" scope="row">
-            {row.name}
+            <ResourceLink onOpen={() => onFileSelected(row)}>
+              {row.name}
+            </ResourceLink>
           </TableCell>
           <TableCell>{row.suppliedId}</TableCell>
           <TableCell>
@@ -191,25 +186,16 @@ export default function FileCollectionFilesTable({
               e.stopPropagation();
             }}
           >
-            <Tooltip
-              title={
-                isAvailable ? "Download file" : "File is not available yet"
-              }
-            >
-              <span>
-                <IconButton
-                  aria-label={`Download ${row.name}`}
-                  disabled={!isAvailable}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (isAvailable) handleDownload(row.id);
-                  }}
-                  size="small"
-                >
-                  <Download fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
+            <RowActionsMenu
+              actions={[
+                {
+                  disabled: !isAvailable,
+                  label: "Download file",
+                  onClick: () => handleDownload(row.id),
+                },
+              ]}
+              ariaLabel={`Actions for ${row.name}`}
+            />
           </TableCell>
         </TableRow>
       );

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -22,6 +22,7 @@ import { toFileCollectionPage } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
+import { ResourceLink } from "../shared/ResourceLink";
 import { SkeletonBody } from "../shared/SkeletonBody";
 import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
@@ -155,8 +156,6 @@ export default function FileCollectionTable(): JSX.Element {
           tabIndex={-1}
           key={row.id}
           selected={isSel}
-          style={{ cursor: "pointer" }}
-          onClick={() => handleViewFiles(row.id)}
         >
           <TableCell
             padding="checkbox"
@@ -175,7 +174,12 @@ export default function FileCollectionTable(): JSX.Element {
             />
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
-            {row.name}
+            <ResourceLink
+              href={`/file-collections/${encodeURIComponent(row.id)}`}
+              onOpen={() => handleViewFiles(row.id)}
+            >
+              {row.name}
+            </ResourceLink>
           </TableCell>
           <TableCell>{row.id}</TableCell>
           <TableCell>{row.suppliedId}</TableCell>

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -1,11 +1,10 @@
-import { Add, Download } from "@mui/icons-material";
+import { Add } from "@mui/icons-material";
 import {
   Alert,
   Box,
   Button,
   Checkbox,
   Chip,
-  IconButton,
   Paper,
   Snackbar,
   Table,
@@ -15,7 +14,6 @@ import {
   TablePagination,
   TableRow,
   TextField,
-  Tooltip,
 } from "@mui/material";
 import debounce from "lodash.debounce";
 import React from "react";
@@ -28,6 +26,8 @@ import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
+import { ResourceLink } from "../shared/ResourceLink";
+import { RowActionsMenu } from "../shared/RowActionsMenu";
 import { SkeletonBody } from "../shared/SkeletonBody";
 import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
@@ -40,7 +40,7 @@ export const headCells: readonly HeadCell[] = [
   { id: "id", label: "ID" },
   { id: "created", label: "Created", sortable: true },
   { id: "uploaded", label: "Uploaded" },
-  { id: "download", label: "Download" },
+  { id: "actions", label: "Actions" },
 ];
 
 interface UseFilesProps extends SwrProps {
@@ -336,7 +336,6 @@ export default function FileTable({
           tabIndex={-1}
           key={row.id}
           selected={isSel || isActive}
-          onClick={() => onFileSelected(row)}
         >
           <TableCell
             padding="checkbox"
@@ -354,7 +353,9 @@ export default function FileTable({
             />
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
-            {row.name}
+            <ResourceLink onOpen={() => onFileSelected(row)}>
+              {row.name}
+            </ResourceLink>
           </TableCell>
           <TableCell>{row.suppliedId}</TableCell>
           <TableCell>
@@ -374,25 +375,16 @@ export default function FileTable({
               e.stopPropagation();
             }}
           >
-            <Tooltip
-              title={
-                isAvailable ? "Download file" : "File is not available yet"
-              }
-            >
-              <span>
-                <IconButton
-                  aria-label={`Download ${row.name}`}
-                  disabled={!isAvailable}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    if (isAvailable) handleDownload(row.id);
-                  }}
-                  size="small"
-                >
-                  <Download fontSize="small" />
-                </IconButton>
-              </span>
-            </Tooltip>
+            <RowActionsMenu
+              actions={[
+                {
+                  disabled: !isAvailable,
+                  label: "Download file",
+                  onClick: () => handleDownload(row.id),
+                },
+              ]}
+              ariaLabel={`Actions for ${row.name}`}
+            />
           </TableCell>
         </TableRow>
       );

--- a/src/components/part/PartRow.tsx
+++ b/src/components/part/PartRow.tsx
@@ -1,6 +1,5 @@
-import { Add, KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
+import { KeyboardArrowDown, KeyboardArrowUp } from "@mui/icons-material";
 import {
-  Button,
   Checkbox,
   Collapse,
   IconButton,
@@ -18,6 +17,8 @@ import { Paged } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartRevisionPage } from "../../lib/part-revisions";
 import { Part } from "../../lib/parts";
+import { ResourceLink } from "../shared/ResourceLink";
+import { RowActionsMenu } from "../shared/RowActionsMenu";
 
 interface PartRowProps {
   readonly activeRevisionId?: string;
@@ -106,26 +107,28 @@ export default function PartRow({
                     <TableRow
                       key={r.id}
                       hover
-                      onClick={() => onRevisionSelected(r)}
                       selected={activeRevisionId === r.id}
                       sx={{ "&:last-child td, &:last-child th": { border: 0 } }}
                     >
-                      <TableCell> {r.name} </TableCell>
+                      <TableCell>
+                        <ResourceLink onOpen={() => onRevisionSelected(r)}>
+                          {r.name}
+                        </ResourceLink>
+                      </TableCell>
                       <TableCell> {r.id} </TableCell>
                       <TableCell>{r.suppliedId}</TableCell>
                       <TableCell>{r.suppliedIterationId}</TableCell>
                       <TableCell>{toLocaleString(r.created)}</TableCell>
                       <TableCell align="right">
-                        <Button
-                          color="secondary"
-                          startIcon={<Add />}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onCreteSceneFromRevision(r.id);
-                          }}
-                        >
-                          New Scene
-                        </Button>
+                        <RowActionsMenu
+                          actions={[
+                            {
+                              label: "New scene",
+                              onClick: () => onCreteSceneFromRevision(r.id),
+                            },
+                          ]}
+                          ariaLabel={`Actions for ${r.name}`}
+                        />
                       </TableCell>
                     </TableRow>
                   ))}

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -1,17 +1,10 @@
-import {
-  EditOutlined,
-  MergeTypeOutlined,
-  VisibilityOutlined,
-  VpnKeyOutlined,
-} from "@mui/icons-material";
+import { MergeTypeOutlined } from "@mui/icons-material";
 import {
   Alert,
   Box,
   Button,
   Checkbox,
   Chip,
-  CircularProgress,
-  IconButton,
   Paper,
   Snackbar,
   Table,
@@ -21,7 +14,6 @@ import {
   TablePagination,
   TableRow,
   TextField,
-  Tooltip,
 } from "@mui/material";
 import { Cursors, SceneData } from "@vertexvis/api-client-node";
 import { Environment } from "@vertexvis/viewer";
@@ -38,6 +30,8 @@ import { encodeCreds } from "../../pages/scene-viewer/[sceneId]";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
+import { ResourceLink } from "../shared/ResourceLink";
+import { RowActionsMenu } from "../shared/RowActionsMenu";
 import { SkeletonBody } from "../shared/SkeletonBody";
 import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
@@ -304,7 +298,6 @@ export default function SceneTable({
                       tabIndex={-1}
                       key={row.id}
                       selected={isSel}
-                      onClick={() => handleClick(row)}
                     >
                       <TableCell
                         padding="checkbox"
@@ -316,7 +309,9 @@ export default function SceneTable({
                         <Checkbox color="primary" checked={isSel} />
                       </TableCell>
                       <TableCell component="th" scope="row" padding="none">
-                        {row.name}
+                        <ResourceLink onOpen={() => handleClick(row)}>
+                          {row.name}
+                        </ResourceLink>
                       </TableCell>
                       <TableCell>{row.suppliedId}</TableCell>
                       <TableCell>
@@ -331,44 +326,26 @@ export default function SceneTable({
                       <TableCell>{row.id}</TableCell>
                       <TableCell>{toLocaleString(row.created)}</TableCell>
                       <TableCell>
-                        <>
-                          {keyLoadingSceneId === row.id && (
-                            <CircularProgress
-                              size={36}
-                              sx={{ position: "absolute" }}
-                            />
-                          )}
-                          <Tooltip title="Generate stream key">
-                            <IconButton
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleGetStreamKey(row.id);
-                              }}
-                            >
-                              <VpnKeyOutlined fontSize="small" />
-                            </IconButton>
-                          </Tooltip>
-                        </>
-                        <Tooltip title="View scene">
-                          <IconButton
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleViewClick(row.id);
-                            }}
-                          >
-                            <VisibilityOutlined />
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Edit scene">
-                          <IconButton
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleEditClick(row);
-                            }}
-                          >
-                            <EditOutlined />
-                          </IconButton>
-                        </Tooltip>
+                        <RowActionsMenu
+                          actions={[
+                            {
+                              disabled: keyLoadingSceneId === row.id,
+                              label: "Generate stream key",
+                              onClick: () => handleGetStreamKey(row.id),
+                            },
+                            {
+                              disabled: !clientId,
+                              label: "View scene",
+                              onClick: () => handleViewClick(row.id),
+                            },
+                            {
+                              label: "Edit scene",
+                              onClick: () => handleEditClick(row),
+                            },
+                          ]}
+                          ariaLabel={`Actions for ${row.name}`}
+                          loading={keyLoadingSceneId === row.id}
+                        />
                       </TableCell>
                     </TableRow>
                   );

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -1,0 +1,29 @@
+import { Link as MuiLink, LinkProps as MuiLinkProps } from "@mui/material";
+import React from "react";
+
+type ResourceLinkProps = Omit<MuiLinkProps, "href"> & {
+  readonly href?: string;
+  readonly onOpen: () => void;
+};
+
+export function ResourceLink({
+  children,
+  href = "#",
+  onOpen,
+  ...props
+}: ResourceLinkProps): JSX.Element {
+  return (
+    <MuiLink
+      href={href}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onOpen();
+      }}
+      underline="hover"
+      {...props}
+    >
+      {children}
+    </MuiLink>
+  );
+}

--- a/src/components/shared/RowActionsMenu.tsx
+++ b/src/components/shared/RowActionsMenu.tsx
@@ -1,0 +1,79 @@
+import { MoreHoriz } from "@mui/icons-material";
+import {
+  CircularProgress,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import React from "react";
+
+export interface RowAction {
+  readonly disabled?: boolean;
+  readonly label: string;
+  readonly onClick: () => void | Promise<void>;
+}
+
+interface RowActionsMenuProps {
+  readonly actions: readonly RowAction[];
+  readonly ariaLabel: string;
+  readonly loading?: boolean;
+}
+
+export function RowActionsMenu({
+  actions,
+  ariaLabel,
+  loading = false,
+}: RowActionsMenuProps): JSX.Element | null {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLElement | null>(null);
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  const open = anchorEl != null;
+
+  return (
+    <>
+      <IconButton
+        aria-label={ariaLabel}
+        onClick={(event) => {
+          event.stopPropagation();
+          setAnchorEl(event.currentTarget);
+        }}
+        size="small"
+      >
+        {loading ? (
+          <CircularProgress size={18} />
+        ) : (
+          <MoreHoriz fontSize="small" />
+        )}
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {actions.map((action) => (
+          <MenuItem
+            key={action.label}
+            disabled={action.disabled}
+            onClick={() => {
+              setAnchorEl(null);
+              void action.onClick();
+            }}
+          >
+            {loading && action.label === "Generate stream key" ? (
+              <ListItemIcon>
+                <CircularProgress size={16} />
+              </ListItemIcon>
+            ) : null}
+            <ListItemText>{action.label}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- make resource names trigger the default open/detail action through a consistent link pattern
- move secondary row actions into a shared ellipsis menu for files, scenes, collection files, and part revisions
- update file collection files tests to cover the new action-menu interaction

## Verification
- yarn test
- yarn build