### PR TITLE
[PLAT-8929] Fail builds on format issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
         with: { node-version: 22.x }
       - name: Install
         run: yarn install --frozen-lockfile
+      - name: Format Check
+        run: yarn format:check
       - name: Lint
         run: yarn lint
       - name: Test

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clean": "rm -rf .next/ node_modules/",
     "dev": "next",
     "format": "prettier --write './**/*.+(js|jsx|ts|tsx|json|yml|yaml|md|mdx|html|css)'",
+    "format:check": "prettier --check './**/*.+(js|jsx|ts|tsx|json|yml|yaml|md|mdx|html|css)'",
     "lint": "next lint",
     "start": "next start",
     "setup": "bash scripts/setup.sh",

--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http,HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 import React from "react";
 
 import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
@@ -288,9 +288,7 @@ function mockFileCollectionFilesApi({
   );
 }
 
-function filePage(
-  data: ReturnType<typeof fileResource>[]
-): {
+function filePage(data: ReturnType<typeof fileResource>[]): {
   cursors: { self: string };
   data: ReturnType<typeof fileResource>[];
   status: number;

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -158,10 +158,7 @@ describe("FileCollectionTable", () => {
 
     expect(await screen.findByText("Collection One")).toBeInTheDocument();
 
-    await userEvent.type(
-      screen.getByLabelText("Supplied ID"),
-      "supplied-2"
-    );
+    await userEvent.type(screen.getByLabelText("Supplied ID"), "supplied-2");
 
     expect(await screen.findByText("Collection Two")).toBeInTheDocument();
     expect(screen.queryByText("Collection One")).not.toBeInTheDocument();
@@ -245,9 +242,7 @@ describe("FileCollectionTable", () => {
         requests.push(url.search);
 
         return HttpResponse.json(
-          url.searchParams.get("suppliedId") === "LIED-2"
-            ? nextPage
-            : firstPage
+          url.searchParams.get("suppliedId") === "LIED-2" ? nextPage : firstPage
         );
       })
     );

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http,HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 import React from "react";
 
 import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { http,HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 import React from "react";
 
 import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";

--- a/src/components/file-collection/FileCollectionMetadataTable.tsx
+++ b/src/components/file-collection/FileCollectionMetadataTable.tsx
@@ -1,12 +1,4 @@
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-} from "@mui/material";
+import { Box, Typography } from "@mui/material";
 
 import { toLocaleString } from "../../lib/dates";
 import { FileCollection } from "../../lib/file-collections";
@@ -21,125 +13,73 @@ export function FileCollectionMetadataTable({
   fileCollection,
   optionalFieldStatus = "ready",
 }: Props): JSX.Element {
-  return (
-    <TableContainer>
-      <Table size="small" sx={{ whiteSpace: "nowrap" }}>
-        <TableBody>
-          <DetailsRow label="Name" value={fileCollection.name} />
-          <DetailsRow label="ID" value={fileCollection.id} />
-          <DetailsRow label="Supplied ID" value={fileCollection.suppliedId} />
-          <DetailsRow
-            label="Created"
-            value={toLocaleString(fileCollection.created)}
-          />
-          <DetailsRow
-            label="Expires"
-            value={toLocaleString(fileCollection.expiresAt)}
-            status={optionalFieldStatus}
-          />
-          <MetadataRow
-            metadata={fileCollection.metadata}
-            status={optionalFieldStatus}
-          />
-        </TableBody>
-      </Table>
-    </TableContainer>
-  );
-}
-
-function DetailsRow({
-  label,
-  status,
-  value,
-}: {
-  readonly label: string;
-  readonly status?: "loading" | "ready";
-  readonly value?: string;
-}): JSX.Element {
-  const displayValue =
-    status === "loading" && value == null
-      ? "Loading..."
-      : toDisplayValue(value);
+  const details = [
+    { label: "Name", value: fileCollection.name },
+    { label: "ID", value: fileCollection.id },
+    { label: "Supplied ID", value: fileCollection.suppliedId },
+    { label: "Created", value: toLocaleString(fileCollection.created) },
+    {
+      label: "Expires",
+      status: optionalFieldStatus,
+      value: toLocaleString(fileCollection.expiresAt),
+    },
+  ];
+  const metadata = Object.entries(fileCollection.metadata ?? {});
 
   return (
-    <TableRow>
-      <TableCell>
-        <Typography variant="subtitle2">{label}</Typography>
-        <Typography
-          sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
-          variant="body2"
-        >
-          {displayValue}
-        </Typography>
-      </TableCell>
-    </TableRow>
-  );
-}
-
-function MetadataRow({
-  metadata,
-  status,
-}: {
-  readonly metadata?: Record<string, string>;
-  readonly status: "loading" | "ready";
-}): JSX.Element {
-  const entries = metadata == null ? [] : Object.entries(metadata);
-
-  return (
-    <TableRow>
-      <TableCell>
-        <Typography variant="subtitle2">Metadata</Typography>
-        {entries.length > 0 ? (
-          <Table size="small" sx={{ mt: 1, tableLayout: "fixed" }}>
-            <TableHead>
-              <TableRow>
-                <TableCell sx={{ px: 0, py: 0.5, width: "40%", pr: 1 }}>
-                  <Typography variant="subtitle2">Key</Typography>
-                </TableCell>
-                <TableCell sx={{ px: 0, py: 0.5, pl: 1 }}>
-                  <Typography variant="subtitle2">Value</Typography>
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {entries.map(([key, value]) => (
-                <TableRow key={key}>
-                  <TableCell sx={{ px: 0, py: 0.5, pr: 1 }}>
-                    <Typography
-                      sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
-                      variant="body2"
-                    >
-                      {toDisplayValue(key)}
-                    </Typography>
-                  </TableCell>
-                  <TableCell sx={{ px: 0, py: 0.5, pl: 1 }}>
-                    <Typography
-                      sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
-                      variant="body2"
-                    >
-                      {toDisplayValue(value)}
-                    </Typography>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        ) : status === "loading" ? (
+    <Box sx={{ whiteSpace: "nowrap" }}>
+      {details.map(({ label, status, value }) => (
+        <Box key={label} sx={{ py: 2 }}>
+          <Typography variant="subtitle2">{label}</Typography>
           <Typography
             sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
             variant="body2"
           >
-            Loading...
+            {status === "loading" && value == null
+              ? "Loading..."
+              : toDisplayValue(value)}
           </Typography>
+        </Box>
+      ))}
+      <Box sx={{ py: 2 }}>
+        <Typography variant="subtitle2">Metadata</Typography>
+        {metadata.length > 0 ? (
+          <Box
+            sx={{
+              display: "grid",
+              gap: 1,
+              gridTemplateColumns: "minmax(0, 40%) minmax(0, 1fr)",
+              mt: 1,
+            }}
+          >
+            <Typography variant="subtitle2">Key</Typography>
+            <Typography variant="subtitle2">Value</Typography>
+            {metadata.flatMap(([key, value]) => [
+              <Typography
+                key={`${key}-key`}
+                sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+                variant="body2"
+              >
+                {toDisplayValue(key)}
+              </Typography>,
+              <Typography
+                key={`${key}-value`}
+                sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+                variant="body2"
+              >
+                {toDisplayValue(value)}
+              </Typography>,
+            ])}
+          </Box>
         ) : (
           <Typography
             sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
             variant="body2"
           >
-            N/A
+            {optionalFieldStatus === "loading" ? "Loading..." : "N/A"}
           </Typography>
         )}
-      </TableCell>
-    </TableRow>
+      </Box>
+    </Box>
   );
 }

--- a/src/components/file-collection/FileCollectionMetadataTable.tsx
+++ b/src/components/file-collection/FileCollectionMetadataTable.tsx
@@ -1,4 +1,12 @@
-import { Box, Typography } from "@mui/material";
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableRow,
+  Typography,
+} from "@mui/material";
 
 import { toLocaleString } from "../../lib/dates";
 import { FileCollection } from "../../lib/file-collections";
@@ -13,37 +21,75 @@ export function FileCollectionMetadataTable({
   fileCollection,
   optionalFieldStatus = "ready",
 }: Props): JSX.Element {
-  const details = [
-    { label: "Name", value: fileCollection.name },
-    { label: "ID", value: fileCollection.id },
-    { label: "Supplied ID", value: fileCollection.suppliedId },
-    { label: "Created", value: toLocaleString(fileCollection.created) },
-    {
-      label: "Expires",
-      status: optionalFieldStatus,
-      value: toLocaleString(fileCollection.expiresAt),
-    },
-  ];
-  const metadata = Object.entries(fileCollection.metadata ?? {});
+  return (
+    <TableContainer>
+      <Table size="small" sx={{ whiteSpace: "nowrap" }}>
+        <TableBody>
+          <DetailsRow label="Name" value={fileCollection.name} />
+          <DetailsRow label="ID" value={fileCollection.id} />
+          <DetailsRow label="Supplied ID" value={fileCollection.suppliedId} />
+          <DetailsRow
+            label="Created"
+            value={toLocaleString(fileCollection.created)}
+          />
+          <DetailsRow
+            label="Expires"
+            value={toLocaleString(fileCollection.expiresAt)}
+            status={optionalFieldStatus}
+          />
+          <MetadataRow
+            metadata={fileCollection.metadata}
+            status={optionalFieldStatus}
+          />
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function DetailsRow({
+  label,
+  status,
+  value,
+}: {
+  readonly label: string;
+  readonly status?: "loading" | "ready";
+  readonly value?: string;
+}): JSX.Element {
+  const displayValue =
+    status === "loading" && value == null
+      ? "Loading..."
+      : toDisplayValue(value);
 
   return (
-    <Box sx={{ whiteSpace: "nowrap" }}>
-      {details.map(({ label, status, value }) => (
-        <Box key={label} sx={{ py: 2 }}>
-          <Typography variant="subtitle2">{label}</Typography>
-          <Typography
-            sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
-            variant="body2"
-          >
-            {status === "loading" && value == null
-              ? "Loading..."
-              : toDisplayValue(value)}
-          </Typography>
-        </Box>
-      ))}
-      <Box sx={{ py: 2 }}>
+    <TableRow>
+      <TableCell>
+        <Typography variant="subtitle2">{label}</Typography>
+        <Typography
+          sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+          variant="body2"
+        >
+          {displayValue}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function MetadataRow({
+  metadata,
+  status,
+}: {
+  readonly metadata?: Record<string, string>;
+  readonly status: "loading" | "ready";
+}): JSX.Element {
+  const entries = metadata == null ? [] : Object.entries(metadata);
+
+  return (
+    <TableRow>
+      <TableCell>
         <Typography variant="subtitle2">Metadata</Typography>
-        {metadata.length > 0 ? (
+        {entries.length > 0 ? (
           <Box
             sx={{
               display: "grid",
@@ -54,7 +100,7 @@ export function FileCollectionMetadataTable({
           >
             <Typography variant="subtitle2">Key</Typography>
             <Typography variant="subtitle2">Value</Typography>
-            {metadata.flatMap(([key, value]) => [
+            {entries.flatMap(([key, value]) => [
               <Typography
                 key={`${key}-key`}
                 sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
@@ -76,10 +122,10 @@ export function FileCollectionMetadataTable({
             sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
             variant="body2"
           >
-            {optionalFieldStatus === "loading" ? "Loading..." : "N/A"}
+            {status === "loading" ? "Loading..." : "N/A"}
           </Typography>
         )}
-      </Box>
-    </Box>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/src/components/file-collection/FileCollectionMetadataTable.tsx
+++ b/src/components/file-collection/FileCollectionMetadataTable.tsx
@@ -57,7 +57,9 @@ function DetailsRow({
   readonly value?: string;
 }): JSX.Element {
   const displayValue =
-    status === "loading" && value == null ? "Loading..." : toDisplayValue(value);
+    status === "loading" && value == null
+      ? "Loading..."
+      : toDisplayValue(value);
 
   return (
     <TableRow>

--- a/test/msw/installJsdomMockServer.ts
+++ b/test/msw/installJsdomMockServer.ts
@@ -1,10 +1,7 @@
 import { server } from "./server";
 
 function createRelativeUrlFetch(nativeFetch: typeof fetch): typeof fetch {
-  return ((
-    input: RequestInfo | URL,
-    init?: RequestInit
-  ): Promise<Response> => {
+  return ((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     if (typeof input === "string" || input instanceof URL) {
       return nativeFetch(
         new URL(input.toString(), "http://localhost").toString(),

--- a/test/render/renderWithSWR.tsx
+++ b/test/render/renderWithSWR.tsx
@@ -9,8 +9,8 @@ export function renderWithSWR(ui: React.ReactElement) {
         value={{
           dedupingInterval: 0,
           fetcher: (url: string) =>
-            fetch(new URL(url, window.location.origin).toString()).then(
-              (res) => res.json()
+            fetch(new URL(url, window.location.origin).toString()).then((res) =>
+              res.json()
             ),
           provider: () => new Map(),
         }}


### PR DESCRIPTION
## Summary
Some formatting drift had accumulated in dashboard. We have a prettier formatting task in package.json, but its execution wasn't enforced anywhere - adding a ci step to check the formatting and fail build if it doesn't match. Adding lefthook as an optional dev automation in a separate PR

## Test Plan
Change code to violate formatting rules and make a PR of the code change. Note build failure

## Release Notes
n/a

## Possible Regressions
n/a

## Dependencies
n/a
