### PR TITLE
Share file collection API types with MSW

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -146,7 +146,10 @@ function stubFileCollectionsTable({
   deleteOptions,
 }: {
   readonly byCursor?: Record<string, ReturnType<typeof fileCollectionsPage>>;
-  readonly bySuppliedId?: Record<string, ReturnType<typeof fileCollectionsPage>>;
+  readonly bySuppliedId?: Record<
+    string,
+    ReturnType<typeof fileCollectionsPage>
+  >;
   readonly defaultPage: ReturnType<typeof fileCollectionsPage>;
   readonly deleteOptions?: Parameters<typeof deleteFileCollections>[0];
 }): void {

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -5,11 +5,18 @@ import {
   VertexClient,
 } from "@vertexvis/api-client-node";
 
-import { GetRes } from "./api";
+import type { GetRes, Res } from "./api";
 import { Paged, toPage } from "./paging";
 
-export type FileCollection = FileCollectionList["data"][number]["attributes"] &
-  Pick<FileCollectionList["data"][number], "id">;
+export type FileCollectionResource = FileCollectionList["data"][number];
+export type FileCollectionAttributes = FileCollectionResource["attributes"];
+export type FileCollectionPageRes = GetRes<FileCollectionResource>;
+export type FileCollectionDetailRes = Res & {
+  readonly data: FileCollectionResource;
+};
+
+export type FileCollection = FileCollectionAttributes &
+  Pick<FileCollectionResource, "id">;
 
 export function toFileCollection(
   data: FileCollectionMetadataData
@@ -18,12 +25,9 @@ export function toFileCollection(
 }
 
 export function toFileCollectionPage(
-  res: GetRes<FileCollectionList["data"][number]>
+  res: FileCollectionPageRes
 ): Paged<FileCollection> {
-  return toPage<
-    FileCollectionList["data"][number],
-    FileCollectionList["data"][number]["attributes"]
-  >(res);
+  return toPage<FileCollectionResource, FileCollectionAttributes>(res);
 }
 
 export function getFileCollectionsApi(

--- a/test/msw/handlers/file-collections.ts
+++ b/test/msw/handlers/file-collections.ts
@@ -1,37 +1,21 @@
 import { rest, RestHandler } from "msw";
 
-interface FileCollectionAttributes {
-  readonly created: string;
-  readonly name: string;
-  readonly suppliedId?: string;
-}
-
-interface FileCollectionResource {
-  readonly attributes: FileCollectionAttributes;
-  readonly id: string;
-  readonly type: "file-collection";
-}
-
-interface FileCollectionsPage {
-  readonly cursors: {
-    readonly next?: string;
-    readonly self?: string;
-  };
-  readonly data: readonly FileCollectionResource[];
-  readonly status: 200;
-}
+import type { DeleteReq, ErrorRes, Res } from "../../../src/lib/api";
+import type {
+  FileCollectionPageRes,
+  FileCollectionResource,
+} from "../../../src/lib/file-collections";
 
 interface FileCollectionsQueryMap {
-  readonly byCursor?: Record<string, FileCollectionsPage>;
-  readonly bySuppliedId?: Record<string, FileCollectionsPage>;
-  readonly defaultPage: FileCollectionsPage;
+  readonly byCursor?: Record<string, FileCollectionPageRes>;
+  readonly bySuppliedId?: Record<string, FileCollectionPageRes>;
+  readonly defaultPage: FileCollectionPageRes;
 }
 
 interface DeleteFileCollectionsOptions {
   readonly expectedIds?: readonly string[];
-  readonly response?: {
+  readonly response?: Res & {
     readonly body: Record<string, unknown>;
-    readonly status: number;
   };
 }
 
@@ -61,7 +45,7 @@ export function fileCollectionsPage({
     readonly self?: string;
   };
   readonly data: readonly FileCollectionResource[];
-}): FileCollectionsPage {
+}): FileCollectionPageRes {
   return {
     cursors,
     data,
@@ -113,7 +97,7 @@ export function deleteFileCollections(
   };
 
   return rest.delete("*/api/file-collections", async (req, res, ctx) => {
-    const body = (await req.json()) as { ids?: string[] };
+    const body = (await req.json()) as Partial<DeleteReq>;
     const ids = body.ids ?? [];
 
     if (
@@ -122,13 +106,16 @@ export function deleteFileCollections(
     ) {
       return res(
         ctx.status(400),
-        ctx.json({
+        ctx.json<ErrorRes>({
           message: "Unexpected file collection delete payload.",
           status: 400,
         })
       );
     }
 
-    return res(ctx.status(successResponse.status), ctx.json(successResponse.body));
+    return res(
+      ctx.status(successResponse.status),
+      ctx.json(successResponse.body)
+    );
   });
 }

--- a/test/msw/handlers/file-collections.ts
+++ b/test/msw/handlers/file-collections.ts
@@ -48,7 +48,7 @@ export function fileCollectionsPage({
 }): FileCollectionPageRes {
   return {
     cursors,
-    data,
+    data: [...data],
     status: 200,
   };
 }

--- a/test/msw/install.ts
+++ b/test/msw/install.ts
@@ -10,12 +10,12 @@ interface FetchApis {
 function createRelativeUrlFetch(nativeFetch: typeof fetch): typeof fetch {
   return ((
     input: RequestInfo | URL,
-    init?: RequestInit,
+    init?: RequestInit
   ): Promise<globalThis.Response> => {
     if (typeof input === "string" || input instanceof URL) {
       return nativeFetch(
         new URL(input.toString(), "http://localhost").toString(),
-        init,
+        init
       );
     }
 


### PR DESCRIPTION
## Summary
- export file collection API response aliases from the shared file-collections lib
- update the file-collection MSW handlers to use those shared API contract types
- keep MSW scenario-wiring types local to the test helper

## Testing
- yarn lint
- yarn test src/__tests__/components/file-collection/FileCollectionTable.test.tsx --runInBand