### PR TITLE
feat(scenes): roll out nuqs deep linking to the Scenes table (per-page cost demo)

### DIFF
--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
+import { NuqsTestingAdapter, UrlUpdateEvent } from "nuqs/adapters/testing";
 import React from "react";
 
 import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
@@ -140,6 +141,85 @@ describe("SceneTable", () => {
       "/scene-viewer/scene-1"
     );
   });
+
+  it("loads transferable table state from the URL", async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get("*/api/scenes", ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable(undefined, undefined, {
+      searchParams:
+        "?sceneName=alpha&sceneSuppliedId=supplied-scene-1" +
+        "&sceneCursor=cursor-2&scenePage=2",
+    });
+
+    expect(await screen.findByText("Scene One")).toBeInTheDocument();
+    expect(screen.getByLabelText("Name Filter")).toHaveValue("alpha");
+    expect(screen.getByLabelText("Supplied ID Filter")).toHaveValue(
+      "supplied-scene-1"
+    );
+    expect(screen.getByLabelText("Go to previous page")).toBeDisabled();
+
+    const request = new URL(requests[0]);
+    expect(request.searchParams.get("cursor")).toBe("cursor-2");
+    expect(request.searchParams.get("name")).toBe("alpha");
+    expect(request.searchParams.get("suppliedId")).toBe("supplied-scene-1");
+  });
+
+  it("updates a filter and resets paging as one URL update", async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get("*/api/scenes", () => HttpResponse.json(page)));
+
+    renderTable(undefined, undefined, {
+      onUrlUpdate: (event) => events.push(event),
+      searchParams: "?sceneCursor=cursor-2&scenePage=2",
+    });
+
+    expect(await screen.findByText("Scene One")).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText("Name Filter"), "alpha");
+
+    await waitFor(() => {
+      const last = events[events.length - 1];
+      expect(last?.searchParams.get("sceneName")).toBe("alpha");
+    });
+
+    const last = events[events.length - 1];
+    expect(last.options.history).toBe("replace");
+    expect(last.searchParams.has("sceneCursor")).toBe(false);
+    expect(last.searchParams.has("scenePage")).toBe(false);
+    expect(screen.getByLabelText("Name Filter")).toHaveValue("alpha");
+  });
+
+  it("moves forward with the API cursor using push history", async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(
+      http.get("*/api/scenes", () =>
+        HttpResponse.json({
+          ...page,
+          cursors: { self: "page-1", next: "page-2" },
+        })
+      )
+    );
+
+    renderTable(undefined, undefined, {
+      onUrlUpdate: (event) => events.push(event),
+    });
+
+    expect(await screen.findByText("Scene One")).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText("Go to next page"));
+
+    await waitFor(() => expect(events.length).toBe(1));
+    expect(events[0].options.history).toBe("push");
+    expect(events[0].searchParams.get("sceneCursor")).toBe("page-2");
+    expect(events[0].searchParams.get("scenePage")).toBe("1");
+  });
 });
 
 function getSceneRow(name = "Scene One"): HTMLTableRowElement {
@@ -149,24 +229,37 @@ function getSceneRow(name = "Scene One"): HTMLTableRowElement {
   return row;
 }
 
+interface AdapterProps {
+  readonly onUrlUpdate?: (event: UrlUpdateEvent) => void;
+  readonly searchParams?: string;
+}
+
 function renderTable(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
+  adapterProps: AdapterProps = {}
 ) {
-  return renderWithSWR(renderTableElement(scene, props));
+  return renderWithSWR(renderTableElement(scene, props, adapterProps));
 }
 
 function renderTableElement(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
+  adapterProps: AdapterProps = {}
 ): JSX.Element {
   return (
-    <SceneTable
-      invalidationCount={0}
-      onClick={jest.fn()}
-      onEditClick={jest.fn()}
-      scene={scene}
-      {...props}
-    />
+    <NuqsTestingAdapter
+      hasMemory={true}
+      onUrlUpdate={adapterProps.onUrlUpdate}
+      searchParams={adapterProps.searchParams}
+    >
+      <SceneTable
+        invalidationCount={0}
+        onClick={jest.fn()}
+        onEditClick={jest.fn()}
+        scene={scene}
+        {...props}
+      />
+    </NuqsTestingAdapter>
   );
 }

--- a/src/__tests__/lib/files-nuqs-state.test.ts
+++ b/src/__tests__/lib/files-nuqs-state.test.ts
@@ -1,8 +1,4 @@
-import {
-  DefaultFileSort,
-  parseAsFileSort,
-  parseAsPageIndex,
-} from "../../lib/files-nuqs-state";
+import { DefaultFileSort, parseAsFileSort } from "../../lib/files-nuqs-state";
 
 describe("files-nuqs-state", () => {
   describe("parseAsFileSort", () => {
@@ -28,9 +24,9 @@ describe("files-nuqs-state", () => {
     });
 
     it("serializes back to the API sort parameter", () => {
-      expect(
-        parseAsFileSort.serialize({ field: "name", order: "desc" })
-      ).toBe("-name");
+      expect(parseAsFileSort.serialize({ field: "name", order: "desc" })).toBe(
+        "-name"
+      );
       expect(parseAsFileSort.serialize(DefaultFileSort)).toBe("-created");
     });
 
@@ -44,18 +40,6 @@ describe("files-nuqs-state", () => {
       expect(
         parseAsFileSort.eq(DefaultFileSort, { field: "name", order: "desc" })
       ).toBe(false);
-    });
-  });
-
-  describe("parseAsPageIndex", () => {
-    it("parses non-negative integers", () => {
-      expect(parseAsPageIndex.parse("0")).toBe(0);
-      expect(parseAsPageIndex.parse("12")).toBe(12);
-    });
-
-    it("returns null for malformed values so the default applies", () => {
-      expect(parseAsPageIndex.parse("-1")).toBeNull();
-      expect(parseAsPageIndex.parse("not-a-page")).toBeNull();
     });
   });
 });

--- a/src/__tests__/lib/nuqs-table-state.test.ts
+++ b/src/__tests__/lib/nuqs-table-state.test.ts
@@ -1,0 +1,62 @@
+import { makeSortParser, parseAsPageIndex } from "../../lib/nuqs-table-state";
+
+describe("nuqs-table-state", () => {
+  describe("parseAsPageIndex", () => {
+    it("parses non-negative integers", () => {
+      expect(parseAsPageIndex.parse("0")).toBe(0);
+      expect(parseAsPageIndex.parse("12")).toBe(12);
+    });
+
+    it("returns null for malformed values so the default applies", () => {
+      expect(parseAsPageIndex.parse("-1")).toBeNull();
+      expect(parseAsPageIndex.parse("not-a-page")).toBeNull();
+    });
+  });
+
+  describe("makeSortParser", () => {
+    const parser = makeSortParser({
+      "-created": { field: "created", order: "desc" },
+      created: { field: "created", order: "asc" },
+    });
+
+    it("parses known API sort parameter values", () => {
+      expect(parser.parse("created")).toEqual({
+        field: "created",
+        order: "asc",
+      });
+      expect(parser.parse("-created")).toEqual({
+        field: "created",
+        order: "desc",
+      });
+    });
+
+    it("returns null for unknown values so the default applies", () => {
+      expect(parser.parse("unsupported")).toBeNull();
+      expect(parser.parse("")).toBeNull();
+    });
+
+    it("serializes back to the API sort parameter", () => {
+      expect(parser.serialize({ field: "created", order: "desc" })).toBe(
+        "-created"
+      );
+      expect(parser.serialize({ field: "created", order: "asc" })).toBe(
+        "created"
+      );
+    });
+
+    it("treats equivalent sort states as equal for default elision", () => {
+      expect(
+        parser.eq?.(
+          { field: "created", order: "desc" },
+          { field: "created", order: "desc" }
+        )
+      ).toBe(true);
+      expect(
+        parser.eq?.(
+          { field: "created", order: "desc" },
+          { field: "name", order: "desc" }
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/src/components/file/NuqsFileTable.tsx
+++ b/src/components/file/NuqsFileTable.tsx
@@ -15,7 +15,6 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Cursors } from "@vertexvis/api-client-node";
 import { debounce, Nullable, useQueryStates } from "nuqs";
 import React from "react";
 import useSWR from "swr";
@@ -38,6 +37,7 @@ import {
   FileTableState,
   fileTableUrlKeys,
 } from "../../lib/files-nuqs-state";
+import { useUrlCursorPaging } from "../../lib/nuqs-table-state";
 import { buildQuery, SwrProps } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import {
@@ -136,10 +136,6 @@ export default function NuqsFileTable({
   const [state, setState] = useQueryStates(fileTableParsers, {
     urlKeys: fileTableUrlKeys,
   });
-  const [cachedCursors, setCachedCursors] = React.useState<Cursors>();
-  const [previousCursors, setPreviousCursors] = React.useState<
-    Record<number, string | undefined>
-  >({});
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
   const [showToast, setShowToast] = React.useState(false);
@@ -165,16 +161,26 @@ export default function NuqsFileTable({
   const page = data && !isErrorRes(data) ? toFilePage(data) : undefined;
   const visiblePage = page;
   const pageLength = visiblePage ? visiblePage.items.length : 0;
-  const paginationCursors = visiblePage?.cursors ?? cachedCursors;
+  const paging = useUrlCursorPaging({
+    cursor: state.cursor,
+    cursors: page?.cursors ?? undefined,
+    loaded: page != null,
+    page: state.page,
+    searchKey: JSON.stringify({
+      createdAtEnd: state.createdAtEnd,
+      createdAtStart: state.createdAtStart,
+      filterId: state.filterId,
+      name: state.name,
+      sort: state.sort,
+      suppliedId: state.suppliedId,
+    }),
+    setPaging: (patch) => void setState(patch, { history: "push" }),
+  });
+  const { paginationCursors, resetPagingCache } = paging;
   const emptyRows =
     paginationCursors?.next == null && paginationCursors?.self == null
       ? 0
       : pageSize - pageLength;
-
-  const resetPagingCache = React.useCallback(() => {
-    setCachedCursors(undefined);
-    setPreviousCursors({});
-  }, []);
 
   function handleTextFilterChange(
     field: "filterId" | "name" | "suppliedId",
@@ -190,29 +196,6 @@ export default function NuqsFileTable({
     void setState(patch, { limitUrlUpdates: debounce(FilterDebounceMs) });
   }
 
-  const searchKey = JSON.stringify({
-    createdAtEnd: state.createdAtEnd,
-    createdAtStart: state.createdAtStart,
-    filterId: state.filterId,
-    name: state.name,
-    sort: state.sort,
-    suppliedId: state.suppliedId,
-  });
-  const previousSearchKey = React.useRef(searchKey);
-
-  React.useEffect(() => {
-    if (previousSearchKey.current !== searchKey) {
-      previousSearchKey.current = searchKey;
-      resetPagingCache();
-    }
-  }, [searchKey, resetPagingCache]);
-
-  React.useEffect(() => {
-    if (page == null) return;
-
-    setCachedCursors(page.cursors ?? undefined);
-  }, [page]);
-
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
     if (visiblePage == null) return;
 
@@ -227,24 +210,6 @@ export default function NuqsFileTable({
     else upd.add(id);
 
     setSelected(upd);
-  }
-
-  function handleChangePage(
-    _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
-  ) {
-    let nextCursor = state.cursor;
-    if (state.page < num) {
-      nextCursor = paginationCursors?.next ?? null;
-      setPreviousCursors((current) => ({
-        ...current,
-        [state.page]: paginationCursors?.self,
-      }));
-    } else if (state.page > num) {
-      nextCursor = previousCursors[num] ?? null;
-    }
-
-    void setState({ cursor: nextCursor, page: num }, { history: "push" });
   }
 
   function handleSortChange(field: string) {
@@ -501,14 +466,11 @@ export default function NuqsFileTable({
           }
           rowsPerPage={pageSize}
           page={state.page}
-          onPageChange={handleChangePage}
+          onPageChange={paging.handleChangePage}
           slotProps={{
             actions: {
-              nextButton: { disabled: paginationCursors?.next == null },
-              previousButton: {
-                disabled:
-                  state.page === 0 || previousCursors[state.page - 1] == null,
-              },
+              nextButton: { disabled: paging.nextDisabled },
+              previousButton: { disabled: paging.previousDisabled },
             },
           }}
         />

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -15,16 +15,22 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Cursors, SceneData } from "@vertexvis/api-client-node";
-import debounce from "lodash.debounce";
+import { SceneData } from "@vertexvis/api-client-node";
 import { useRouter } from "next/router";
+import { debounce, Nullable, useQueryStates } from "nuqs";
 import React, { useEffect } from "react";
 import useSWR from "swr";
 
 import { ErrorRes, GetRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
+import { useUrlCursorPaging } from "../../lib/nuqs-table-state";
 import { SwrProps } from "../../lib/paging";
 import { Scene, toScenePage } from "../../lib/scenes";
+import {
+  sceneTableParsers,
+  SceneTableState,
+  sceneTableUrlKeys,
+} from "../../lib/scenes-nuqs-state";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -41,6 +47,8 @@ interface Props {
   readonly scene?: Scene;
   readonly invalidationCount: number;
 }
+
+const FilterDebounceMs = 300;
 
 const headCells: readonly HeadCell[] = [
   { id: "name", disablePadding: true, label: "Name" },
@@ -84,31 +92,24 @@ export default function SceneTable({
   invalidationCount,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
-  const [curPage, setCurPage] = React.useState(0);
+  const [state, setState] = useQueryStates(sceneTableParsers, {
+    urlKeys: sceneTableUrlKeys,
+  });
   const [showMergeScene, setShowMergeScene] = React.useState(false);
-  const [cursor, setCursor] = React.useState<string | undefined>();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [keyLoadingSceneId, setKeyLoadingSceneId] = React.useState<
     string | undefined
   >();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
-  );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [activeSceneId, setActiveSceneId] = React.useState<string | undefined>(
     () => scene?.id
   );
-  const [suppliedId, setSuppliedIdFilter] = React.useState<
-    string | undefined
-  >();
-  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
 
   const { data, error, mutate } = useScenes({
-    cursor,
+    cursor: state.cursor ?? undefined,
     pageSize,
-    suppliedId,
-    name: nameFilter,
+    suppliedId: state.suppliedId?.trim() || undefined,
+    name: state.name?.trim() || undefined,
   });
 
   useEffect(() => {
@@ -118,24 +119,33 @@ export default function SceneTable({
   const router = useRouter();
   const page = data ? toScenePage(data) : undefined;
   const pageLength = page ? page.items.length : 0;
+  const paging = useUrlCursorPaging({
+    cursor: state.cursor,
+    cursors: page?.cursors ?? undefined,
+    loaded: page != null,
+    page: state.page,
+    searchKey: JSON.stringify({
+      name: state.name,
+      suppliedId: state.suppliedId,
+    }),
+    setPaging: (patch) => void setState(patch, { history: "push" }),
+  });
+  const { paginationCursors } = paging;
   const emptyRows =
-    cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
+    paginationCursors?.next == null && paginationCursors?.self == null
+      ? 0
+      : pageSize - pageLength;
 
-  const debouncedSetSuppliedIdFilter = React.useMemo(
-    () => debounce(setSuppliedIdFilter, 300),
-    []
-  );
+  function handleFilterChange(field: "name" | "suppliedId", value: string) {
+    const patch: Partial<Nullable<SceneTableState>> = {
+      cursor: null,
+      page: null,
+    };
+    patch[field] = value === "" ? null : value;
 
-  const debouncedSetNameFilter = React.useMemo(
-    () => debounce(setNameFilter, 300),
-    []
-  );
-
-  React.useEffect(() => {
-    if (page == null) return;
-
-    setCursors(page.cursors ?? undefined);
-  }, [page]);
+    paging.resetPagingCache();
+    void setState(patch, { limitUrlUpdates: debounce(FilterDebounceMs) });
+  }
 
   React.useEffect(() => {
     if (scene != null) setActiveSceneId(scene.id);
@@ -160,18 +170,6 @@ export default function SceneTable({
   function handleClick(s: Scene) {
     setActiveSceneId(s.id);
     onClick(s);
-  }
-
-  function handleChangePage(
-    _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
-  ) {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
   }
 
   async function handleDelete() {
@@ -243,10 +241,9 @@ export default function SceneTable({
             id="nameFilter"
             label="Name Filter"
             type="text"
-            onChange={(e) => {
-              debouncedSetNameFilter(e.target.value?.trim() ?? undefined);
-            }}
+            onChange={(e) => handleFilterChange("name", e.target.value)}
             sx={{ mt: 0, width: "20rem" }}
+            value={state.name ?? ""}
           />
           <TextField
             variant="standard"
@@ -255,10 +252,9 @@ export default function SceneTable({
             id="suppliedIdFilter"
             label="Supplied ID Filter"
             type="text"
-            onChange={(e) => {
-              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? undefined);
-            }}
+            onChange={(e) => handleFilterChange("suppliedId", e.target.value)}
             sx={{ mt: 0, width: "20rem" }}
+            value={state.suppliedId ?? ""}
           />
         </Box>
         <TableContainer>
@@ -362,17 +358,18 @@ export default function SceneTable({
           labelDisplayedRows={(displayedRows) =>
             formatCursorPaginationLabel(
               displayedRows,
-              cursors?.next != null,
+              paginationCursors?.next != null,
               pageLength,
               page != null
             )
           }
           rowsPerPage={pageSize}
-          page={curPage}
-          onPageChange={handleChangePage}
+          page={state.page}
+          onPageChange={paging.handleChangePage}
           slotProps={{
             actions: {
-              nextButton: { disabled: cursors?.next == null },
+              nextButton: { disabled: paging.nextDisabled },
+              previousButton: { disabled: paging.previousDisabled },
             },
           }}
         />

--- a/src/lib/files-nuqs-state.ts
+++ b/src/lib/files-nuqs-state.ts
@@ -1,36 +1,18 @@
-import { createParser, inferParserType, parseAsInteger, parseAsString } from "nuqs";
+import { inferParserType, parseAsString } from "nuqs";
 
-import { SortState, toSortParam } from "./sorting";
+import { makeSortParser, parseAsPageIndex } from "./nuqs-table-state";
+import { SortState } from "./sorting";
 
 export const DefaultFileSort: SortState = {
   field: "created",
   order: "desc",
 };
 
-const FileSortValues: Record<string, SortState> = {
+export const parseAsFileSort = makeSortParser({
   "-created": { field: "created", order: "desc" },
   "-name": { field: "name", order: "desc" },
   created: { field: "created", order: "asc" },
   name: { field: "name", order: "asc" },
-};
-
-/**
- * Sort is stored in the URL as the API sort parameter, e.g. `-created`.
- * Unknown values parse to `null`, which nuqs replaces with the default.
- */
-export const parseAsFileSort = createParser<SortState>({
-  eq: (a, b) => a.field === b.field && a.order === b.order,
-  parse: (value) => FileSortValues[value] ?? null,
-  serialize: toSortParam,
-});
-
-/** Page index must be a non-negative integer; anything else falls back. */
-export const parseAsPageIndex = createParser<number>({
-  parse: (value) => {
-    const parsed = parseAsInteger.parse(value);
-    return parsed == null || parsed < 0 ? null : parsed;
-  },
-  serialize: (value) => parseAsInteger.serialize(value),
 });
 
 export const fileTableParsers = {

--- a/src/lib/nuqs-table-state.ts
+++ b/src/lib/nuqs-table-state.ts
@@ -1,0 +1,123 @@
+import { Cursors } from "@vertexvis/api-client-node";
+import { createParser, parseAsInteger } from "nuqs";
+import React from "react";
+
+import { SortState, toSortParam } from "./sorting";
+
+/** Page index must be a non-negative integer; anything else falls back. */
+export const parseAsPageIndex = createParser<number>({
+  parse: (value) => {
+    const parsed = parseAsInteger.parse(value);
+    return parsed == null || parsed < 0 ? null : parsed;
+  },
+  serialize: (value) => parseAsInteger.serialize(value),
+});
+
+/**
+ * Sort is stored in the URL as the API sort parameter, e.g. `-created`.
+ * Unknown values parse to `null`, which nuqs replaces with the default.
+ */
+export function makeSortParser(
+  values: Record<string, SortState>
+): ReturnType<typeof createParser<SortState>> {
+  return createParser<SortState>({
+    eq: (a, b) => a.field === b.field && a.order === b.order,
+    parse: (value) => values[value] ?? null,
+    serialize: toSortParam,
+  });
+}
+
+export interface CursorPagingPatch {
+  readonly cursor: string | null;
+  readonly page: number;
+}
+
+interface UseUrlCursorPagingProps {
+  /** Cursor currently stored in the URL. */
+  readonly cursor: string | null;
+  /** Cursors returned with the currently loaded page, if any. */
+  readonly cursors?: Cursors;
+  /** Whether a page of results has loaded. */
+  readonly loaded: boolean;
+  /** Page index currently stored in the URL. */
+  readonly page: number;
+  /** Key derived from filter and sort state; a change resets the cache. */
+  readonly searchKey: string;
+  readonly setPaging: (patch: CursorPagingPatch) => void;
+}
+
+interface UseUrlCursorPaging {
+  readonly handleChangePage: (
+    event: React.MouseEvent<HTMLButtonElement> | null,
+    num: number
+  ) => void;
+  readonly nextDisabled: boolean;
+  readonly paginationCursors?: Cursors;
+  readonly previousDisabled: boolean;
+  readonly resetPagingCache: () => void;
+}
+
+/**
+ * Cursor-based paging on top of URL state. The URL stores the cursor and
+ * page index; previous-page cursors are ephemeral server tokens that only
+ * live in session state, so the previous button is disabled on a fresh
+ * deep link until the user pages forward again.
+ */
+export function useUrlCursorPaging({
+  cursor,
+  cursors,
+  loaded,
+  page,
+  searchKey,
+  setPaging,
+}: UseUrlCursorPagingProps): UseUrlCursorPaging {
+  const [cachedCursors, setCachedCursors] = React.useState<Cursors>();
+  const [previousCursors, setPreviousCursors] = React.useState<
+    Record<number, string | undefined>
+  >({});
+
+  const paginationCursors = cursors ?? cachedCursors;
+
+  const resetPagingCache = React.useCallback(() => {
+    setCachedCursors(undefined);
+    setPreviousCursors({});
+  }, []);
+
+  const previousSearchKey = React.useRef(searchKey);
+  React.useEffect(() => {
+    if (previousSearchKey.current !== searchKey) {
+      previousSearchKey.current = searchKey;
+      resetPagingCache();
+    }
+  }, [searchKey, resetPagingCache]);
+
+  React.useEffect(() => {
+    if (loaded) setCachedCursors(cursors);
+  }, [cursors, loaded]);
+
+  function handleChangePage(
+    _: React.MouseEvent<HTMLButtonElement> | null,
+    num: number
+  ) {
+    let nextCursor = cursor;
+    if (page < num) {
+      nextCursor = paginationCursors?.next ?? null;
+      setPreviousCursors((current) => ({
+        ...current,
+        [page]: paginationCursors?.self,
+      }));
+    } else if (page > num) {
+      nextCursor = previousCursors[num] ?? null;
+    }
+
+    setPaging({ cursor: nextCursor, page: num });
+  }
+
+  return {
+    handleChangePage,
+    nextDisabled: paginationCursors?.next == null,
+    paginationCursors,
+    previousDisabled: page === 0 || previousCursors[page - 1] == null,
+    resetPagingCache,
+  };
+}

--- a/src/lib/scenes-nuqs-state.ts
+++ b/src/lib/scenes-nuqs-state.ts
@@ -1,0 +1,19 @@
+import { inferParserType, parseAsString } from "nuqs";
+
+import { parseAsPageIndex } from "./nuqs-table-state";
+
+export const sceneTableParsers = {
+  cursor: parseAsString,
+  name: parseAsString,
+  page: parseAsPageIndex.withDefault(0),
+  suppliedId: parseAsString,
+};
+
+export const sceneTableUrlKeys = {
+  cursor: "sceneCursor",
+  name: "sceneName",
+  page: "scenePage",
+  suppliedId: "sceneSuppliedId",
+};
+
+export type SceneTableState = inferParserType<typeof sceneTableParsers>;


### PR DESCRIPTION
## What

Stacked on #345 (the nuqs Files prototype). Demonstrates the **steady-state per-page cost** of rolling nuqs deep linking out to another page, by:

1. **Extracting the shared helpers** into `src/lib/nuqs-table-state.ts` (~123 lines, one-time):
   - `parseAsPageIndex` — non-negative page index parser
   - `makeSortParser(values)` — factory for API-sort-param parsers (`-created` style)
   - `useUrlCursorPaging` — cursor cache + previous-cursor map + page-change handler + filter-change cache reset, on top of URL state
2. **Refactoring the Files prototype onto them** — `NuqsFileTable.tsx` shrinks by ~50 lines, `files-nuqs-state.ts` by ~20
3. **Converting the Scenes table in place** (it lives on the home page `/`) — this diff is the demo

## The per-page cost

| File | Delta |
|---|---|
| `src/lib/scenes-nuqs-state.ts` (new) | +19 — the whole deep-link contract: 4 params, their URL names, defaults |
| `src/components/scene/SceneTable.tsx` | +49/−52 (**net −3**) — URL wiring *replaces* existing local-state wiring (`useState` × 5, lodash debounce memos, cursor effect) |

**Net: +16 lines** to make the Scenes table deep-linkable, versus ~260 lines/page under the bespoke framework approach (#344).

## What the Scenes page gains

- Shareable URLs for name/supplied-ID filters and pagination position: `/?sceneName=alpha&scenePage=1&sceneCursor=…`
- Back/forward button moves through pagination history (`history: "push"` on page changes)
- Filter typing debounces URL writes (300 ms) and atomically resets paging in the same update
- Same known limitation as Files, inherent to cursor paging: the previous button is disabled on a fresh deep link because previous-page cursors are ephemeral server tokens (session-only)

## Testing

- `SceneTable.test.tsx`: existing 4 tests updated for the nuqs testing adapter, plus 3 new deep-link tests mirroring the Files ones (URL hydration → inputs + API request params, filter-resets-paging as one replace update, next-page push with cursor)
- New `nuqs-table-state.test.ts` for the shared parsers
- Full suite: 21 suites / 110 tests pass; `tsc --noEmit` shows only the 6 pre-existing errors; lint clean