### PR TITLE
[PLAT-8772] Update scene filters for partial matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.18.0",
     "@mui/material": "^5.18.0",
-    "@vertexvis/api-client-node": "0.43.0",
+    "@vertexvis/api-client-node": "0.44.0",
     "@vertexvis/geometry": "^0.24.2",
     "@vertexvis/viewer-react": "^0.24.2",
     "filesize": "^11.0.17",

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -266,7 +266,7 @@ export default function SceneTable({
             size="small"
             margin="normal"
             id="nameFilter"
-            label="Name Filter (exact)"
+            label="Name Filter"
             type="text"
             onChange={(e) => {
               debouncedSetNameFilter(e.target.value?.trim() ?? undefined);
@@ -278,7 +278,7 @@ export default function SceneTable({
             size="small"
             margin="normal"
             id="suppliedIdFilter"
-            label="Supplied ID Filter (exact)"
+            label="Supplied ID Filter"
             type="text"
             onChange={(e) => {
               debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? undefined);

--- a/src/pages/api/scenes.ts
+++ b/src/pages/api/scenes.ts
@@ -7,11 +7,13 @@ import {
   PartDataRelationshipsPartRevisionsTypeEnum,
   QueuedJobData,
   SceneData,
+  SceneList,
   ScenesApiUpdateSceneRequest,
   UpdateSceneRequestDataAttributes,
   UpdateSceneRequestDataAttributesStateEnum,
   VertexError,
 } from "@vertexvis/api-client-node";
+import { AxiosResponse } from "axios";
 import { NextApiResponse } from "next";
 
 import {
@@ -25,6 +27,7 @@ import {
   ServerError,
   toErrorRes,
 } from "../../lib/api";
+import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
@@ -84,16 +87,24 @@ async function get(
       n != null ? ({ contains: n } satisfies FilterExpression) : undefined;
     const filterSuppliedId =
       sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined;
+    const query = new URLSearchParams();
+    if (pc != null) query.set("page[cursor]", pc);
+    query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
+    query.set(
+      "fields[scene]",
+      "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
+    );
+    setFilterExpression(query, "name", filterName);
+    setFilterExpression(query, "suppliedId", filterSuppliedId);
 
-    const { cursors, page } = await getPage(() =>
-      c.scenes.getScenes({
-        pageCursor: pc,
-        pageSize: parsePositiveQueryInt(ps, 10),
-        filterSuppliedId,
-        filterName,
-        fieldsScene:
-          "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount",
-      })
+    const { cursors, page } = await getPage(
+      () =>
+        c.axiosInstance.get(`${c.config.basePath}/scenes?${query.toString()}`, {
+          headers: {
+            Accept: "application/vnd.api+json",
+            Authorization: `Bearer ${c.token.access_token}`,
+          },
+        }) as Promise<AxiosResponse<SceneList>>
     );
     return { cursors, data: page.data, status: 200 };
   } catch (error) {

--- a/src/pages/api/scenes.ts
+++ b/src/pages/api/scenes.ts
@@ -7,13 +7,11 @@ import {
   PartDataRelationshipsPartRevisionsTypeEnum,
   QueuedJobData,
   SceneData,
-  SceneList,
   ScenesApiUpdateSceneRequest,
   UpdateSceneRequestDataAttributes,
   UpdateSceneRequestDataAttributesStateEnum,
   VertexError,
 } from "@vertexvis/api-client-node";
-import { AxiosResponse } from "axios";
 import { NextApiResponse } from "next";
 
 import {
@@ -27,7 +25,6 @@ import {
   ServerError,
   toErrorRes,
 } from "../../lib/api";
-import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
@@ -87,24 +84,16 @@ async function get(
       n != null ? ({ contains: n } satisfies FilterExpression) : undefined;
     const filterSuppliedId =
       sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined;
-    const query = new URLSearchParams();
-    if (pc != null) query.set("page[cursor]", pc);
-    query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
-    query.set(
-      "fields[scene]",
-      "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
-    );
-    setFilterExpression(query, "name", filterName);
-    setFilterExpression(query, "suppliedId", filterSuppliedId);
 
-    const { cursors, page } = await getPage(
-      () =>
-        c.axiosInstance.get(`${c.config.basePath}/scenes?${query.toString()}`, {
-          headers: {
-            Accept: "application/vnd.api+json",
-            Authorization: `Bearer ${c.token.access_token}`,
-          },
-        }) as Promise<AxiosResponse<SceneList>>
+    const { cursors, page } = await getPage(() =>
+      c.scenes.getScenes({
+        pageCursor: pc,
+        pageSize: parsePositiveQueryInt(ps, 10),
+        filterSuppliedId,
+        filterName,
+        fieldsScene:
+          "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount",
+      })
     );
     return { cursors, data: page.data, status: 200 };
   } catch (error) {

--- a/src/pages/api/scenes.ts
+++ b/src/pages/api/scenes.ts
@@ -1,16 +1,19 @@
 import {
   CreateSceneRequestDataAttributes,
+  FilterExpression,
   getPage,
   head,
   logError,
   PartDataRelationshipsPartRevisionsTypeEnum,
   QueuedJobData,
   SceneData,
+  SceneList,
   ScenesApiUpdateSceneRequest,
   UpdateSceneRequestDataAttributes,
   UpdateSceneRequestDataAttributesStateEnum,
   VertexError,
 } from "@vertexvis/api-client-node";
+import { AxiosResponse } from "axios";
 import { NextApiResponse } from "next";
 
 import {
@@ -24,6 +27,7 @@ import {
   ServerError,
   toErrorRes,
 } from "../../lib/api";
+import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
@@ -79,16 +83,28 @@ async function get(
     const pc = head(req.query.cursor);
     const sId = head(req.query.suppliedId);
     const n = head(req.query.name);
+    const filterName =
+      n != null ? ({ contains: n } satisfies FilterExpression) : undefined;
+    const filterSuppliedId =
+      sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined;
+    const query = new URLSearchParams();
+    if (pc != null) query.set("page[cursor]", pc);
+    query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
+    query.set(
+      "fields[scene]",
+      "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
+    );
+    setFilterExpression(query, "name", filterName);
+    setFilterExpression(query, "suppliedId", filterSuppliedId);
 
-    const { cursors, page } = await getPage(() =>
-      c.scenes.getScenes({
-        pageCursor: pc,
-        pageSize: parsePositiveQueryInt(ps, 10),
-        filterSuppliedId: sId,
-        filterName: n,
-        fieldsScene:
-          "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount",
-      })
+    const { cursors, page } = await getPage(
+      () =>
+        c.axiosInstance.get(`${c.config.basePath}/scenes?${query.toString()}`, {
+          headers: {
+            Accept: "application/vnd.api+json",
+            Authorization: `Bearer ${c.token.access_token}`,
+          },
+        }) as Promise<AxiosResponse<SceneList>>
     );
     return { cursors, data: page.data, status: 200 };
   } catch (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,10 +1844,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@vertexvis/api-client-node@0.43.0":
-  version "0.43.0"
-  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.43.0.tgz#cc514432d13ec0d7fd0c2370e06efd2b822576e1"
-  integrity sha512-JuZWQesS1avDH9G4hxBlWeA88C2mwNzKiac6mMPV+0Rg7n5eCiSJf/HA3gwlG+XCiM50ofoRTUndvaepRhQhSg==
+"@vertexvis/api-client-node@0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@vertexvis/api-client-node/-/api-client-node-0.44.0.tgz#355c763454c11b6247f6d3d53d7681be2a75ff69"
+  integrity sha512-o0P+rHeCPh5TQeAA9D0Tled8c5DetIMbgghdbECnzywzvBCZvHy26Z1Vi/kV8V5ZEtkzyvEdyVVTmE6Y/s2mkw==
   dependencies:
     axios "1.18.0"
     p-limit "^3"


### PR DESCRIPTION
## Summary
- update the scene API route to send canonical `filter[name][contains]` and `filter[suppliedId][contains]` query parameters to Vertex API
- keep using the existing cursor pagination flow while bridging the older scene SDK surface with a raw authenticated request
- remove `(exact)` from the scene filter labels to match the new partial-match behavior

## Validation
- `./node_modules/.bin/prettier --write src/components/scene/SceneTable.tsx src/pages/api/scenes.ts`
- `yarn lint`