### PR TITLE
feat(files): add nuqs deep-linking prototype

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ const projectConfig = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(@mswjs|@open-draft|msw|rettime|until-async|headers-polyfill|is-node-process|outvariant|strict-event-emitter|path-to-regexp)/)",
+    "/node_modules/(?!(@mswjs|@open-draft|msw|nuqs|rettime|until-async|headers-polyfill|is-node-process|outvariant|strict-event-emitter|path-to-regexp)/)",
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "next": "^15.5.18",
     "next-connect": "^0.13.0",
     "next-iron-session": "^4.2",
+    "nuqs": "^2.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.63.0",
@@ -59,7 +60,7 @@
     "ts-jest": "^29.4.11",
     "tslib": "^2.3",
     "tsx": "^4.23.1",
-    "typescript": "^4"
+    "typescript": "^5"
   },
   "scripts": {
     "build": "next build",

--- a/src/__tests__/components/file/NuqsFileTable.test.tsx
+++ b/src/__tests__/components/file/NuqsFileTable.test.tsx
@@ -1,0 +1,142 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { NuqsTestingAdapter, UrlUpdateEvent } from "nuqs/adapters/testing";
+import React from "react";
+
+import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
+import { server } from "../../../../test/msw/server";
+import { renderWithSWR } from "../../../../test/render/renderWithSWR";
+import NuqsFileTable from "../../../components/file/NuqsFileTable";
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+const page = {
+  cursors: { self: "page-1" },
+  data: [
+    {
+      type: "file",
+      id: "file-1",
+      attributes: {
+        created: "2026-06-10T15:30:00Z",
+        name: "alpha.jt",
+        status: "complete",
+        suppliedId: "supplied-1",
+        uploaded: "2026-06-10T15:45:00Z",
+      },
+    },
+  ],
+  status: 200,
+};
+
+const pagedPage = {
+  cursors: { self: "page-1", next: "page-2" },
+  data: page.data,
+  status: 200,
+};
+
+describe("NuqsFileTable", () => {
+  installJsdomMockServer();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads transferable table state from the URL", async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get("*/api/files", ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable({
+      searchParams:
+        "?fileName=alpha&fileFilterId=file-filter&fileSuppliedId=supplied-1" +
+        "&fileCreatedAtStart=2026-06-01&fileCreatedAtEnd=2026-06-30" +
+        "&fileCursor=cursor-2&filePage=2&fileSort=name",
+    });
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("alpha");
+    expect(screen.getByLabelText("File ID")).toHaveValue("file-filter");
+    expect(screen.getByLabelText("Supplied ID")).toHaveValue("supplied-1");
+    expect(screen.getByLabelText("Created From")).toHaveValue("2026-06-01");
+    expect(screen.getByLabelText("Created To")).toHaveValue("2026-06-30");
+    expect(screen.getByLabelText("Go to previous page")).toBeDisabled();
+
+    const request = new URL(requests[0]);
+    expect(request.searchParams.get("cursor")).toBe("cursor-2");
+    expect(request.searchParams.get("fileId")).toBe("file-filter");
+    expect(request.searchParams.get("name")).toBe("alpha");
+    expect(request.searchParams.get("sort")).toBe("name");
+    expect(request.searchParams.get("suppliedId")).toBe("supplied-1");
+    expect(request.searchParams.has("createdAtStart")).toBe(true);
+    expect(request.searchParams.has("createdAtEnd")).toBe(true);
+  });
+
+  it("updates a filter and resets paging as one URL update", async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get("*/api/files", () => HttpResponse.json(page)));
+
+    renderTable({
+      onUrlUpdate: (event) => events.push(event),
+      searchParams: "?fileCursor=cursor-2&filePage=2",
+    });
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("Name"), "alpha");
+
+    await waitFor(() => {
+      const last = events[events.length - 1];
+      expect(last?.searchParams.get("fileName")).toBe("alpha");
+    });
+
+    const last = events[events.length - 1];
+    expect(last.options.history).toBe("replace");
+    expect(last.searchParams.has("fileCursor")).toBe(false);
+    expect(last.searchParams.has("filePage")).toBe(false);
+    expect(screen.getByLabelText("Name")).toHaveValue("alpha");
+  });
+
+  it("moves forward with the API cursor using push history", async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get("*/api/files", () => HttpResponse.json(pagedPage)));
+
+    renderTable({ onUrlUpdate: (event) => events.push(event) });
+
+    expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Go to next page"));
+
+    await waitFor(() => expect(events.length).toBe(1));
+    expect(events[0].options.history).toBe("push");
+    expect(events[0].searchParams.get("fileCursor")).toBe("page-2");
+    expect(events[0].searchParams.get("filePage")).toBe("1");
+  });
+});
+
+function renderTable({
+  onUrlUpdate,
+  searchParams,
+}: {
+  onUrlUpdate?: (event: UrlUpdateEvent) => void;
+  searchParams?: string;
+} = {}): void {
+  renderWithSWR(
+    <NuqsTestingAdapter
+      hasMemory={true}
+      onUrlUpdate={onUrlUpdate}
+      searchParams={searchParams}
+    >
+      <NuqsFileTable onFileSelected={jest.fn()} />
+    </NuqsTestingAdapter>
+  );
+}

--- a/src/__tests__/lib/files-nuqs-state.test.ts
+++ b/src/__tests__/lib/files-nuqs-state.test.ts
@@ -1,0 +1,61 @@
+import {
+  DefaultFileSort,
+  parseAsFileSort,
+  parseAsPageIndex,
+} from "../../lib/files-nuqs-state";
+
+describe("files-nuqs-state", () => {
+  describe("parseAsFileSort", () => {
+    it("parses API sort parameter values", () => {
+      expect(parseAsFileSort.parse("name")).toEqual({
+        field: "name",
+        order: "asc",
+      });
+      expect(parseAsFileSort.parse("-name")).toEqual({
+        field: "name",
+        order: "desc",
+      });
+      expect(parseAsFileSort.parse("created")).toEqual({
+        field: "created",
+        order: "asc",
+      });
+      expect(parseAsFileSort.parse("-created")).toEqual(DefaultFileSort);
+    });
+
+    it("returns null for unknown values so the default applies", () => {
+      expect(parseAsFileSort.parse("unsupported")).toBeNull();
+      expect(parseAsFileSort.parse("")).toBeNull();
+    });
+
+    it("serializes back to the API sort parameter", () => {
+      expect(
+        parseAsFileSort.serialize({ field: "name", order: "desc" })
+      ).toBe("-name");
+      expect(parseAsFileSort.serialize(DefaultFileSort)).toBe("-created");
+    });
+
+    it("treats equivalent sort states as equal for default elision", () => {
+      expect(
+        parseAsFileSort.eq(DefaultFileSort, {
+          field: "created",
+          order: "desc",
+        })
+      ).toBe(true);
+      expect(
+        parseAsFileSort.eq(DefaultFileSort, { field: "name", order: "desc" })
+      ).toBe(false);
+    });
+  });
+
+  describe("parseAsPageIndex", () => {
+    it("parses non-negative integers", () => {
+      expect(parseAsPageIndex.parse("0")).toBe(0);
+      expect(parseAsPageIndex.parse("12")).toBe(12);
+    });
+
+    it("returns null for malformed values so the default applies", () => {
+      expect(parseAsPageIndex.parse("-1")).toBeNull();
+      expect(parseAsPageIndex.parse("not-a-page")).toBeNull();
+    });
+  });
+});

--- a/src/components/file/NuqsFileTable.tsx
+++ b/src/components/file/NuqsFileTable.tsx
@@ -1,0 +1,545 @@
+import { Add } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Paper,
+  Snackbar,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TablePagination,
+  TableRow,
+  TextField,
+} from "@mui/material";
+import { Cursors } from "@vertexvis/api-client-node";
+import { debounce, Nullable, useQueryStates } from "nuqs";
+import React from "react";
+import useSWR from "swr";
+
+import { isErrorRes } from "../../lib/api";
+import {
+  toLocalDateInputValue,
+  toLocalDayBoundaryIso,
+  toLocaleString,
+} from "../../lib/dates";
+import {
+  File,
+  FileStatusComplete,
+  isCompleteFileStatus,
+  normalizeFileStatus,
+  toFilePage,
+} from "../../lib/files";
+import {
+  fileTableParsers,
+  FileTableState,
+  fileTableUrlKeys,
+} from "../../lib/files-nuqs-state";
+import { buildQuery, SwrProps } from "../../lib/paging";
+import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
+import {
+  CreatedAtDateRange,
+  CreatedAtDateRangeFilter,
+} from "../shared/CreatedAtDateRangeFilter";
+import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
+import { DataLoadError } from "../shared/DataLoadError";
+import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
+import { ResourceLink } from "../shared/ResourceLink";
+import { RowActionsMenu } from "../shared/RowActionsMenu";
+import { SkeletonBody } from "../shared/SkeletonBody";
+import { HeadCell, TableHead } from "../shared/TableHead";
+import { TableToolbar } from "../shared/TableToolbar";
+import CreateFileDialog from "./CreateFileDialog";
+
+export const headCells: readonly HeadCell[] = [
+  { id: "name", disablePadding: true, label: "Name", sortable: true },
+  { id: "supplied-id", label: "Supplied ID" },
+  { id: "status", label: "Status" },
+  { id: "id", label: "ID" },
+  { id: "created", label: "Created", sortable: true },
+  { id: "uploaded", label: "Uploaded" },
+  { id: "actions", label: "Actions" },
+];
+
+const FilterDebounceMs = 300;
+
+interface UseFilesProps extends SwrProps {
+  readonly createdAtEnd?: string;
+  readonly createdAtStart?: string;
+  readonly fileId?: string;
+  readonly name?: string;
+  readonly sort?: SortState;
+  readonly suppliedId?: string;
+}
+
+function useFiles({
+  createdAtEnd,
+  createdAtStart,
+  cursor,
+  fileId,
+  name,
+  pageSize,
+  sort,
+  suppliedId,
+}: UseFilesProps) {
+  return useSWR(
+    buildQuery("/api/files", {
+      createdAtEnd,
+      createdAtStart,
+      cursor,
+      fileId,
+      name,
+      pageSize,
+      sort: sort != null ? toSortParam(sort) : undefined,
+      suppliedId,
+    })
+  );
+}
+
+function isFileAvailable(file: File): boolean {
+  return isCompleteFileStatus(file.status);
+}
+
+function statusLabel(status?: string): string {
+  return status ?? "N/A";
+}
+
+function statusColor(
+  status?: string
+): "default" | "success" | "warning" | "error" {
+  switch (normalizeFileStatus(status)) {
+    case FileStatusComplete:
+      return "success";
+    case "pending":
+      return "warning";
+    case "error":
+    case "failed":
+      return "error";
+    default:
+      return "default";
+  }
+}
+
+interface Props {
+  readonly activeFileId?: string;
+  readonly onFileSelected: (file: File) => void;
+}
+
+export default function NuqsFileTable({
+  activeFileId,
+  onFileSelected,
+}: Props): JSX.Element {
+  const pageSize = DefaultPageSize;
+  const [state, setState] = useQueryStates(fileTableParsers, {
+    urlKeys: fileTableUrlKeys,
+  });
+  const [cachedCursors, setCachedCursors] = React.useState<Cursors>();
+  const [previousCursors, setPreviousCursors] = React.useState<
+    Record<number, string | undefined>
+  >({});
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [showDialog, setShowDialog] = React.useState(false);
+  const [showToast, setShowToast] = React.useState(false);
+  const [downloadError, setDownloadError] = React.useState<string>();
+
+  const { data, error, mutate } = useFiles({
+    createdAtEnd:
+      state.createdAtEnd != null
+        ? toLocalDayBoundaryIso(state.createdAtEnd, "end")
+        : undefined,
+    createdAtStart:
+      state.createdAtStart != null
+        ? toLocalDayBoundaryIso(state.createdAtStart, "start")
+        : undefined,
+    cursor: state.cursor ?? undefined,
+    fileId: state.filterId?.trim() || undefined,
+    name: state.name?.trim() || undefined,
+    pageSize,
+    sort: state.sort,
+    suppliedId: state.suppliedId?.trim() || undefined,
+  });
+  const loadError = error ?? (isErrorRes(data) ? data : undefined);
+  const page = data && !isErrorRes(data) ? toFilePage(data) : undefined;
+  const visiblePage = page;
+  const pageLength = visiblePage ? visiblePage.items.length : 0;
+  const paginationCursors = visiblePage?.cursors ?? cachedCursors;
+  const emptyRows =
+    paginationCursors?.next == null && paginationCursors?.self == null
+      ? 0
+      : pageSize - pageLength;
+
+  const resetPagingCache = React.useCallback(() => {
+    setCachedCursors(undefined);
+    setPreviousCursors({});
+  }, []);
+
+  function handleTextFilterChange(
+    field: "filterId" | "name" | "suppliedId",
+    value: string
+  ) {
+    const patch: Partial<Nullable<FileTableState>> = {
+      cursor: null,
+      page: null,
+    };
+    patch[field] = value === "" ? null : value;
+
+    resetPagingCache();
+    void setState(patch, { limitUrlUpdates: debounce(FilterDebounceMs) });
+  }
+
+  const searchKey = JSON.stringify({
+    createdAtEnd: state.createdAtEnd,
+    createdAtStart: state.createdAtStart,
+    filterId: state.filterId,
+    name: state.name,
+    sort: state.sort,
+    suppliedId: state.suppliedId,
+  });
+  const previousSearchKey = React.useRef(searchKey);
+
+  React.useEffect(() => {
+    if (previousSearchKey.current !== searchKey) {
+      previousSearchKey.current = searchKey;
+      resetPagingCache();
+    }
+  }, [searchKey, resetPagingCache]);
+
+  React.useEffect(() => {
+    if (page == null) return;
+
+    setCachedCursors(page.cursors ?? undefined);
+  }, [page]);
+
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+    if (visiblePage == null) return;
+
+    const upd = new Set<string>();
+    if (e.target.checked) visiblePage.items.forEach((n) => upd.add(n.id));
+    setSelected(upd);
+  }
+
+  function handleCheck(id: string) {
+    const upd = new Set(selected);
+    if (selected.has(id)) upd.delete(id);
+    else upd.add(id);
+
+    setSelected(upd);
+  }
+
+  function handleChangePage(
+    _: React.MouseEvent<HTMLButtonElement> | null,
+    num: number
+  ) {
+    let nextCursor = state.cursor;
+    if (state.page < num) {
+      nextCursor = paginationCursors?.next ?? null;
+      setPreviousCursors((current) => ({
+        ...current,
+        [state.page]: paginationCursors?.self,
+      }));
+    } else if (state.page > num) {
+      nextCursor = previousCursors[num] ?? null;
+    }
+
+    void setState({ cursor: nextCursor, page: num }, { history: "push" });
+  }
+
+  function handleSortChange(field: string) {
+    resetPagingCache();
+    void setState((current) => ({
+      cursor: null,
+      page: null,
+      sort: toggleSort(current.sort, field),
+    }));
+  }
+
+  function handleCreatedAtChange(filters: CreatedAtDateRange) {
+    resetPagingCache();
+    void setState({
+      createdAtEnd: toLocalDateInputValue(filters.createdAtEnd) || null,
+      createdAtStart: toLocalDateInputValue(filters.createdAtStart) || null,
+      cursor: null,
+      page: null,
+    });
+  }
+
+  async function handleDelete() {
+    setSelected(new Set());
+    await fetch("/api/files", {
+      body: JSON.stringify({ ids: [...selected] }),
+      method: "DELETE",
+    });
+    mutate();
+  }
+
+  async function handleDownload(id: string) {
+    setDownloadError(undefined);
+
+    const res = await fetch(
+      `/api/files/${encodeURIComponent(id)}/download-url`,
+      {
+        method: "POST",
+      }
+    );
+
+    const body = await res.json();
+    if (!res.ok || body.url == null) {
+      setDownloadError(
+        body.message ?? "Could not create a download URL for this file."
+      );
+      return;
+    }
+
+    const opened = window.open(body.url as string, "_blank", "noopener");
+    if (opened == null) {
+      window.location.assign(body.url as string);
+    }
+  }
+
+  let tableRows: React.ReactNode;
+  if (loadError) {
+    tableRows = <DataLoadError colSpan={headCells.length + 1} />;
+  } else if (!visiblePage) {
+    tableRows = (
+      <SkeletonBody
+        includeCheckbox={true}
+        numCellsPerRow={8}
+        numRows={pageSize - pageLength}
+        rowHeight={DefaultRowHeight}
+      />
+    );
+  } else {
+    tableRows = visiblePage.items.map((row) => {
+      const isSel = selected.has(row.id);
+      const isActive = activeFileId === row.id;
+      const isAvailable = isFileAvailable(row);
+
+      return (
+        <TableRow
+          hover
+          role="checkbox"
+          tabIndex={-1}
+          key={row.id}
+          selected={isSel || isActive}
+          onClick={() => onFileSelected(row)}
+        >
+          <TableCell
+            padding="checkbox"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleCheck(row.id);
+            }}
+          >
+            <Checkbox
+              color="primary"
+              checked={isSel}
+              inputProps={{
+                "aria-label": `Select ${row.name ?? row.id}`,
+              }}
+            />
+          </TableCell>
+          <TableCell component="th" scope="row" padding="none">
+            <ResourceLink
+              component="a"
+              disabled={!isAvailable}
+              href={`/api/files/${encodeURIComponent(row.id)}/download`}
+              primaryActionLabel={
+                isAvailable
+                  ? `Download ${row.name}`
+                  : `${row.name} is not available for download`
+              }
+            >
+              {row.name}
+            </ResourceLink>
+          </TableCell>
+          <TableCell>{row.suppliedId}</TableCell>
+          <TableCell>
+            <Chip
+              color={statusColor(row.status)}
+              label={statusLabel(row.status)}
+              size="small"
+              sx={{ fontWeight: 600, textTransform: "uppercase" }}
+              variant="outlined"
+            />
+          </TableCell>
+          <TableCell>{row.id}</TableCell>
+          <TableCell>{toLocaleString(row.created)}</TableCell>
+          <TableCell>{toLocaleString(row.uploaded)}</TableCell>
+          <TableCell
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          >
+            <RowActionsMenu
+              actions={[
+                {
+                  disabled: !isAvailable,
+                  label: "Download file",
+                  onClick: () => handleDownload(row.id),
+                },
+              ]}
+              ariaLabel={`Actions for ${row.name}`}
+            />
+          </TableCell>
+        </TableRow>
+      );
+    });
+  }
+
+  return (
+    <>
+      <Paper sx={{ m: 2 }}>
+        <TableToolbar
+          customActions={
+            selected.size === 0 ? (
+              <Button
+                key="upload"
+                variant="contained"
+                startIcon={<Add />}
+                onClick={() => setShowDialog(true)}
+                sx={{ whiteSpace: "nowrap" }}
+              >
+                Add File
+              </Button>
+            ) : undefined
+          }
+          numSelected={selected.size}
+          onDelete={handleDelete}
+          title="Files"
+        />
+        <Box
+          sx={{
+            px: { sm: 2 },
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", flex: 1 }}>
+            <TextField
+              variant="standard"
+              size="small"
+              margin="normal"
+              id="nameFilter"
+              label="Name"
+              type="text"
+              onChange={(e) => handleTextFilterChange("name", e.target.value)}
+              sx={{ mt: 0, width: "16rem" }}
+              value={state.name ?? ""}
+            />
+            <TextField
+              variant="standard"
+              size="small"
+              margin="normal"
+              id="fileIdFilter"
+              label="File ID"
+              type="text"
+              onChange={(e) =>
+                handleTextFilterChange("filterId", e.target.value)
+              }
+              sx={{ mt: 0, width: "16rem" }}
+              value={state.filterId ?? ""}
+            />
+            <TextField
+              variant="standard"
+              size="small"
+              margin="normal"
+              id="suppliedIdFilter"
+              label="Supplied ID"
+              type="text"
+              onChange={(e) =>
+                handleTextFilterChange("suppliedId", e.target.value)
+              }
+              sx={{ mt: 0, width: "16rem" }}
+              value={state.suppliedId ?? ""}
+            />
+          </Box>
+        </Box>
+        <CreatedAtDateRangeFilter
+          onChange={handleCreatedAtChange}
+          value={{
+            createdAtEnd: state.createdAtEnd ?? undefined,
+            createdAtStart: state.createdAtStart ?? undefined,
+          }}
+        />
+        <TableContainer>
+          <Table>
+            <TableHead
+              headCells={headCells}
+              numSelected={selected.size}
+              onSelectAllClick={handleSelectAll}
+              onSortChange={handleSortChange}
+              rowCount={pageLength}
+              sort={state.sort}
+            />
+            <TableBody>
+              {tableRows}
+              {emptyRows > 0 && (
+                <TableRow style={{ height: DefaultRowHeight * emptyRows }}>
+                  <TableCell colSpan={headCells.length + 1} />
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+        <TablePagination
+          rowsPerPageOptions={[]}
+          component="div"
+          count={-1}
+          labelDisplayedRows={(displayedRows) =>
+            formatCursorPaginationLabel(
+              displayedRows,
+              paginationCursors?.next != null,
+              pageLength,
+              visiblePage != null
+            )
+          }
+          rowsPerPage={pageSize}
+          page={state.page}
+          onPageChange={handleChangePage}
+          slotProps={{
+            actions: {
+              nextButton: { disabled: paginationCursors?.next == null },
+              previousButton: {
+                disabled:
+                  state.page === 0 || previousCursors[state.page - 1] == null,
+              },
+            },
+          }}
+        />
+      </Paper>
+      <CreateFileDialog
+        open={showDialog}
+        onClose={() => setShowDialog(false)}
+        onFileCreated={() => {
+          setShowDialog(false);
+          setShowToast(true);
+          mutate();
+        }}
+      />
+      <Snackbar
+        open={showToast}
+        autoHideDuration={6000}
+        onClose={() => setShowToast(false)}
+      >
+        <Alert onClose={() => setShowToast(false)} severity="success">
+          File created!
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={downloadError != null}
+        autoHideDuration={6000}
+        onClose={() => setDownloadError(undefined)}
+      >
+        <Alert onClose={() => setDownloadError(undefined)} severity="error">
+          {downloadError}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+}

--- a/src/lib/files-nuqs-state.ts
+++ b/src/lib/files-nuqs-state.ts
@@ -1,0 +1,58 @@
+import { createParser, inferParserType, parseAsInteger, parseAsString } from "nuqs";
+
+import { SortState, toSortParam } from "./sorting";
+
+export const DefaultFileSort: SortState = {
+  field: "created",
+  order: "desc",
+};
+
+const FileSortValues: Record<string, SortState> = {
+  "-created": { field: "created", order: "desc" },
+  "-name": { field: "name", order: "desc" },
+  created: { field: "created", order: "asc" },
+  name: { field: "name", order: "asc" },
+};
+
+/**
+ * Sort is stored in the URL as the API sort parameter, e.g. `-created`.
+ * Unknown values parse to `null`, which nuqs replaces with the default.
+ */
+export const parseAsFileSort = createParser<SortState>({
+  eq: (a, b) => a.field === b.field && a.order === b.order,
+  parse: (value) => FileSortValues[value] ?? null,
+  serialize: toSortParam,
+});
+
+/** Page index must be a non-negative integer; anything else falls back. */
+export const parseAsPageIndex = createParser<number>({
+  parse: (value) => {
+    const parsed = parseAsInteger.parse(value);
+    return parsed == null || parsed < 0 ? null : parsed;
+  },
+  serialize: (value) => parseAsInteger.serialize(value),
+});
+
+export const fileTableParsers = {
+  createdAtEnd: parseAsString,
+  createdAtStart: parseAsString,
+  cursor: parseAsString,
+  filterId: parseAsString,
+  name: parseAsString,
+  page: parseAsPageIndex.withDefault(0),
+  sort: parseAsFileSort.withDefault(DefaultFileSort),
+  suppliedId: parseAsString,
+};
+
+export const fileTableUrlKeys = {
+  createdAtEnd: "fileCreatedAtEnd",
+  createdAtStart: "fileCreatedAtStart",
+  cursor: "fileCursor",
+  filterId: "fileFilterId",
+  name: "fileName",
+  page: "filePage",
+  sort: "fileSort",
+  suppliedId: "fileSuppliedId",
+};
+
+export type FileTableState = inferParserType<typeof fileTableParsers>;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from "@mui/material/styles";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
+import { NuqsAdapter } from "nuqs/adapters/next/pages";
 import React from "react";
 import { SWRConfig } from "swr";
 
@@ -114,7 +115,9 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
           <SWRConfig
             value={{ fetcher: (url) => fetch(url).then((res) => res.json()) }}
           >
-            <Component {...pageProps} />
+            <NuqsAdapter>
+              <Component {...pageProps} />
+            </NuqsAdapter>
           </SWRConfig>
         </ThemeProvider>
       </CacheProvider>

--- a/src/pages/files-nuqs.tsx
+++ b/src/pages/files-nuqs.tsx
@@ -1,0 +1,73 @@
+import { Alert, Box } from "@mui/material";
+import { FileList } from "@vertexvis/api-client-node";
+import dynamic from "next/dynamic";
+import { parseAsString, useQueryState } from "nuqs";
+import React from "react";
+import useSWR from "swr";
+
+import { FileDetailsDrawer } from "../components/file/FileDetailsDrawer";
+import { AppLink } from "../components/shared/AppLink";
+import { Layout } from "../components/shared/Layout";
+import { ErrorRes } from "../lib/api";
+import { File, toFile } from "../lib/files";
+import { defaultServerSideProps } from "../lib/with-session";
+
+const NuqsFileTable = dynamic(
+  () => import("../components/file/NuqsFileTable"),
+  { ssr: false }
+);
+
+type FileData = FileList["data"][number];
+
+function toSelectedFile(data?: FileData | ErrorRes): File | undefined {
+  if (data == null || !("attributes" in data)) return undefined;
+  return toFile(data);
+}
+
+export default function FilesNuqs(): JSX.Element {
+  const [selectedFileId, setSelectedFileId] = useQueryState(
+    "fileId",
+    parseAsString.withOptions({ history: "push" })
+  );
+  const { data: selectedFromUrl } = useSWR<FileData | ErrorRes>(
+    selectedFileId != null
+      ? `/api/files/${encodeURIComponent(selectedFileId)}`
+      : null
+  );
+
+  const selectedFile = toSelectedFile(selectedFromUrl);
+  const drawerOpen = selectedFileId != null;
+
+  return (
+    <Layout
+      main={
+        <>
+          <Box sx={{ mx: 2, mt: 2 }}>
+            <Alert severity="info">
+              This page stores its transferable state in the URL with nuqs.
+              Compare the{" "}
+              <AppLink href="/files-route-state">
+                bespoke route-state page
+              </AppLink>{" "}
+              and the <AppLink href="/files">original Files page</AppLink>.
+            </Alert>
+          </Box>
+          <NuqsFileTable
+            activeFileId={selectedFileId ?? undefined}
+            onFileSelected={(file) => void setSelectedFileId(file.id)}
+          />
+        </>
+      }
+      rightDrawer={
+        <FileDetailsDrawer
+          file={selectedFile}
+          onClose={() => void setSelectedFileId(null)}
+          open={drawerOpen}
+        />
+      }
+      rightDrawerOpen={drawerOpen}
+    />
+  );
+}
+
+export const getServerSideProps = defaultServerSideProps;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,15 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "paths": {
+      "nuqs": ["./node_modules/nuqs/dist/index.d.ts"],
+      "nuqs/adapters/next/pages": [
+        "./node_modules/nuqs/dist/adapters/next/pages.d.ts"
+      ],
+      "nuqs/adapters/testing": [
+        "./node_modules/nuqs/dist/adapters/testing.d.ts"
+      ]
+    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1547,6 +1547,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@standard-schema/spec@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@stencil/core@^2.16.1":
   version "2.22.3"
   resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.22.3.tgz#83987e20bba855c450f6d6780e3a20192603f13f"
@@ -5598,6 +5603,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nuqs@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/nuqs/-/nuqs-2.9.1.tgz#b2a510a43e4dd46cb69bfcc14f0227f1aafe9713"
+  integrity sha512-xctOTExJ/M2lV9NBXTkLMb3vnGBLk/eMuZyiXSbj0jA24H6ie2d7/LJiaA0C30p5XCIWaDTZl5DEF/N2Yo1LCw==
+  dependencies:
+    "@standard-schema/spec" "1.1.0"
+
 nwsapi@^2.2.2:
   version "2.2.24"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
@@ -7111,10 +7123,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
Counterpart to #344: `/files-nuqs` stores the same URL state (filters, sort, cursor paging, selected file) with [nuqs](https://nuqs.dev) instead of the bespoke route-state framework, for side-by-side comparison. Both pages use identical URL parameter names, so any deep link works on either page by swapping the path segment.

## Comparison vs the bespoke prototype

- **676 lines** (58 lib + 545 table + 73 page) vs **975** (212 framework + 50 lib + 619 table + 94 page).
- Gone: the per-input local state + URL→input sync effect (and its mid-typing wipe bug — inputs are URL-controlled with `limitUrlUpdates: debounce(300)`), lodash.debounce, and the page-level `setTableState` lens.
- Free fixes: batched updates (no lost-update race), parse-never-crashes (bad URL values fall back to defaults), default elision.
- Unsolved by either: session-only cursor cache, reset-paging-on-filter-change effect, and the disabled previous button on a deep-linked page N (cursor-paging design issue, kept for parity).

## Adoption costs

- TypeScript upgraded to ^5 (nuqs ships TS 5 syntax in its type definitions); zero new type errors vs 4.9.
- `tsconfig` `paths` mappings for nuqs entry points, because `moduleResolution: "node"` cannot read package exports (droppable if the repo moves to `"bundler"`).
- nuqs is ESM-only, so it is added to Jest `transformIgnorePatterns`.

## Testing

- `NuqsFileTable.test.tsx` (via `NuqsTestingAdapter`): deep-link hydration, atomic filter+paging-reset update, push-history pagination.
- `files-nuqs-state.test.ts`: sort/page parsers.
- Full suite green; lint, typecheck, and production build pass.