### PR TITLE
[PLAT-8991] Add dedicated resource hrefs

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -89,16 +89,7 @@ describe("FileCollectionFilesTable", () => {
       "Download File One"
     );
 
-    await userEvent.click(name);
-
-    await waitFor(() => {
-      expect(createDownloadUrl).toHaveBeenCalledTimes(1);
-    });
-    expect(window.open).toHaveBeenCalledWith(
-      downloadUrlById["file-1"],
-      "_blank",
-      "noopener"
-    );
+    expect(name).toHaveAttribute("href", "/api/files/file-1/download");
     expect(onFileSelected).not.toHaveBeenCalled();
 
     await userEvent.click(screen.getByText("supplied-file-1"));
@@ -120,7 +111,7 @@ describe("FileCollectionFilesTable", () => {
     );
 
     await waitFor(() => {
-      expect(createDownloadUrl).toHaveBeenCalledTimes(2);
+      expect(createDownloadUrl).toHaveBeenCalledTimes(1);
     });
     expect(window.open).toHaveBeenLastCalledWith(
       downloadUrlById["file-1"],

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -12,14 +12,6 @@ import { server } from "../../../../test/msw/server";
 import { renderWithSWR } from "../../../../test/render/renderWithSWR";
 import FileCollectionTable from "../../../components/file-collection/FileCollectionTable";
 
-const mockPush = jest.fn();
-
-jest.mock("next/router", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
-}));
-
 const firstPage = fileCollectionsPage({
   data: [
     fileCollection({
@@ -67,10 +59,6 @@ const emptyCollectionPage = fileCollectionsPage({ data: [] });
 
 describe("FileCollectionTable", () => {
   installJsdomMockServer();
-
-  beforeEach(() => {
-    mockPush.mockClear();
-  });
 
   it("paginates file collections using the next cursor", async () => {
     const requests: string[] = [];
@@ -401,7 +389,7 @@ describe("FileCollectionTable", () => {
     expect(createdTo).toHaveValue("2026-06-10");
   });
 
-  it("navigates to the file collection detail route when a row is clicked", async () => {
+  it("renders the existing file collection detail route as an href", async () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(firstPage);
@@ -412,9 +400,10 @@ describe("FileCollectionTable", () => {
 
     expect(await screen.findByText("Collection One")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText("Collection One"));
-
-    expect(mockPush).toHaveBeenCalledWith("/file-collections/collection-1");
+    expect(screen.getByLabelText("Open Collection One")).toHaveAttribute(
+      "href",
+      "/file-collections/collection-1"
+    );
   });
 });
 

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -67,6 +67,21 @@ describe("FileTable", () => {
     );
   });
 
+  it("renders an available file as a dedicated download href", async () => {
+    server.use(
+      http.get("*/api/files", () => {
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByLabelText("Download alpha.jt")).toHaveAttribute(
+      "href",
+      "/api/files/file-1/download"
+    );
+  });
+
   it("sorts by name and toggles direction", async () => {
     const requests: string[] = [];
 

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -12,9 +12,7 @@ import { Scene } from "../../../lib/scenes";
 const mockPush = jest.fn();
 
 jest.mock("next/router", () => ({
-  useRouter: () => ({
-    push: mockPush,
-  }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 const scene: Scene = {
@@ -126,28 +124,21 @@ describe("SceneTable", () => {
     );
   });
 
-  it("opens the scene viewer when the scene name is clicked", async () => {
+  it("renders a dedicated scene viewer href", async () => {
     const onClick = jest.fn();
 
     server.use(
       http.get("*/api/scenes", () => {
         return HttpResponse.json(page);
-      }),
-      http.post("*/api/stream-keys", () => {
-        return HttpResponse.json({ key: "stream-key-1" });
       })
     );
 
     renderTable(scene, { onClick });
 
-    await userEvent.click(await screen.findByLabelText("Open Scene One"));
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith(
-        "scene-viewer/scene-1/?clientId=client-id&streamKey=stream-key-1&vertexEnv=platdev"
-      );
-    });
-    expect(onClick).not.toHaveBeenCalled();
+    expect(await screen.findByLabelText("Open Scene One")).toHaveAttribute(
+      "href",
+      "/scene-viewer/scene-1"
+    );
   });
 });
 
@@ -171,12 +162,10 @@ function renderTableElement(
 ): JSX.Element {
   return (
     <SceneTable
-      clientId="client-id"
       invalidationCount={0}
       onClick={jest.fn()}
       onEditClick={jest.fn()}
       scene={scene}
-      vertexEnv="platdev"
       {...props}
     />
   );

--- a/src/__tests__/components/shared/ResourceLink.test.tsx
+++ b/src/__tests__/components/shared/ResourceLink.test.tsx
@@ -4,6 +4,22 @@ import React from "react";
 import { ResourceLink } from "../../../components/shared/ResourceLink";
 
 describe("ResourceLink", () => {
+  it("uses Next Link for resource pages by default", () => {
+    render(
+      <ResourceLink
+        href="/scene-viewer/scene-1"
+        primaryActionLabel="Open Scene"
+      >
+        Scene
+      </ResourceLink>
+    );
+
+    expect(screen.getByRole("link", { name: "Open Scene" })).toHaveAttribute(
+      "href",
+      "/scene-viewer/scene-1"
+    );
+  });
+
   it("does not bubble href-backed clicks while preserving default navigation", () => {
     const onParentClick = jest.fn();
 

--- a/src/__tests__/components/shared/ResourceLink.test.tsx
+++ b/src/__tests__/components/shared/ResourceLink.test.tsx
@@ -1,0 +1,25 @@
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { ResourceLink } from "../../../components/shared/ResourceLink";
+
+describe("ResourceLink", () => {
+  it("does not bubble href-backed clicks while preserving default navigation", () => {
+    const onParentClick = jest.fn();
+
+    render(
+      <div onClick={onParentClick}>
+        <ResourceLink href="#resource" primaryActionLabel="Open Resource">
+          Resource
+        </ResourceLink>
+      </div>
+    );
+
+    const link = screen.getByRole("link", { name: "Open Resource" });
+    const event = createEvent.click(link);
+    fireEvent(link, event);
+
+    expect(onParentClick).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/src/__tests__/components/shared/ResourceLink.test.tsx
+++ b/src/__tests__/components/shared/ResourceLink.test.tsx
@@ -38,4 +38,20 @@ describe("ResourceLink", () => {
     expect(onParentClick).not.toHaveBeenCalled();
     expect(event.defaultPrevented).toBe(false);
   });
+
+  it("lets disabled link clicks bubble to the resource row", () => {
+    const onParentClick = jest.fn();
+
+    render(
+      <div onClick={onParentClick}>
+        <ResourceLink disabled primaryActionLabel="Download unavailable">
+          Resource
+        </ResourceLink>
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Download unavailable" }));
+
+    expect(onParentClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/__tests__/pages/api/file-download.test.ts
+++ b/src/__tests__/pages/api/file-download.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+import type { NextApiResponse } from "next";
+
+import { NextIronRequest } from "../../../lib/with-session";
+import { handleFileDownload } from "../../../pages/api/files/[id]/download";
+
+const mockCreateDownloadUrl = jest.fn();
+
+jest.mock("../../../lib/vertex-api", () => ({
+  getClientFromSession: jest.fn(() => ({
+    files: { createDownloadUrl: mockCreateDownloadUrl },
+  })),
+}));
+
+describe("file download route", () => {
+  beforeEach(() => {
+    mockCreateDownloadUrl.mockReset();
+  });
+
+  it("redirects a file href to the generated download URL", async () => {
+    mockCreateDownloadUrl.mockResolvedValue({
+      data: {
+        data: { attributes: { uri: "https://downloads.example.test/file-1" } },
+      },
+    });
+    const res = createResponse();
+
+    await handleFileDownload(
+      {
+        method: "GET",
+        query: { id: "file-1" },
+        session: {},
+      } as NextIronRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(mockCreateDownloadUrl).toHaveBeenCalledWith({
+      id: "file-1",
+      createDownloadRequest: {
+        data: {
+          type: "download-url",
+          attributes: { expiry: 30 },
+        },
+      },
+    });
+    expect(res.redirect).toHaveBeenCalledWith(
+      302,
+      "https://downloads.example.test/file-1"
+    );
+  });
+});
+
+function createResponse() {
+  const res = {
+    json: jest.fn(),
+    redirect: jest.fn(),
+    status: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}

--- a/src/__tests__/pages/scene-viewer/sceneId.test.ts
+++ b/src/__tests__/pages/scene-viewer/sceneId.test.ts
@@ -8,74 +8,28 @@ import {
 } from "../../../lib/with-session";
 import { serverSidePropsHandler } from "../../../pages/scene-viewer/[sceneId]";
 
-const mockCreateSceneStreamKey = jest.fn();
-
-jest.mock("../../../lib/vertex-api", () => ({
-  ...jest.requireActual("../../../lib/vertex-api"),
-  getClientFromSession: jest.fn(() => ({
-    streamKeys: { createSceneStreamKey: mockCreateSceneStreamKey },
-  })),
-}));
-
 describe("scene viewer route", () => {
-  beforeEach(() => {
-    mockCreateSceneStreamKey.mockReset();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it("creates a stream key and redirects when the URL only specifies a scene", async () => {
-    mockCreateSceneStreamKey.mockResolvedValue({
-      data: { data: { attributes: { key: "stream-key-1" } } },
-    });
-
+  it("does not create a stream key while serving a scene route", async () => {
     const result = await serverSidePropsHandler({
       query: { sceneId: "scene-1" },
       req: createReq(),
     });
 
-    expect(mockCreateSceneStreamKey).toHaveBeenCalledWith({
-      id: "scene-1",
-      createStreamKeyRequest: {
-        data: { type: "stream-key", attributes: { expiry: 86400 } },
-      },
-    });
     expect(result).toEqual({
-      redirect: {
-        destination:
-          "/scene-viewer/scene-1/?clientId=client-id&streamKey=stream-key-1&vertexEnv=platdev",
-        permanent: false,
+      props: {
+        clientId: "client-id",
+        networkConfig: undefined,
+        vertexEnv: "platdev",
       },
     });
   });
 
-  it("returns notFound when stream-key creation rejects with a client error", async () => {
-    jest.spyOn(console, "error").mockImplementation(() => undefined);
-    mockCreateSceneStreamKey.mockRejectedValue({
-      response: {
-        data: {
-          errors: [{ status: "404", title: "Scene not found." }],
-        },
-      },
-    });
-
-    const result = await serverSidePropsHandler({
-      query: { sceneId: "missing-scene" },
-      req: createReq(),
-    });
-
-    expect(result).toEqual({ notFound: true });
-  });
-
-  it("uses a supplied stream key without creating a replacement", async () => {
+  it("does not mutate when a supplied stream key is present", async () => {
     const result = await serverSidePropsHandler({
       query: { sceneId: "scene-1", streamKey: "provided-key" },
       req: createReq(),
     });
 
-    expect(mockCreateSceneStreamKey).not.toHaveBeenCalled();
     expect(result).toEqual({
       props: {
         clientId: "client-id",

--- a/src/__tests__/pages/scene-viewer/sceneId.test.ts
+++ b/src/__tests__/pages/scene-viewer/sceneId.test.ts
@@ -11,6 +11,7 @@ import { serverSidePropsHandler } from "../../../pages/scene-viewer/[sceneId]";
 const mockCreateSceneStreamKey = jest.fn();
 
 jest.mock("../../../lib/vertex-api", () => ({
+  ...jest.requireActual("../../../lib/vertex-api"),
   getClientFromSession: jest.fn(() => ({
     streamKeys: { createSceneStreamKey: mockCreateSceneStreamKey },
   })),
@@ -19,6 +20,10 @@ jest.mock("../../../lib/vertex-api", () => ({
 describe("scene viewer route", () => {
   beforeEach(() => {
     mockCreateSceneStreamKey.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("creates a stream key and redirects when the URL only specifies a scene", async () => {
@@ -39,10 +44,29 @@ describe("scene viewer route", () => {
     });
     expect(result).toEqual({
       redirect: {
-        destination: "/scene-viewer/scene-1?streamKey=stream-key-1",
+        destination:
+          "/scene-viewer/scene-1/?clientId=client-id&streamKey=stream-key-1&vertexEnv=platdev",
         permanent: false,
       },
     });
+  });
+
+  it("returns notFound when stream-key creation rejects with a client error", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => undefined);
+    mockCreateSceneStreamKey.mockRejectedValue({
+      response: {
+        data: {
+          errors: [{ status: "404", title: "Scene not found." }],
+        },
+      },
+    });
+
+    const result = await serverSidePropsHandler({
+      query: { sceneId: "missing-scene" },
+      req: createReq(),
+    });
+
+    expect(result).toEqual({ notFound: true });
   });
 
   it("uses a supplied stream key without creating a replacement", async () => {

--- a/src/__tests__/pages/scene-viewer/sceneId.test.ts
+++ b/src/__tests__/pages/scene-viewer/sceneId.test.ts
@@ -1,0 +1,88 @@
+import type { Session } from "next-iron-session";
+
+import {
+  CredsKey,
+  EnvKey,
+  NextIronRequest,
+  TokenKey,
+} from "../../../lib/with-session";
+import { serverSidePropsHandler } from "../../../pages/scene-viewer/[sceneId]";
+
+const mockCreateSceneStreamKey = jest.fn();
+
+jest.mock("../../../lib/vertex-api", () => ({
+  getClientFromSession: jest.fn(() => ({
+    streamKeys: { createSceneStreamKey: mockCreateSceneStreamKey },
+  })),
+}));
+
+describe("scene viewer route", () => {
+  beforeEach(() => {
+    mockCreateSceneStreamKey.mockReset();
+  });
+
+  it("creates a stream key and redirects when the URL only specifies a scene", async () => {
+    mockCreateSceneStreamKey.mockResolvedValue({
+      data: { data: { attributes: { key: "stream-key-1" } } },
+    });
+
+    const result = await serverSidePropsHandler({
+      query: { sceneId: "scene-1" },
+      req: createReq(),
+    });
+
+    expect(mockCreateSceneStreamKey).toHaveBeenCalledWith({
+      id: "scene-1",
+      createStreamKeyRequest: {
+        data: { type: "stream-key", attributes: { expiry: 86400 } },
+      },
+    });
+    expect(result).toEqual({
+      redirect: {
+        destination: "/scene-viewer/scene-1?streamKey=stream-key-1",
+        permanent: false,
+      },
+    });
+  });
+
+  it("uses a supplied stream key without creating a replacement", async () => {
+    const result = await serverSidePropsHandler({
+      query: { sceneId: "scene-1", streamKey: "provided-key" },
+      req: createReq(),
+    });
+
+    expect(mockCreateSceneStreamKey).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      props: {
+        clientId: "client-id",
+        networkConfig: undefined,
+        vertexEnv: "platdev",
+      },
+    });
+  });
+});
+
+function createReq(): NextIronRequest {
+  const values = new Map<string, unknown>([
+    [CredsKey, { id: "client-id", secret: "client-secret" }],
+    [EnvKey, "platdev"],
+    [
+      TokenKey,
+      {
+        expiration: Date.now() + 60 * 60 * 1000,
+        token: {
+          access_token: "test-token",
+          account_id: "account-id",
+          expires_in: 60 * 60,
+          scopes: [],
+          token_type: "Bearer",
+        },
+      },
+    ],
+  ]);
+
+  const session = {
+    get: (key: string) => values.get(key),
+  } as Session;
+  return { session } as NextIronRequest;
+}

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -177,6 +177,7 @@ export default function FileCollectionFilesTable({
         >
           <TableCell component="th" scope="row">
             <ResourceLink
+              component="a"
               disabled={!isAvailable}
               href={`/api/files/${encodeURIComponent(row.id)}/download`}
               primaryActionLabel={

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -178,7 +178,7 @@ export default function FileCollectionFilesTable({
           <TableCell component="th" scope="row">
             <ResourceLink
               disabled={!isAvailable}
-              onPrimaryAction={() => handleDownload(row.id)}
+              href={`/api/files/${encodeURIComponent(row.id)}/download`}
               primaryActionLabel={
                 isAvailable
                   ? `Download ${row.name}`

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -13,7 +13,6 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
-import NextLink from "next/link";
 import React from "react";
 import useSWR from "swr";
 
@@ -242,7 +241,6 @@ export default function FileCollectionTable({
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
-              component={NextLink}
               href={`/file-collections/${encodeURIComponent(row.id)}`}
               primaryActionLabel={`Open ${row.name}`}
             >

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -13,6 +13,7 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
+import NextLink from "next/link";
 import React from "react";
 import useSWR from "swr";
 
@@ -241,6 +242,7 @@ export default function FileCollectionTable({
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
+              component={NextLink}
               href={`/file-collections/${encodeURIComponent(row.id)}`}
               primaryActionLabel={`Open ${row.name}`}
             >

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -13,7 +13,6 @@ import {
   TextField,
 } from "@mui/material";
 import debounce from "lodash.debounce";
-import { useRouter } from "next/router";
 import React from "react";
 import useSWR from "swr";
 
@@ -76,7 +75,6 @@ export default function FileCollectionTable({
   activeFileCollectionId,
   onFileCollectionSelected,
 }: Props): JSX.Element {
-  const router = useRouter();
   const pageSize = DefaultPageSize;
   const {
     currentPage,
@@ -180,10 +178,6 @@ export default function FileCollectionTable({
     mutate();
   }
 
-  function handleOpenFileCollection(fileCollectionId: string) {
-    router.push(`/file-collections/${encodeURIComponent(fileCollectionId)}`);
-  }
-
   let tableRows: React.ReactNode;
   if (error) {
     tableRows = <DataLoadError colSpan={headCells.length + 1} />;
@@ -228,7 +222,7 @@ export default function FileCollectionTable({
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
-              onPrimaryAction={() => handleOpenFileCollection(row.id)}
+              href={`/file-collections/${encodeURIComponent(row.id)}`}
               primaryActionLabel={`Open ${row.name}`}
             >
               {row.name}

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -308,6 +308,7 @@ export default function FileTable({
           </TableCell>
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
+              component="a"
               disabled={!isAvailable}
               href={`/api/files/${encodeURIComponent(row.id)}/download`}
               primaryActionLabel={

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -309,7 +309,7 @@ export default function FileTable({
           <TableCell component="th" scope="row" padding="none">
             <ResourceLink
               disabled={!isAvailable}
-              onPrimaryAction={() => handleDownload(row.id)}
+              href={`/api/files/${encodeURIComponent(row.id)}/download`}
               primaryActionLabel={
                 isAvailable
                   ? `Download ${row.name}`

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -16,17 +16,15 @@ import {
   TextField,
 } from "@mui/material";
 import { Cursors, SceneData } from "@vertexvis/api-client-node";
-import { Environment } from "@vertexvis/viewer";
 import debounce from "lodash.debounce";
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import useSWR from "swr";
 
-import { ErrorRes, GetRes, isErrorRes } from "../../lib/api";
+import { ErrorRes, GetRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
 import { SwrProps } from "../../lib/paging";
 import { Scene, toScenePage } from "../../lib/scenes";
-import { encodeCreds } from "../../pages/scene-viewer/[sceneId]";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -38,11 +36,9 @@ import { HeadCell, TableHead } from "../shared/TableHead";
 import { TableToolbar } from "../shared/TableToolbar";
 
 interface Props {
-  readonly clientId?: string;
   readonly onClick: (s: Scene) => void;
   readonly onEditClick: (s: Scene) => void;
   readonly scene?: Scene;
-  readonly vertexEnv: Environment;
   readonly invalidationCount: number;
 }
 
@@ -82,11 +78,9 @@ function stateColor(
 }
 
 export default function SceneTable({
-  clientId,
   onClick,
   onEditClick,
   scene,
-  vertexEnv,
   invalidationCount,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
@@ -194,21 +188,8 @@ export default function SceneTable({
     onEditClick(s);
   }
 
-  async function handleViewClick(sceneId: string) {
-    if (!clientId) return;
-
-    const json = await (
-      await fetch("/api/stream-keys", {
-        body: JSON.stringify({ id: sceneId }),
-        method: "POST",
-      })
-    ).json();
-
-    if (isErrorRes(json)) console.error("Error creating stream key.", json);
-    else
-      router.push(
-        encodeCreds({ clientId, streamKey: json.key, vertexEnv, sceneId })
-      );
+  function handleViewClick(sceneId: string) {
+    router.push(`/scene-viewer/${encodeURIComponent(sceneId)}`);
   }
 
   async function handleGetStreamKey(sceneId: string) {
@@ -323,7 +304,7 @@ export default function SceneTable({
                       </TableCell>
                       <TableCell component="th" scope="row" padding="none">
                         <ResourceLink
-                          onPrimaryAction={() => handleViewClick(row.id)}
+                          href={`/scene-viewer/${encodeURIComponent(row.id)}`}
                           primaryActionLabel={`Open ${row.name}`}
                         >
                           {row.name}
@@ -350,7 +331,6 @@ export default function SceneTable({
                               onClick: () => handleGetStreamKey(row.id),
                             },
                             {
-                              disabled: !clientId,
                               label: "View scene",
                               onClick: () => handleViewClick(row.id),
                             },

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -1,7 +1,8 @@
 import { Box, BoxProps, Tooltip } from "@mui/material";
 import React from "react";
 
-type ResourceLinkProps = Omit<BoxProps<"a">, "onClick"> & {
+type ResourceLinkProps = Omit<BoxProps<"a">, "component" | "onClick"> & {
+  readonly component?: React.ElementType;
   readonly disabled?: boolean;
   readonly href?: string;
   readonly onPrimaryAction?: () => void;
@@ -10,6 +11,7 @@ type ResourceLinkProps = Omit<BoxProps<"a">, "onClick"> & {
 
 export function ResourceLink({
   children,
+  component = "a",
   disabled = false,
   href,
   onPrimaryAction,
@@ -20,30 +22,31 @@ export function ResourceLink({
   return (
     <Tooltip title={primaryActionLabel}>
       <Box
-        component="a"
+        component={component}
         href={disabled ? undefined : href ?? "#"}
         role="link"
         tabIndex={disabled ? -1 : undefined}
         aria-disabled={disabled}
         aria-label={primaryActionLabel}
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
-          if (disabled || event.button !== 0 || href != null) {
+          event.stopPropagation();
+          if (disabled) {
+            event.preventDefault();
             return;
           }
+          if (event.button !== 0 || href != null) return;
+
           event.preventDefault();
-          event.stopPropagation();
           onPrimaryAction?.();
         }}
         onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {
-          if (disabled || href != null) {
-            return;
-          }
+          event.stopPropagation();
+          if (disabled || href != null) return;
           if (event.key !== "Enter" && event.key !== " ") {
             return;
           }
 
           event.preventDefault();
-          event.stopPropagation();
           onPrimaryAction?.();
         }}
         sx={[

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -4,7 +4,7 @@ import React from "react";
 type ResourceLinkProps = Omit<BoxProps<"a">, "onClick"> & {
   readonly disabled?: boolean;
   readonly href?: string;
-  readonly onPrimaryAction: () => void;
+  readonly onPrimaryAction?: () => void;
   readonly primaryActionLabel: string;
 };
 
@@ -27,15 +27,15 @@ export function ResourceLink({
         aria-disabled={disabled}
         aria-label={primaryActionLabel}
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
-          if (disabled || event.button !== 0) {
+          if (disabled || event.button !== 0 || href != null) {
             return;
           }
           event.preventDefault();
           event.stopPropagation();
-          onPrimaryAction();
+          onPrimaryAction?.();
         }}
         onKeyDown={(event: React.KeyboardEvent<HTMLAnchorElement>) => {
-          if (disabled) {
+          if (disabled || href != null) {
             return;
           }
           if (event.key !== "Enter" && event.key !== " ") {
@@ -44,7 +44,7 @@ export function ResourceLink({
 
           event.preventDefault();
           event.stopPropagation();
-          onPrimaryAction();
+          onPrimaryAction?.();
         }}
         sx={[
           {

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, Tooltip } from "@mui/material";
+import NextLink from "next/link";
 import React from "react";
 
 type ResourceLinkProps = Omit<BoxProps<"a">, "component" | "onClick"> & {
@@ -6,15 +7,18 @@ type ResourceLinkProps = Omit<BoxProps<"a">, "component" | "onClick"> & {
   readonly disabled?: boolean;
   readonly href?: string;
   readonly onPrimaryAction?: () => void;
+  /** Disable viewport prefetching for resource pages with request-time side effects. */
+  readonly prefetch?: boolean;
   readonly primaryActionLabel: string;
 };
 
 export function ResourceLink({
   children,
-  component = "a",
+  component = NextLink,
   disabled = false,
   href,
   onPrimaryAction,
+  prefetch = false,
   primaryActionLabel,
   sx,
   ...props
@@ -24,6 +28,7 @@ export function ResourceLink({
       <Box
         component={component}
         href={disabled ? undefined : href ?? "#"}
+        {...(component === NextLink ? { prefetch } : {})}
         role="link"
         tabIndex={disabled ? -1 : undefined}
         aria-disabled={disabled}

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -23,22 +23,25 @@ export function ResourceLink({
   sx,
   ...props
 }: ResourceLinkProps): JSX.Element {
+  const linkComponent = disabled ? "a" : component;
+
   return (
     <Tooltip title={primaryActionLabel}>
       <Box
-        component={component}
+        component={linkComponent}
         href={disabled ? undefined : href ?? "#"}
-        {...(component === NextLink ? { prefetch } : {})}
+        {...(linkComponent === NextLink ? { prefetch } : {})}
         role="link"
         tabIndex={disabled ? -1 : undefined}
         aria-disabled={disabled}
         aria-label={primaryActionLabel}
         onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
-          event.stopPropagation();
           if (disabled) {
             event.preventDefault();
             return;
           }
+
+          event.stopPropagation();
           if (event.button !== 0 || href != null) return;
 
           event.preventDefault();

--- a/src/pages/api/files/[id]/download.ts
+++ b/src/pages/api/files/[id]/download.ts
@@ -1,0 +1,55 @@
+import { head, logError, VertexError } from "@vertexvis/api-client-node";
+import { NextApiResponse } from "next";
+
+import {
+  ErrorRes,
+  InvalidBody,
+  MethodNotAllowed,
+  ServerError,
+  toErrorRes,
+} from "../../../../lib/api";
+import { getClientFromSession } from "../../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../../lib/with-session";
+
+const DefaultDownloadExpirySeconds = 30;
+
+export default withSession(handleFileDownload);
+
+export async function handleFileDownload(
+  req: NextIronRequest,
+  res: NextApiResponse<ErrorRes>
+): Promise<void> {
+  if (req.method !== "GET") {
+    return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+  }
+
+  try {
+    const id = head(req.query.id);
+    if (id == null) return res.status(InvalidBody.status).json(InvalidBody);
+
+    const client = await getClientFromSession(req.session);
+    const downloadRes = await client.files.createDownloadUrl({
+      id,
+      createDownloadRequest: {
+        data: {
+          type: "download-url",
+          attributes: { expiry: DefaultDownloadExpirySeconds },
+        },
+      },
+    });
+    const url =
+      downloadRes.data.data.attributes.uri ??
+      downloadRes.data.data.attributes.downloadUrl;
+    if (url == null) return res.status(ServerError.status).json(ServerError);
+
+    res.redirect(302, url);
+    return;
+  } catch (error) {
+    const e = error as VertexError;
+    logError(e);
+    const response = e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError.res })
+      : ServerError;
+    return res.status(response.status).json(response);
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,16 +4,13 @@ import React, { useCallback } from "react";
 import { SceneDrawer } from "../components/scene/SceneDrawer";
 import { Layout } from "../components/shared/Layout";
 import { Scene } from "../lib/scenes";
-import { CommonProps, defaultServerSideProps } from "../lib/with-session";
+import { defaultServerSideProps } from "../lib/with-session";
 
 const SceneTable = dynamic(() => import("../components/scene/SceneTable"), {
   ssr: false,
 });
 
-export default function Home({
-  clientId,
-  vertexEnv,
-}: CommonProps): JSX.Element {
+export default function Home(): JSX.Element {
   const [editing, setEditing] = React.useState<boolean>(false);
   const [scene, setScene] = React.useState<Scene | undefined>();
   const drawerOpen = Boolean(scene);
@@ -39,11 +36,9 @@ export default function Home({
     <Layout
       main={
         <SceneTable
-          clientId={clientId}
           onClick={handleClick}
           onEditClick={handleEditClick}
           scene={scene}
-          vertexEnv={vertexEnv}
           invalidationCount={invalidationCount}
         />
       }

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -14,12 +14,12 @@ import { LeftSidebar } from "../../components/viewer/LeftSidebar";
 import { RightDrawer } from "../../components/viewer/RightDrawer";
 import { RightSidebar } from "../../components/viewer/RightSidebar";
 import { Viewer } from "../../components/viewer/Viewer";
-import { ErrorRes, GetRes } from "../../lib/api";
+import { ErrorRes, GetRes, isErrorFailure, toErrorRes } from "../../lib/api";
 import { head, StreamCredentials } from "../../lib/config";
 import { Metadata, toMetadataFromItem } from "../../lib/metadata";
 import { useModelViews } from "../../lib/model-views";
 import { applySceneViewState, selectByHit } from "../../lib/scene-items";
-import { getClientFromSession } from "../../lib/vertex-api";
+import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import { useViewer } from "../../lib/viewer";
 import {
   CommonProps,
@@ -214,21 +214,34 @@ export async function serverSidePropsHandler({
     return authResult;
   }
 
+  const props = await authResult.props;
   const client = await getClientFromSession(req.session);
-  const keyRes = await client.streamKeys.createSceneStreamKey({
-    id: sceneId,
-    createStreamKeyRequest: {
-      data: { type: "stream-key", attributes: { expiry: 86400 } },
-    },
-  });
-  const streamKey = keyRes.data.data.attributes.key;
+  const keyRes = await makeCall(() =>
+    client.streamKeys.createSceneStreamKey({
+      id: sceneId,
+      createStreamKeyRequest: {
+        data: { type: "stream-key", attributes: { expiry: 86400 } },
+      },
+    })
+  );
+  if (isErrorFailure(keyRes)) {
+    const error = toErrorRes({ failure: keyRes });
+    if (error.status >= 400 && error.status < 500) return { notFound: true };
+
+    throw new Error(error.message);
+  }
+
+  const streamKey = keyRes.data.attributes.key;
   if (streamKey == null) throw new Error("Created scene stream key was empty.");
 
   return {
     redirect: {
-      destination: `/scene-viewer/${encodeURIComponent(
-        sceneId
-      )}?streamKey=${encodeURIComponent(streamKey)}`,
+      destination: encodeCreds({
+        clientId: props.clientId,
+        sceneId,
+        streamKey,
+        vertexEnv: props.vertexEnv,
+      }),
       permanent: false,
     },
   };

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -1,7 +1,9 @@
 import { SceneItemData, SceneViewStateData } from "@vertexvis/api-client-node";
 import { vertexvis } from "@vertexvis/frame-streaming-protos";
 import { Environment, TapEventDetails } from "@vertexvis/viewer";
+import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { useRouter } from "next/router";
+import { withIronSession } from "next-iron-session";
 import React from "react";
 import useSWR from "swr";
 
@@ -17,8 +19,14 @@ import { head, StreamCredentials } from "../../lib/config";
 import { Metadata, toMetadataFromItem } from "../../lib/metadata";
 import { useModelViews } from "../../lib/model-views";
 import { applySceneViewState, selectByHit } from "../../lib/scene-items";
+import { getClientFromSession } from "../../lib/vertex-api";
 import { useViewer } from "../../lib/viewer";
-import { CommonProps, defaultServerSideProps } from "../../lib/with-session";
+import {
+  CommonProps,
+  CookieAttributes,
+  NextIronRequest,
+  serverSidePropsHandler as commonServerSidePropsHandler,
+} from "../../lib/with-session";
 
 const ViewerId = "vertex-viewer-id";
 
@@ -35,7 +43,9 @@ function useSceneItem({ itemId }: { itemId?: string }) {
 }
 
 export default function SceneViewer({
+  clientId,
   networkConfig,
+  vertexEnv,
 }: CommonProps): JSX.Element {
   const router = useRouter();
   const viewerState = useViewer();
@@ -60,9 +70,9 @@ export default function SceneViewer({
   React.useEffect(() => {
     if (!router.isReady) return;
 
-    const cId = head(router.query.clientId);
+    const cId = head(router.query.clientId) ?? clientId;
     const sk = head(router.query.streamKey);
-    const ve = head(router.query.vertexEnv) as Environment;
+    const ve = (head(router.query.vertexEnv) as Environment) ?? vertexEnv;
 
     setCredentials(
       cId && sk && ve
@@ -181,10 +191,50 @@ export function encodeCreds({
   vertexEnv: Environment;
   sceneId?: string;
 }): string {
-  const path = `scene-viewer/${sceneId ? sceneId : "unknown"}`;
+  const path = `/scene-viewer/${encodeURIComponent(sceneId ?? "unknown")}`;
   const cId = `clientId=${encodeURIComponent(clientId)}`;
   const sk = `streamKey=${encodeURIComponent(streamKey)}`;
   const ve = `vertexEnv=${encodeURIComponent(vertexEnv)}`;
   return `${path}/?${cId}&${sk}&${ve}`;
 }
-export const getServerSideProps = defaultServerSideProps;
+
+export async function serverSidePropsHandler({
+  query,
+  req,
+}: Pick<GetServerSidePropsContext, "query"> & {
+  readonly req: NextIronRequest;
+}): Promise<GetServerSidePropsResult<CommonProps>> {
+  const authResult = commonServerSidePropsHandler({ req });
+  if (!("props" in authResult)) return authResult;
+
+  const sceneId = head(query.sceneId);
+  if (sceneId == null) return { notFound: true };
+
+  if (head(query.streamKey) != null) {
+    return authResult;
+  }
+
+  const client = await getClientFromSession(req.session);
+  const keyRes = await client.streamKeys.createSceneStreamKey({
+    id: sceneId,
+    createStreamKeyRequest: {
+      data: { type: "stream-key", attributes: { expiry: 86400 } },
+    },
+  });
+  const streamKey = keyRes.data.data.attributes.key;
+  if (streamKey == null) throw new Error("Created scene stream key was empty.");
+
+  return {
+    redirect: {
+      destination: `/scene-viewer/${encodeURIComponent(
+        sceneId
+      )}?streamKey=${encodeURIComponent(streamKey)}`,
+      permanent: false,
+    },
+  };
+}
+
+export const getServerSideProps = withIronSession(
+  serverSidePropsHandler,
+  CookieAttributes
+);

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -14,12 +14,11 @@ import { LeftSidebar } from "../../components/viewer/LeftSidebar";
 import { RightDrawer } from "../../components/viewer/RightDrawer";
 import { RightSidebar } from "../../components/viewer/RightSidebar";
 import { Viewer } from "../../components/viewer/Viewer";
-import { ErrorRes, GetRes, isErrorFailure, toErrorRes } from "../../lib/api";
+import { ErrorRes, GetRes } from "../../lib/api";
 import { head, StreamCredentials } from "../../lib/config";
 import { Metadata, toMetadataFromItem } from "../../lib/metadata";
 import { useModelViews } from "../../lib/model-views";
 import { applySceneViewState, selectByHit } from "../../lib/scene-items";
-import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import { useViewer } from "../../lib/viewer";
 import {
   CommonProps,
@@ -52,6 +51,8 @@ export default function SceneViewer({
   const [credentials, setCredentials] = React.useState<
     StreamCredentials | undefined
   >();
+  const [streamKeyError, setStreamKeyError] = React.useState<string>();
+  const requestedStreamKeyForScene = React.useRef<string>();
   const [selectedItemId, setSelectedItemId] = React.useState<
     string | undefined
   >();
@@ -66,21 +67,38 @@ export default function SceneViewer({
     viewerState,
   });
 
-  // Prefer credentials in URL to enable easy scene sharing. If empty, use defaults.
+  // Prefer credentials in URL to enable easy scene sharing. Create a stream key only
+  // after this page has mounted so route prefetching remains read-only.
   React.useEffect(() => {
     if (!router.isReady) return;
 
     const cId = head(router.query.clientId) ?? clientId;
     const sk = head(router.query.streamKey);
     const ve = (head(router.query.vertexEnv) as Environment) ?? vertexEnv;
+    const sceneId = head(router.query.sceneId);
 
-    setCredentials(
-      cId && sk && ve
-        ? { clientId: cId, streamKey: sk, vertexEnv: ve }
-        : undefined
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.isReady]);
+    if (cId && sk && ve) {
+      setCredentials({ clientId: cId, streamKey: sk, vertexEnv: ve });
+      return;
+    }
+    if (!cId || !sceneId || requestedStreamKeyForScene.current === sceneId) {
+      return;
+    }
+
+    requestedStreamKeyForScene.current = sceneId;
+    setStreamKeyError(undefined);
+    void createStreamKey(sceneId)
+      .then((streamKey) =>
+        router.replace(
+          encodeCreds({ clientId: cId, sceneId, streamKey, vertexEnv: ve }),
+          undefined,
+          { shallow: true }
+        )
+      )
+      .catch(() =>
+        setStreamKeyError("Unable to create a stream key for this scene.")
+      );
+  }, [clientId, router, vertexEnv]);
 
   async function handleSelect(
     detail: TapEventDetails,
@@ -114,6 +132,10 @@ export default function SceneViewer({
   }, [selectedItem.data]);
 
   const featureLines = { width: 0.5, color: "#444444" };
+
+  if (streamKeyError) {
+    return <p role="alert">{streamKeyError}</p>;
+  }
 
   return router.isReady && credentials ? (
     <Layout
@@ -180,6 +202,18 @@ export default function SceneViewer({
   );
 }
 
+async function createStreamKey(sceneId: string): Promise<string> {
+  const response = await fetch("/api/stream-keys", {
+    body: JSON.stringify({ id: sceneId }),
+    method: "POST",
+  });
+  if (!response.ok) throw new Error("Stream-key creation failed.");
+
+  const { key } = (await response.json()) as { key?: string };
+  if (!key) throw new Error("Created scene stream key was empty.");
+  return key;
+}
+
 export function encodeCreds({
   clientId,
   streamKey,
@@ -198,53 +232,19 @@ export function encodeCreds({
   return `${path}/?${cId}&${sk}&${ve}`;
 }
 
-export async function serverSidePropsHandler({
+export function serverSidePropsHandler({
   query,
   req,
 }: Pick<GetServerSidePropsContext, "query"> & {
   readonly req: NextIronRequest;
-}): Promise<GetServerSidePropsResult<CommonProps>> {
+}): GetServerSidePropsResult<CommonProps> {
   const authResult = commonServerSidePropsHandler({ req });
   if (!("props" in authResult)) return authResult;
 
   const sceneId = head(query.sceneId);
   if (sceneId == null) return { notFound: true };
 
-  if (head(query.streamKey) != null) {
-    return authResult;
-  }
-
-  const props = await authResult.props;
-  const client = await getClientFromSession(req.session);
-  const keyRes = await makeCall(() =>
-    client.streamKeys.createSceneStreamKey({
-      id: sceneId,
-      createStreamKeyRequest: {
-        data: { type: "stream-key", attributes: { expiry: 86400 } },
-      },
-    })
-  );
-  if (isErrorFailure(keyRes)) {
-    const error = toErrorRes({ failure: keyRes });
-    if (error.status >= 400 && error.status < 500) return { notFound: true };
-
-    throw new Error(error.message);
-  }
-
-  const streamKey = keyRes.data.attributes.key;
-  if (streamKey == null) throw new Error("Created scene stream key was empty.");
-
-  return {
-    redirect: {
-      destination: encodeCreds({
-        clientId: props.clientId,
-        sceneId,
-        streamKey,
-        vertexEnv: props.vertexEnv,
-      }),
-      permanent: false,
-    },
-  };
+  return authResult;
 }
 
 export const getServerSideProps = withIronSession(


### PR DESCRIPTION
## Summary

- Add real, resource-specific hrefs for scenes, file collections, and files.
- Generate a scene stream key server-side for scene-viewer links that omit one, while preserving supplied stream keys.
- Add an authenticated file-download endpoint that redirects to the generated download URL.



https://github.com/user-attachments/assets/686232fb-7c68-4c3d-a8a3-5894daef6e01



## Impact

Resource names now support copy-link and open-in-new-tab browser behavior without removing existing row selection, drawers, or action-menu downloads.

## Validation

- `yarn lint`
- `yarn build`
