### PR TITLE
feat: URL deep linking with nuqs (full conversion of Files and Scenes)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,7 @@ const projectConfig = {
     '^.+\\.(ts|tsx|js|jsx|mjs)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }],
   },
   transformIgnorePatterns: [
-    '/node_modules/(?!(@mswjs|@open-draft|msw|rettime|until-async|headers-polyfill|is-node-process|outvariant|strict-event-emitter|path-to-regexp)/)',
+    '/node_modules/(?!(@mswjs|@open-draft|msw|nuqs|rettime|until-async|headers-polyfill|is-node-process|outvariant|strict-event-emitter|path-to-regexp)/)',
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "^15.5.18",
     "next-connect": "^0.13.0",
     "next-iron-session": "^4.2",
+    "nuqs": "^2.9.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.63.0",

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { NuqsTestingAdapter, UrlUpdateEvent } from 'nuqs/adapters/testing';
 import React from 'react';
 
 import { installJsdomMockServer } from '../../../../test/msw/installJsdomMockServer';
@@ -200,11 +201,101 @@ describe('FileTable', () => {
     expect(fromInput).toHaveValue('2026-07-01');
     expect(toInput).toHaveValue('');
   });
+
+  it('loads transferable table state from the URL', async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get('*/api/files', ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable(jest.fn(), undefined, {
+      searchParams:
+        '?fileName=alpha&fileFilterId=file-filter&fileSuppliedId=supplied-1' +
+        '&fileCreatedAtStart=2026-06-01&fileCreatedAtEnd=2026-06-30' +
+        '&fileCursor=cursor-2&filePage=2&fileSort=name',
+    });
+
+    expect(await screen.findByText('alpha.jt')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toHaveValue('alpha');
+    expect(screen.getByLabelText('File ID')).toHaveValue('file-filter');
+    expect(screen.getByLabelText('Supplied ID')).toHaveValue('supplied-1');
+    expect(screen.getByLabelText('Created From')).toHaveValue('2026-06-01');
+    expect(screen.getByLabelText('Created To')).toHaveValue('2026-06-30');
+    expect(screen.getByLabelText('Go to previous page')).toBeDisabled();
+
+    const request = new URL(requests[0]);
+    expect(request.searchParams.get('cursor')).toBe('cursor-2');
+    expect(request.searchParams.get('fileId')).toBe('file-filter');
+    expect(request.searchParams.get('name')).toBe('alpha');
+    expect(request.searchParams.get('sort')).toBe('name');
+    expect(request.searchParams.get('suppliedId')).toBe('supplied-1');
+    expect(request.searchParams.has('createdAtStart')).toBe(true);
+    expect(request.searchParams.has('createdAtEnd')).toBe(true);
+  });
+
+  it('updates a filter and resets paging as one URL update', async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get('*/api/files', () => HttpResponse.json(page)));
+
+    renderTable(jest.fn(), undefined, {
+      onUrlUpdate: (event) => events.push(event),
+      searchParams: '?fileCursor=cursor-2&filePage=2',
+    });
+
+    expect(await screen.findByText('alpha.jt')).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText('Name'), 'alpha');
+
+    await waitFor(() => {
+      const last = events[events.length - 1];
+      expect(last?.searchParams.get('fileName')).toBe('alpha');
+    });
+
+    const last = events[events.length - 1];
+    expect(last.options.history).toBe('replace');
+    expect(last.searchParams.has('fileCursor')).toBe(false);
+    expect(last.searchParams.has('filePage')).toBe(false);
+    expect(screen.getByLabelText('Name')).toHaveValue('alpha');
+  });
+
+  it('moves forward with the API cursor using push history', async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get('*/api/files', () => HttpResponse.json(pagedPage)));
+
+    renderTable(jest.fn(), undefined, {
+      onUrlUpdate: (event) => events.push(event),
+    });
+
+    expect(await screen.findByText('alpha.jt')).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('Go to next page'));
+
+    await waitFor(() => expect(events.length).toBe(1));
+    expect(events[0].options.history).toBe('push');
+    expect(events[0].searchParams.get('fileCursor')).toBe('page-2');
+    expect(events[0].searchParams.get('filePage')).toBe('1');
+  });
 });
 
 function renderTable(
   onFileSelected = jest.fn(),
-  props: Partial<React.ComponentProps<typeof FileTable>> = {}
+  props: Partial<React.ComponentProps<typeof FileTable>> = {},
+  adapterProps: {
+    onUrlUpdate?: (event: UrlUpdateEvent) => void;
+    searchParams?: string;
+  } = {}
 ): void {
-  renderWithSWR(<FileTable onFileSelected={onFileSelected} {...props} />);
+  renderWithSWR(
+    <NuqsTestingAdapter
+      hasMemory={true}
+      onUrlUpdate={adapterProps.onUrlUpdate}
+      searchParams={adapterProps.searchParams}
+    >
+      <FileTable onFileSelected={onFileSelected} {...props} />
+    </NuqsTestingAdapter>
+  );
 }

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -1,6 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
+import { NuqsTestingAdapter, UrlUpdateEvent } from 'nuqs/adapters/testing';
 import React from 'react';
 
 import { installJsdomMockServer } from '../../../../test/msw/installJsdomMockServer';
@@ -138,6 +139,83 @@ describe('SceneTable', () => {
       '/scene-viewer/scene-1'
     );
   });
+
+  it('loads transferable table state from the URL', async () => {
+    const requests: string[] = [];
+
+    server.use(
+      http.get('*/api/scenes', ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json(page);
+      })
+    );
+
+    renderTable(undefined, undefined, {
+      searchParams:
+        '?sceneName=alpha&sceneSuppliedId=supplied-scene-1' +
+        '&sceneCursor=cursor-2&scenePage=2',
+    });
+
+    expect(await screen.findByText('Scene One')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name Filter')).toHaveValue('alpha');
+    expect(screen.getByLabelText('Supplied ID Filter')).toHaveValue('supplied-scene-1');
+    expect(screen.getByLabelText('Go to previous page')).toBeDisabled();
+
+    const request = new URL(requests[0]);
+    expect(request.searchParams.get('cursor')).toBe('cursor-2');
+    expect(request.searchParams.get('name')).toBe('alpha');
+    expect(request.searchParams.get('suppliedId')).toBe('supplied-scene-1');
+  });
+
+  it('updates a filter and resets paging as one URL update', async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(http.get('*/api/scenes', () => HttpResponse.json(page)));
+
+    renderTable(undefined, undefined, {
+      onUrlUpdate: (event) => events.push(event),
+      searchParams: '?sceneCursor=cursor-2&scenePage=2',
+    });
+
+    expect(await screen.findByText('Scene One')).toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText('Name Filter'), 'alpha');
+
+    await waitFor(() => {
+      const last = events[events.length - 1];
+      expect(last?.searchParams.get('sceneName')).toBe('alpha');
+    });
+
+    const last = events[events.length - 1];
+    expect(last.options.history).toBe('replace');
+    expect(last.searchParams.has('sceneCursor')).toBe(false);
+    expect(last.searchParams.has('scenePage')).toBe(false);
+    expect(screen.getByLabelText('Name Filter')).toHaveValue('alpha');
+  });
+
+  it('moves forward with the API cursor using push history', async () => {
+    const events: UrlUpdateEvent[] = [];
+
+    server.use(
+      http.get('*/api/scenes', () =>
+        HttpResponse.json({
+          ...page,
+          cursors: { self: 'page-1', next: 'page-2' },
+        })
+      )
+    );
+
+    renderTable(undefined, undefined, {
+      onUrlUpdate: (event) => events.push(event),
+    });
+
+    expect(await screen.findByText('Scene One')).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('Go to next page'));
+
+    await waitFor(() => expect(events.length).toBe(1));
+    expect(events[0].options.history).toBe('push');
+    expect(events[0].searchParams.get('sceneCursor')).toBe('page-2');
+    expect(events[0].searchParams.get('scenePage')).toBe('1');
+  });
 });
 
 function getSceneRow(name = 'Scene One'): HTMLTableRowElement {
@@ -147,24 +225,37 @@ function getSceneRow(name = 'Scene One'): HTMLTableRowElement {
   return row;
 }
 
+interface AdapterProps {
+  readonly onUrlUpdate?: (event: UrlUpdateEvent) => void;
+  readonly searchParams?: string;
+}
+
 function renderTable(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
+  adapterProps: AdapterProps = {}
 ): ReturnType<typeof renderWithSWR> {
-  return renderWithSWR(renderTableElement(scene, props));
+  return renderWithSWR(renderTableElement(scene, props, adapterProps));
 }
 
 function renderTableElement(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
+  adapterProps: AdapterProps = {}
 ): JSX.Element {
   return (
-    <SceneTable
-      invalidationCount={0}
-      onClick={jest.fn()}
-      onEditClick={jest.fn()}
-      scene={scene}
-      {...props}
-    />
+    <NuqsTestingAdapter
+      hasMemory={true}
+      onUrlUpdate={adapterProps.onUrlUpdate}
+      searchParams={adapterProps.searchParams}
+    >
+      <SceneTable
+        invalidationCount={0}
+        onClick={jest.fn()}
+        onEditClick={jest.fn()}
+        scene={scene}
+        {...props}
+      />
+    </NuqsTestingAdapter>
   );
 }

--- a/src/__tests__/lib/files-nuqs-state.test.ts
+++ b/src/__tests__/lib/files-nuqs-state.test.ts
@@ -1,0 +1,43 @@
+import { DefaultFileSort, parseAsFileSort } from '../../lib/files-nuqs-state';
+
+describe('files-nuqs-state', () => {
+  describe('parseAsFileSort', () => {
+    it('parses API sort parameter values', () => {
+      expect(parseAsFileSort.parse('name')).toEqual({
+        field: 'name',
+        order: 'asc',
+      });
+      expect(parseAsFileSort.parse('-name')).toEqual({
+        field: 'name',
+        order: 'desc',
+      });
+      expect(parseAsFileSort.parse('created')).toEqual({
+        field: 'created',
+        order: 'asc',
+      });
+      expect(parseAsFileSort.parse('-created')).toEqual(DefaultFileSort);
+    });
+
+    it('returns null for unknown values so the default applies', () => {
+      expect(parseAsFileSort.parse('unsupported')).toBeNull();
+      expect(parseAsFileSort.parse('')).toBeNull();
+    });
+
+    it('serializes back to the API sort parameter', () => {
+      expect(parseAsFileSort.serialize({ field: 'name', order: 'desc' })).toBe('-name');
+      expect(parseAsFileSort.serialize(DefaultFileSort)).toBe('-created');
+    });
+
+    it('treats equivalent sort states as equal for default elision', () => {
+      expect(
+        parseAsFileSort.eq(DefaultFileSort, {
+          field: 'created',
+          order: 'desc',
+        })
+      ).toBe(true);
+      expect(parseAsFileSort.eq(DefaultFileSort, { field: 'name', order: 'desc' })).toBe(
+        false
+      );
+    });
+  });
+});

--- a/src/__tests__/lib/nuqs-table-state.test.ts
+++ b/src/__tests__/lib/nuqs-table-state.test.ts
@@ -1,0 +1,55 @@
+import { makeSortParser, parseAsPageIndex } from '../../lib/nuqs-table-state';
+
+describe('nuqs-table-state', () => {
+  describe('parseAsPageIndex', () => {
+    it('parses non-negative integers', () => {
+      expect(parseAsPageIndex.parse('0')).toBe(0);
+      expect(parseAsPageIndex.parse('12')).toBe(12);
+    });
+
+    it('returns null for malformed values so the default applies', () => {
+      expect(parseAsPageIndex.parse('-1')).toBeNull();
+      expect(parseAsPageIndex.parse('not-a-page')).toBeNull();
+    });
+  });
+
+  describe('makeSortParser', () => {
+    const parser = makeSortParser({
+      '-created': { field: 'created', order: 'desc' },
+      created: { field: 'created', order: 'asc' },
+    });
+
+    it('parses known API sort parameter values', () => {
+      expect(parser.parse('created')).toEqual({
+        field: 'created',
+        order: 'asc',
+      });
+      expect(parser.parse('-created')).toEqual({
+        field: 'created',
+        order: 'desc',
+      });
+    });
+
+    it('returns null for unknown values so the default applies', () => {
+      expect(parser.parse('unsupported')).toBeNull();
+      expect(parser.parse('')).toBeNull();
+    });
+
+    it('serializes back to the API sort parameter', () => {
+      expect(parser.serialize({ field: 'created', order: 'desc' })).toBe('-created');
+      expect(parser.serialize({ field: 'created', order: 'asc' })).toBe('created');
+    });
+
+    it('treats equivalent sort states as equal for default elision', () => {
+      expect(
+        parser.eq?.(
+          { field: 'created', order: 'desc' },
+          { field: 'created', order: 'desc' }
+        )
+      ).toBe(true);
+      expect(
+        parser.eq?.({ field: 'created', order: 'desc' }, { field: 'name', order: 'desc' })
+      ).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/pages/api/file-by-id.test.ts
+++ b/src/__tests__/pages/api/file-by-id.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+import type { NextApiResponse } from 'next';
+
+import { NextIronRequest } from '../../../lib/with-session';
+import { handleFileById } from '../../../pages/api/files/[id]';
+
+const mockGetFile = jest.fn();
+
+jest.mock('../../../lib/vertex-api', () => ({
+  getClientFromSession: jest.fn(() => ({
+    files: { getFile: mockGetFile },
+  })),
+}));
+
+describe('file by id route', () => {
+  beforeEach(() => {
+    mockGetFile.mockReset();
+  });
+
+  it('returns the single file so a deep link can hydrate the drawer', async () => {
+    const file = {
+      id: 'file-1',
+      type: 'file',
+      attributes: { name: 'alpha.jt', status: 'complete' },
+    };
+    mockGetFile.mockResolvedValue({ data: { data: file } });
+    const res = createResponse();
+
+    await handleFileById(
+      {
+        method: 'GET',
+        query: { id: 'file-1' },
+        session: {},
+      } as unknown as NextIronRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(mockGetFile).toHaveBeenCalledWith({ id: 'file-1' });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(file);
+  });
+
+  it('returns a 400 when the id is missing', async () => {
+    const res = createResponse();
+
+    await handleFileById(
+      { method: 'GET', query: {}, session: {} } as unknown as NextIronRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(mockGetFile).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects non-GET methods', async () => {
+    const res = createResponse();
+
+    await handleFileById(
+      {
+        method: 'POST',
+        query: { id: 'file-1' },
+        session: {},
+      } as unknown as NextIronRequest,
+      res as unknown as NextApiResponse
+    );
+
+    expect(mockGetFile).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+});
+
+function createResponse(): {
+  json: jest.Mock;
+  redirect: jest.Mock;
+  status: jest.Mock;
+} {
+  const res = {
+    json: jest.fn(),
+    redirect: jest.fn(),
+    status: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+}

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -15,12 +15,16 @@ import {
   TableRow,
   TextField,
 } from '@mui/material';
-import debounce from 'lodash.debounce';
+import { debounce, Nullable, useQueryStates } from 'nuqs';
 import React from 'react';
-import useSWR, { SWRResponse } from 'swr';
+import useSWR from 'swr';
 
 import { isErrorRes } from '../../lib/api';
-import { toLocaleString } from '../../lib/dates';
+import {
+  toLocalDateInputValue,
+  toLocalDayBoundaryIso,
+  toLocaleString,
+} from '../../lib/dates';
 import {
   File,
   FileStatusComplete,
@@ -28,8 +32,13 @@ import {
   normalizeFileStatus,
   toFilePage,
 } from '../../lib/files';
-import { buildQuery, SwrProps, useCursorPagingState } from '../../lib/paging';
-import { reportError } from '../../lib/report-error';
+import {
+  fileTableParsers,
+  FileTableState,
+  fileTableUrlKeys,
+} from '../../lib/files-nuqs-state';
+import { useUrlCursorPaging } from '../../lib/nuqs-table-state';
+import { buildQuery, SwrProps } from '../../lib/paging';
 import { SortState, toggleSort, toSortParam } from '../../lib/sorting';
 import {
   CreatedAtDateRange,
@@ -55,6 +64,8 @@ export const headCells: readonly HeadCell[] = [
   { id: 'actions', label: 'Actions' },
 ];
 
+const FilterDebounceMs = 300;
+
 interface UseFilesProps extends SwrProps {
   readonly createdAtEnd?: string;
   readonly createdAtStart?: string;
@@ -73,7 +84,7 @@ function useFiles({
   pageSize,
   sort,
   suppliedId,
-}: UseFilesProps): SWRResponse {
+}: UseFilesProps): ReturnType<typeof useSWR> {
   return useSWR(
     buildQuery('/api/files', {
       createdAtEnd,
@@ -115,70 +126,70 @@ interface Props {
   readonly onFileSelected: (file: File) => void;
 }
 
-type SetOptionalString = React.Dispatch<React.SetStateAction<string | undefined>>;
-function useDebouncedFilter(
-  setFilter: SetOptionalString,
-  resetPaging: () => void
-): (value: string) => void {
-  return React.useMemo(
-    () =>
-      debounce((value: string) => {
-        resetPaging();
-        setFilter(value === '' ? undefined : value);
-      }, 300),
-    [resetPaging, setFilter]
-  );
-}
-
 export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
-  const [sort, setSort] = React.useState<SortState>({
-    field: 'created',
-    order: 'desc',
+  const [state, setState] = useQueryStates(fileTableParsers, {
+    urlKeys: fileTableUrlKeys,
   });
-  const { currentPage, cursor, cursors, handlePageChange, resetPaging, setCursors } =
-    useCursorPagingState();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showDialog, setShowDialog] = React.useState(false);
-  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
-  const [fileIdFilter, setFileIdFilter] = React.useState<string | undefined>();
-  const [suppliedIdFilter, setSuppliedIdFilter] = React.useState<string | undefined>();
-  const [createdAtFilters, setCreatedAtFilters] = React.useState<CreatedAtDateRange>({});
   const [showToast, setShowToast] = React.useState(false);
   const [downloadError, setDownloadError] = React.useState<string>();
 
   const { data, error, mutate } = useFiles({
-    createdAtEnd: createdAtFilters.createdAtEnd,
-    createdAtStart: createdAtFilters.createdAtStart,
-    cursor,
-    fileId: fileIdFilter,
-    name: nameFilter,
+    createdAtEnd:
+      state.createdAtEnd != null
+        ? toLocalDayBoundaryIso(state.createdAtEnd, 'end')
+        : undefined,
+    createdAtStart:
+      state.createdAtStart != null
+        ? toLocalDayBoundaryIso(state.createdAtStart, 'start')
+        : undefined,
+    cursor: state.cursor ?? undefined,
+    fileId: state.filterId?.trim() || undefined,
+    name: state.name?.trim() || undefined,
     pageSize,
-    sort,
-    suppliedId: suppliedIdFilter,
+    sort: state.sort,
+    suppliedId: state.suppliedId?.trim() || undefined,
   });
   const loadError = error ?? (isErrorRes(data) ? data : undefined);
   const page = data && !isErrorRes(data) ? toFilePage(data) : undefined;
   const visiblePage = page;
   const pageLength = visiblePage ? visiblePage.items.length : 0;
-  const paginationCursors = visiblePage?.cursors ?? cursors;
+  const paging = useUrlCursorPaging({
+    cursor: state.cursor,
+    cursors: page?.cursors ?? undefined,
+    loaded: page != null,
+    page: state.page,
+    searchKey: JSON.stringify({
+      createdAtEnd: state.createdAtEnd,
+      createdAtStart: state.createdAtStart,
+      filterId: state.filterId,
+      name: state.name,
+      sort: state.sort,
+      suppliedId: state.suppliedId,
+    }),
+    setPaging: (patch) => void setState(patch, { history: 'push' }),
+  });
+  const { paginationCursors, resetPagingCache } = paging;
   const emptyRows =
     paginationCursors?.next == null && paginationCursors?.self == null
       ? 0
       : pageSize - pageLength;
 
-  const debouncedSetNameFilter = useDebouncedFilter(setNameFilter, resetPaging);
-  const debouncedSetFileIdFilter = useDebouncedFilter(setFileIdFilter, resetPaging);
-  const debouncedSetSuppliedIdFilter = useDebouncedFilter(
-    setSuppliedIdFilter,
-    resetPaging
-  );
+  function handleTextFilterChange(
+    field: 'filterId' | 'name' | 'suppliedId',
+    value: string
+  ): void {
+    const patch: Partial<Nullable<FileTableState>> = {
+      cursor: null,
+      page: null,
+    };
+    patch[field] = value === '' ? null : value;
 
-  React.useEffect(() => {
-    if (page == null) return;
-
-    setCursors(page.cursors ?? undefined);
-  }, [page, setCursors]);
+    resetPagingCache();
+    void setState(patch, { limitUrlUpdates: debounce(FilterDebounceMs) });
+  }
 
   function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (visiblePage == null) return;
@@ -196,21 +207,23 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
     setSelected(upd);
   }
 
-  function handleChangePage(
-    _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
-  ): void {
-    handlePageChange(num);
-  }
-
   function handleSortChange(field: string): void {
-    setSort((current) => toggleSort(current, field));
-    resetPaging();
+    resetPagingCache();
+    void setState((current) => ({
+      cursor: null,
+      page: null,
+      sort: toggleSort(current.sort, field),
+    }));
   }
 
   function handleCreatedAtChange(filters: CreatedAtDateRange): void {
-    resetPaging();
-    setCreatedAtFilters(filters);
+    resetPagingCache();
+    void setState({
+      createdAtEnd: toLocalDateInputValue(filters.createdAtEnd) || null,
+      createdAtStart: toLocalDateInputValue(filters.createdAtStart) || null,
+      cursor: null,
+      page: null,
+    });
   }
 
   async function handleDelete(): Promise<void> {
@@ -241,23 +254,17 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
     }
   }
 
-  function renderTableRows(): React.ReactNode {
-    if (loadError) {
-      return <DataLoadError colSpan={headCells.length + 1} />;
-    }
-
-    if (!visiblePage) {
-      return (
-        <SkeletonBody
-          includeCheckbox={true}
-          numCellsPerRow={8}
-          numRows={pageSize - pageLength}
-          rowHeight={DefaultRowHeight}
-        />
-      );
-    }
-
-    return visiblePage.items.map((row) => {
+  const tableRows = loadError ? (
+    <DataLoadError colSpan={headCells.length + 1} />
+  ) : !visiblePage ? (
+    <SkeletonBody
+      includeCheckbox={true}
+      numCellsPerRow={8}
+      numRows={pageSize - pageLength}
+      rowHeight={DefaultRowHeight}
+    />
+  ) : (
+    visiblePage.items.map((row) => {
       const isSel = selected.has(row.id);
       const isActive = activeFileId === row.id;
       const isAvailable = isFileAvailable(row);
@@ -323,7 +330,7 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
                 {
                   disabled: !isAvailable,
                   label: 'Download file',
-                  onClick: () => handleDownload(row.id),
+                  onClick: () => void handleDownload(row.id),
                 },
               ]}
               ariaLabel={`Actions for ${row.name}`}
@@ -331,10 +338,8 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
           </TableCell>
         </TableRow>
       );
-    });
-  }
-
-  const tableRows = renderTableRows();
+    })
+  );
 
   return (
     <>
@@ -354,9 +359,7 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
             ) : undefined
           }
           numSelected={selected.size}
-          onDelete={() => {
-            handleDelete().catch(reportError('Failed to delete files'));
-          }}
+          onDelete={() => void handleDelete()}
           title="Files"
         />
         <Box
@@ -377,10 +380,9 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
               id="nameFilter"
               label="Name"
               type="text"
-              onChange={(e) => {
-                debouncedSetNameFilter(e.target.value?.trim() ?? '');
-              }}
+              onChange={(e) => handleTextFilterChange('name', e.target.value)}
               sx={{ mt: 0, width: '16rem' }}
+              value={state.name ?? ''}
             />
             <TextField
               variant="standard"
@@ -389,10 +391,9 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
               id="fileIdFilter"
               label="File ID"
               type="text"
-              onChange={(e) => {
-                debouncedSetFileIdFilter(e.target.value?.trim() ?? '');
-              }}
+              onChange={(e) => handleTextFilterChange('filterId', e.target.value)}
               sx={{ mt: 0, width: '16rem' }}
+              value={state.filterId ?? ''}
             />
             <TextField
               variant="standard"
@@ -401,14 +402,19 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
               id="suppliedIdFilter"
               label="Supplied ID"
               type="text"
-              onChange={(e) => {
-                debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? '');
-              }}
+              onChange={(e) => handleTextFilterChange('suppliedId', e.target.value)}
               sx={{ mt: 0, width: '16rem' }}
+              value={state.suppliedId ?? ''}
             />
           </Box>
         </Box>
-        <CreatedAtDateRangeFilter onChange={handleCreatedAtChange} />
+        <CreatedAtDateRangeFilter
+          onChange={handleCreatedAtChange}
+          value={{
+            createdAtEnd: state.createdAtEnd ?? undefined,
+            createdAtStart: state.createdAtStart ?? undefined,
+          }}
+        />
         <TableContainer>
           <Table>
             <TableHead
@@ -417,7 +423,7 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
               onSelectAllClick={handleSelectAll}
               onSortChange={handleSortChange}
               rowCount={pageLength}
-              sort={sort}
+              sort={state.sort}
             />
             <TableBody>
               {tableRows}
@@ -442,11 +448,12 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
             )
           }
           rowsPerPage={pageSize}
-          page={currentPage}
-          onPageChange={handleChangePage}
+          page={state.page}
+          onPageChange={paging.handleChangePage}
           slotProps={{
             actions: {
-              nextButton: { disabled: paginationCursors?.next == null },
+              nextButton: { disabled: paging.nextDisabled },
+              previousButton: { disabled: paging.previousDisabled },
             },
           }}
         />
@@ -457,7 +464,7 @@ export default function FileTable({ activeFileId, onFileSelected }: Props): JSX.
         onFileCreated={() => {
           setShowDialog(false);
           setShowToast(true);
-          mutate().catch(reportError('Failed to refresh files'));
+          void mutate();
         }}
       />
       <Snackbar

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -15,17 +15,22 @@ import {
   TableRow,
   TextField,
 } from '@mui/material';
-import { Cursors, SceneData } from '@vertexvis/api-client-node';
-import debounce from 'lodash.debounce';
+import { SceneData } from '@vertexvis/api-client-node';
 import { useRouter } from 'next/router';
+import { debounce, Nullable, useQueryStates } from 'nuqs';
 import React, { useEffect } from 'react';
-import useSWR, { SWRResponse } from 'swr';
+import useSWR from 'swr';
 
 import { ErrorRes, GetRes } from '../../lib/api';
 import { toLocaleString } from '../../lib/dates';
+import { useUrlCursorPaging } from '../../lib/nuqs-table-state';
 import { SwrProps } from '../../lib/paging';
-import { reportError } from '../../lib/report-error';
 import { Scene, toScenePage } from '../../lib/scenes';
+import {
+  sceneTableParsers,
+  SceneTableState,
+  sceneTableUrlKeys,
+} from '../../lib/scenes-nuqs-state';
 import CreateSceneDialog from '../shared/CreateSceneDialog';
 import { formatCursorPaginationLabel } from '../shared/cursor-pagination';
 import { DataLoadError } from '../shared/DataLoadError';
@@ -43,6 +48,8 @@ interface Props {
   readonly invalidationCount: number;
 }
 
+const FilterDebounceMs = 300;
+
 const headCells: readonly HeadCell[] = [
   { id: 'name', disablePadding: true, label: 'Name' },
   { id: 'supplied-id', label: 'Supplied ID' },
@@ -57,7 +64,7 @@ function useScenes({
   pageSize,
   suppliedId,
   name,
-}: SwrProps): SWRResponse<GetRes<SceneData>, ErrorRes> {
+}: SwrProps): ReturnType<typeof useSWR> {
   return useSWR<GetRes<SceneData>, ErrorRes>(
     `/api/scenes?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ''}${
       suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ''
@@ -88,49 +95,58 @@ export default function SceneTable({
   invalidationCount,
 }: Props): JSX.Element {
   const pageSize = DefaultPageSize;
-  const [curPage, setCurPage] = React.useState(0);
+  const [state, setState] = useQueryStates(sceneTableParsers, {
+    urlKeys: sceneTableUrlKeys,
+  });
   const [showMergeScene, setShowMergeScene] = React.useState(false);
-  const [cursor, setCursor] = React.useState<string | undefined>();
-  const [cursors, setCursors] = React.useState<Cursors | undefined>();
   const [keyLoadingSceneId, setKeyLoadingSceneId] = React.useState<string | undefined>();
-  const [prev, setPrev] = React.useState<Record<number, string | undefined>>({});
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [activeSceneId, setActiveSceneId] = React.useState<string | undefined>(
     () => scene?.id
   );
-  const [suppliedId, setSuppliedIdFilter] = React.useState<string | undefined>();
-  const [nameFilter, setNameFilter] = React.useState<string | undefined>();
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
 
   const { data, error, mutate } = useScenes({
-    cursor,
+    cursor: state.cursor ?? undefined,
     pageSize,
-    suppliedId,
-    name: nameFilter,
+    suppliedId: state.suppliedId?.trim() || undefined,
+    name: state.name?.trim() || undefined,
   });
 
   useEffect(() => {
-    mutate().catch(reportError('Failed to refresh scenes'));
+    void mutate();
   }, [invalidationCount, mutate]);
 
   const router = useRouter();
   const page = data ? toScenePage(data) : undefined;
   const pageLength = page ? page.items.length : 0;
+  const paging = useUrlCursorPaging({
+    cursor: state.cursor,
+    cursors: page?.cursors ?? undefined,
+    loaded: page != null,
+    page: state.page,
+    searchKey: JSON.stringify({
+      name: state.name,
+      suppliedId: state.suppliedId,
+    }),
+    setPaging: (patch) => void setState(patch, { history: 'push' }),
+  });
+  const { paginationCursors } = paging;
   const emptyRows =
-    cursors?.next == null && cursors?.self == null ? 0 : pageSize - pageLength;
+    paginationCursors?.next == null && paginationCursors?.self == null
+      ? 0
+      : pageSize - pageLength;
 
-  const debouncedSetSuppliedIdFilter = React.useMemo(
-    () => debounce(setSuppliedIdFilter, 300),
-    []
-  );
+  function handleFilterChange(field: 'name' | 'suppliedId', value: string): void {
+    const patch: Partial<Nullable<SceneTableState>> = {
+      cursor: null,
+      page: null,
+    };
+    patch[field] = value === '' ? null : value;
 
-  const debouncedSetNameFilter = React.useMemo(() => debounce(setNameFilter, 300), []);
-
-  React.useEffect(() => {
-    if (page == null) return;
-
-    setCursors(page.cursors ?? undefined);
-  }, [page]);
+    paging.resetPagingCache();
+    void setState(patch, { limitUrlUpdates: debounce(FilterDebounceMs) });
+  }
 
   React.useEffect(() => {
     if (scene != null) setActiveSceneId(scene.id);
@@ -157,18 +173,6 @@ export default function SceneTable({
     onClick(s);
   }
 
-  function handleChangePage(
-    _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
-  ): void {
-    if (curPage < num) {
-      setPrev({ ...prev, [num - 1]: cursors?.self });
-      setCursor(cursors?.next);
-    }
-    if (curPage > num) setCursor(prev[num]);
-    setCurPage(num);
-  }
-
   async function handleDelete(): Promise<void> {
     setSelected(new Set());
     await fetch('/api/scenes', {
@@ -184,9 +188,7 @@ export default function SceneTable({
   }
 
   function handleViewClick(sceneId: string): void {
-    router
-      .push(`/scene-viewer/${encodeURIComponent(sceneId)}`)
-      .catch(reportError('Failed to navigate to the scene viewer'));
+    void router.push(`/scene-viewer/${encodeURIComponent(sceneId)}`);
   }
 
   async function handleGetStreamKey(sceneId: string): Promise<void> {
@@ -211,9 +213,7 @@ export default function SceneTable({
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={() => {
-            handleDelete().catch(reportError('Failed to delete scenes'));
-          }}
+          onDelete={() => void handleDelete()}
           title="Scenes"
           customActions={[
             <React.Fragment key="merge">
@@ -242,10 +242,9 @@ export default function SceneTable({
             id="nameFilter"
             label="Name Filter"
             type="text"
-            onChange={(e) => {
-              debouncedSetNameFilter(e.target.value?.trim() ?? undefined);
-            }}
+            onChange={(e) => handleFilterChange('name', e.target.value)}
             sx={{ mt: 0, width: '20rem' }}
+            value={state.name ?? ''}
           />
           <TextField
             variant="standard"
@@ -254,10 +253,9 @@ export default function SceneTable({
             id="suppliedIdFilter"
             label="Supplied ID Filter"
             type="text"
-            onChange={(e) => {
-              debouncedSetSuppliedIdFilter(e.target.value?.trim() ?? undefined);
-            }}
+            onChange={(e) => handleFilterChange('suppliedId', e.target.value)}
             sx={{ mt: 0, width: '20rem' }}
+            value={state.suppliedId ?? ''}
           />
         </Box>
         <TableContainer>
@@ -327,7 +325,7 @@ export default function SceneTable({
                             {
                               disabled: keyLoadingSceneId === row.id,
                               label: 'Generate stream key',
-                              onClick: () => handleGetStreamKey(row.id),
+                              onClick: () => void handleGetStreamKey(row.id),
                             },
                             {
                               label: 'View scene',
@@ -361,17 +359,18 @@ export default function SceneTable({
           labelDisplayedRows={(displayedRows) =>
             formatCursorPaginationLabel(
               displayedRows,
-              cursors?.next != null,
+              paginationCursors?.next != null,
               pageLength,
               page != null
             )
           }
           rowsPerPage={pageSize}
-          page={curPage}
-          onPageChange={handleChangePage}
+          page={state.page}
+          onPageChange={paging.handleChangePage}
           slotProps={{
             actions: {
-              nextButton: { disabled: cursors?.next == null },
+              nextButton: { disabled: paging.nextDisabled },
+              previousButton: { disabled: paging.previousDisabled },
             },
           }}
         />

--- a/src/components/shared/CreatedAtDateRangeFilter.tsx
+++ b/src/components/shared/CreatedAtDateRangeFilter.tsx
@@ -10,15 +10,21 @@ export interface CreatedAtDateRange {
 
 interface Props {
   readonly onChange: (filters: CreatedAtDateRange) => void;
+  readonly value?: CreatedAtDateRange;
 }
 
 function isAfter(left: string, right: string): boolean {
   return left.localeCompare(right) > 0;
 }
 
-export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
-  const [createdAtStartDate, setCreatedAtStartDate] = React.useState('');
-  const [createdAtEndDate, setCreatedAtEndDate] = React.useState('');
+export function CreatedAtDateRangeFilter({
+  onChange,
+  value: selectedValue,
+}: Props): JSX.Element {
+  const [localCreatedAtStartDate, setLocalCreatedAtStartDate] = React.useState('');
+  const [localCreatedAtEndDate, setLocalCreatedAtEndDate] = React.useState('');
+  const createdAtStartDate = selectedValue?.createdAtStart ?? localCreatedAtStartDate;
+  const createdAtEndDate = selectedValue?.createdAtEnd ?? localCreatedAtEndDate;
 
   function handleCreatedAtStartChange(value: string): void {
     const nextEndDate =
@@ -26,8 +32,10 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
         ? ''
         : createdAtEndDate;
 
-    setCreatedAtStartDate(value);
-    setCreatedAtEndDate(nextEndDate);
+    if (selectedValue == null) {
+      setLocalCreatedAtStartDate(value);
+      setLocalCreatedAtEndDate(nextEndDate);
+    }
     onChange({
       createdAtEnd: nextEndDate ? toLocalDayBoundaryIso(nextEndDate, 'end') : undefined,
       createdAtStart: value ? toLocalDayBoundaryIso(value, 'start') : undefined,
@@ -40,8 +48,10 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
         ? ''
         : createdAtStartDate;
 
-    setCreatedAtStartDate(nextStartDate);
-    setCreatedAtEndDate(value);
+    if (selectedValue == null) {
+      setLocalCreatedAtStartDate(nextStartDate);
+      setLocalCreatedAtEndDate(value);
+    }
     onChange({
       createdAtEnd: value ? toLocalDayBoundaryIso(value, 'end') : undefined,
       createdAtStart: nextStartDate

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -27,3 +27,17 @@ export function toLocalDayBoundaryIso(value: string, boundary: DayBoundary): str
 
   return date.toISOString();
 }
+
+/**
+ * Converts an ISO timestamp to the corresponding local date input value.
+ */
+export function toLocalDateInputValue(value?: string): string {
+  if (value == null) return '';
+
+  const date = new Date(value);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}

--- a/src/lib/files-nuqs-state.ts
+++ b/src/lib/files-nuqs-state.ts
@@ -1,0 +1,40 @@
+import { inferParserType, parseAsString } from 'nuqs';
+
+import { makeSortParser, parseAsPageIndex } from './nuqs-table-state';
+import { SortState } from './sorting';
+
+export const DefaultFileSort: SortState = {
+  field: 'created',
+  order: 'desc',
+};
+
+export const parseAsFileSort = makeSortParser({
+  '-created': { field: 'created', order: 'desc' },
+  '-name': { field: 'name', order: 'desc' },
+  created: { field: 'created', order: 'asc' },
+  name: { field: 'name', order: 'asc' },
+});
+
+export const fileTableParsers = {
+  createdAtEnd: parseAsString,
+  createdAtStart: parseAsString,
+  cursor: parseAsString,
+  filterId: parseAsString,
+  name: parseAsString,
+  page: parseAsPageIndex.withDefault(0),
+  sort: parseAsFileSort.withDefault(DefaultFileSort),
+  suppliedId: parseAsString,
+};
+
+export const fileTableUrlKeys = {
+  createdAtEnd: 'fileCreatedAtEnd',
+  createdAtStart: 'fileCreatedAtStart',
+  cursor: 'fileCursor',
+  filterId: 'fileFilterId',
+  name: 'fileName',
+  page: 'filePage',
+  sort: 'fileSort',
+  suppliedId: 'fileSuppliedId',
+};
+
+export type FileTableState = inferParserType<typeof fileTableParsers>;

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -12,6 +12,10 @@ export interface FileDownloadUrlRes extends Res {
 
 export const FileStatusComplete = 'complete';
 
+export function toFile(data: FileList['data'][number]): File {
+  return { ...data.attributes, id: data.id };
+}
+
 export function normalizeFileStatus(status?: string): string | undefined {
   return status?.trim().toLowerCase();
 }

--- a/src/lib/nuqs-table-state.ts
+++ b/src/lib/nuqs-table-state.ts
@@ -1,0 +1,123 @@
+import { Cursors } from '@vertexvis/api-client-node';
+import { createParser, parseAsInteger } from 'nuqs';
+import React from 'react';
+
+import { SortState, toSortParam } from './sorting';
+
+/** Page index must be a non-negative integer; anything else falls back. */
+export const parseAsPageIndex = createParser<number>({
+  parse: (value) => {
+    const parsed = parseAsInteger.parse(value);
+    return parsed == null || parsed < 0 ? null : parsed;
+  },
+  serialize: (value) => parseAsInteger.serialize(value),
+});
+
+/**
+ * Sort is stored in the URL as the API sort parameter, e.g. `-created`.
+ * Unknown values parse to `null`, which nuqs replaces with the default.
+ */
+export function makeSortParser(
+  values: Record<string, SortState>
+): ReturnType<typeof createParser<SortState>> {
+  return createParser<SortState>({
+    eq: (a, b) => a.field === b.field && a.order === b.order,
+    parse: (value) => values[value] ?? null,
+    serialize: toSortParam,
+  });
+}
+
+export interface CursorPagingPatch {
+  readonly cursor: string | null;
+  readonly page: number;
+}
+
+interface UseUrlCursorPagingProps {
+  /** Cursor currently stored in the URL. */
+  readonly cursor: string | null;
+  /** Cursors returned with the currently loaded page, if any. */
+  readonly cursors?: Cursors;
+  /** Whether a page of results has loaded. */
+  readonly loaded: boolean;
+  /** Page index currently stored in the URL. */
+  readonly page: number;
+  /** Key derived from filter and sort state; a change resets the cache. */
+  readonly searchKey: string;
+  readonly setPaging: (patch: CursorPagingPatch) => void;
+}
+
+interface UseUrlCursorPaging {
+  readonly handleChangePage: (
+    event: React.MouseEvent<HTMLButtonElement> | null,
+    num: number
+  ) => void;
+  readonly nextDisabled: boolean;
+  readonly paginationCursors?: Cursors;
+  readonly previousDisabled: boolean;
+  readonly resetPagingCache: () => void;
+}
+
+/**
+ * Cursor-based paging on top of URL state. The URL stores the cursor and
+ * page index; previous-page cursors are ephemeral server tokens that only
+ * live in session state, so the previous button is disabled on a fresh
+ * deep link until the user pages forward again.
+ */
+export function useUrlCursorPaging({
+  cursor,
+  cursors,
+  loaded,
+  page,
+  searchKey,
+  setPaging,
+}: UseUrlCursorPagingProps): UseUrlCursorPaging {
+  const [cachedCursors, setCachedCursors] = React.useState<Cursors>();
+  const [previousCursors, setPreviousCursors] = React.useState<
+    Record<number, string | undefined>
+  >({});
+
+  const paginationCursors = cursors ?? cachedCursors;
+
+  const resetPagingCache = React.useCallback(() => {
+    setCachedCursors(undefined);
+    setPreviousCursors({});
+  }, []);
+
+  const previousSearchKey = React.useRef(searchKey);
+  React.useEffect(() => {
+    if (previousSearchKey.current !== searchKey) {
+      previousSearchKey.current = searchKey;
+      resetPagingCache();
+    }
+  }, [searchKey, resetPagingCache]);
+
+  React.useEffect(() => {
+    if (loaded) setCachedCursors(cursors);
+  }, [cursors, loaded]);
+
+  function handleChangePage(
+    _: React.MouseEvent<HTMLButtonElement> | null,
+    num: number
+  ): void {
+    let nextCursor = cursor;
+    if (page < num) {
+      nextCursor = paginationCursors?.next ?? null;
+      setPreviousCursors((current) => ({
+        ...current,
+        [page]: paginationCursors?.self,
+      }));
+    } else if (page > num) {
+      nextCursor = previousCursors[num] ?? null;
+    }
+
+    setPaging({ cursor: nextCursor, page: num });
+  }
+
+  return {
+    handleChangePage,
+    nextDisabled: paginationCursors?.next == null,
+    paginationCursors,
+    previousDisabled: page === 0 || previousCursors[page - 1] == null,
+    resetPagingCache,
+  };
+}

--- a/src/lib/scenes-nuqs-state.ts
+++ b/src/lib/scenes-nuqs-state.ts
@@ -1,0 +1,19 @@
+import { inferParserType, parseAsString } from 'nuqs';
+
+import { parseAsPageIndex } from './nuqs-table-state';
+
+export const sceneTableParsers = {
+  cursor: parseAsString,
+  name: parseAsString,
+  page: parseAsPageIndex.withDefault(0),
+  suppliedId: parseAsString,
+};
+
+export const sceneTableUrlKeys = {
+  cursor: 'sceneCursor',
+  name: 'sceneName',
+  page: 'scenePage',
+  suppliedId: 'sceneSuppliedId',
+};
+
+export type SceneTableState = inferParserType<typeof sceneTableParsers>;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,6 +9,7 @@ import { ThemeProvider } from '@mui/material/styles';
 import { AppProps } from 'next/app';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
+import { NuqsAdapter } from 'nuqs/adapters/next/pages';
 import React from 'react';
 import { SWRConfig } from 'swr';
 
@@ -112,7 +113,9 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
             />
           </Fade>
           <SWRConfig value={{ fetcher: (url) => fetch(url).then((res) => res.json()) }}>
-            <Component {...pageProps} />
+            <NuqsAdapter>
+              <Component {...pageProps} />
+            </NuqsAdapter>
           </SWRConfig>
         </ThemeProvider>
       </CacheProvider>

--- a/src/pages/api/files/[id]/index.ts
+++ b/src/pages/api/files/[id]/index.ts
@@ -1,0 +1,37 @@
+import { FileMetadata, head, logError, VertexError } from '@vertexvis/api-client-node';
+import { NextApiResponse } from 'next';
+
+import { ErrorRes, MethodNotAllowed, ServerError, toErrorRes } from '../../../../lib/api';
+import { getClientFromSession } from '../../../../lib/vertex-api';
+import withSession, { NextIronRequest } from '../../../../lib/with-session';
+
+type FileData = FileMetadata['data'];
+
+export async function handleFileById(
+  req: NextIronRequest,
+  res: NextApiResponse<FileData | ErrorRes>
+): Promise<void> {
+  if (req.method === 'GET') {
+    const r = await get(req);
+    return res.status('status' in r ? r.status : 200).json(r);
+  }
+
+  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+}
+
+export default withSession(handleFileById);
+
+async function get(req: NextIronRequest): Promise<ErrorRes | FileData> {
+  try {
+    const client = await getClientFromSession(req.session);
+    const id = head(req.query.id);
+    if (id == null) return { message: 'File ID required.', status: 400 };
+
+    const item = await client.files.getFile({ id });
+    return item.data.data;
+  } catch (error) {
+    const e = error as VertexError;
+    logError(e);
+    return e.vertexError?.res ? toErrorRes({ failure: e.vertexError?.res }) : ServerError;
+  }
+}

--- a/src/pages/files.tsx
+++ b/src/pages/files.tsx
@@ -1,26 +1,50 @@
+import { FileList } from '@vertexvis/api-client-node';
 import dynamic from 'next/dynamic';
+import { parseAsString, useQueryState } from 'nuqs';
 import React from 'react';
+import useSWR from 'swr';
 
 import { FileDetailsDrawer } from '../components/file/FileDetailsDrawer';
 import { Layout } from '../components/shared/Layout';
-import { File } from '../lib/files';
+import { ErrorRes } from '../lib/api';
+import { File, toFile } from '../lib/files';
 import { defaultServerSideProps } from '../lib/with-session';
 
 const FileTable = dynamic(() => import('../components/file/FileTable'), {
   ssr: false,
 });
 
+type FileData = FileList['data'][number];
+
+function toSelectedFile(data?: FileData | ErrorRes): File | undefined {
+  if (data == null || !('attributes' in data)) return undefined;
+  return toFile(data);
+}
+
 export default function Files(): JSX.Element {
-  const [file, setFile] = React.useState<File | undefined>();
-  const drawerOpen = Boolean(file);
+  const [selectedFileId, setSelectedFileId] = useQueryState(
+    'fileId',
+    parseAsString.withOptions({ history: 'push' })
+  );
+  const { data: selectedFromUrl } = useSWR<FileData | ErrorRes>(
+    selectedFileId != null ? `/api/files/${encodeURIComponent(selectedFileId)}` : null
+  );
+
+  const selectedFile = toSelectedFile(selectedFromUrl);
+  const drawerOpen = selectedFileId != null;
 
   return (
     <Layout
-      main={<FileTable activeFileId={file?.id} onFileSelected={setFile} />}
+      main={
+        <FileTable
+          activeFileId={selectedFileId ?? undefined}
+          onFileSelected={(file) => void setSelectedFileId(file.id)}
+        />
+      }
       rightDrawer={
         <FileDetailsDrawer
-          file={file}
-          onClose={() => setFile(undefined)}
+          file={selectedFile}
+          onClose={() => void setSelectedFileId(null)}
           open={drawerOpen}
         />
       }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,12 @@
+import { SceneData } from '@vertexvis/api-client-node';
 import dynamic from 'next/dynamic';
+import { parseAsString, useQueryState } from 'nuqs';
 import React, { useCallback } from 'react';
+import useSWR from 'swr';
 
 import { SceneDrawer } from '../components/scene/SceneDrawer';
 import { Layout } from '../components/shared/Layout';
+import { ErrorRes } from '../lib/api';
 import { Scene } from '../lib/scenes';
 import { defaultServerSideProps } from '../lib/with-session';
 
@@ -10,27 +14,40 @@ const SceneTable = dynamic(() => import('../components/scene/SceneTable'), {
   ssr: false,
 });
 
+function toSelectedScene(data?: SceneData | ErrorRes): Scene | undefined {
+  if (data == null || !('attributes' in data)) return undefined;
+  return { ...data.attributes, id: data.id };
+}
+
 export default function Home(): JSX.Element {
   const [editing, setEditing] = React.useState<boolean>(false);
-  const [scene, setScene] = React.useState<Scene | undefined>();
-  const drawerOpen = Boolean(scene);
+  const [selectedSceneId, setSelectedSceneId] = useQueryState(
+    'sceneId',
+    parseAsString.withOptions({ history: 'push' })
+  );
   const [invalidationCount, setInvalidationCount] = React.useState(0);
 
+  const { data: selectedFromUrl } = useSWR<SceneData | ErrorRes>(
+    selectedSceneId != null ? `/api/scenes/${encodeURIComponent(selectedSceneId)}` : null
+  );
+  const scene = toSelectedScene(selectedFromUrl);
+  const drawerOpen = selectedSceneId != null;
+
   function handleClick(s: Scene): void {
-    setScene(s);
+    void setSelectedSceneId(s.id);
     setEditing(false);
   }
 
   function handleEditClick(s: Scene): void {
-    setScene(s);
+    void setSelectedSceneId(s.id);
     setEditing(true);
   }
 
   const handleClose = useCallback(() => {
-    setScene(undefined);
+    void setSelectedSceneId(null);
     setEditing(false);
-    setInvalidationCount(invalidationCount + 1);
-  }, [invalidationCount]);
+    setInvalidationCount((count) => count + 1);
+  }, [setSelectedSceneId]);
 
   return (
     <Layout

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "paths": {
+      "nuqs": ["./node_modules/nuqs/dist/index.d.ts"],
+      "nuqs/adapters/next/pages": ["./node_modules/nuqs/dist/adapters/next/pages.d.ts"],
+      "nuqs/adapters/testing": ["./node_modules/nuqs/dist/adapters/testing.d.ts"]
+    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1601,6 +1601,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@standard-schema/spec@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
 "@stencil/core@^2.16.1":
   version "2.22.3"
   resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.22.3.tgz#83987e20bba855c450f6d6780e3a20192603f13f"
@@ -5942,6 +5947,13 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+nuqs@^2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/nuqs/-/nuqs-2.9.1.tgz#b2a510a43e4dd46cb69bfcc14f0227f1aafe9713"
+  integrity sha512-xctOTExJ/M2lV9NBXTkLMb3vnGBLk/eMuZyiXSbj0jA24H6ie2d7/LJiaA0C30p5XCIWaDTZl5DEF/N2Yo1LCw==
+  dependencies:
+    "@standard-schema/spec" "1.1.0"
 
 nwsapi@^2.2.2:
   version "2.2.24"


### PR DESCRIPTION
## What

Full in-place conversion — no parallel prototype pages. The existing **Files** page and the home-page **Scenes** table now store their transferable state in the URL with [nuqs](https://nuqs.dev), so views are shareable deep links:

- **`/files`** — name / file-ID / supplied-ID filters, created date range, sort, pagination position, and the selected-file drawer (`?fileId=…`)
- **`/` (Scenes)** — name / supplied-ID filters and pagination position

Two commits: the Files conversion (which carries the one-time infra and shared helpers), then the Scenes rollout (which shows the steady-state per-page cost).

## Structure

| Layer | Files | Cost |
|---|---|---|
| One-time infra | `nuqs` dep, `NuqsAdapter` in `_app.tsx`, tsconfig `paths` + jest transform for nuqs's ESM/TS5 packaging, TypeScript `^4`→`^5` (verified: zero new type errors) | once |
| Shared helpers | `src/lib/nuqs-table-state.ts` — `parseAsPageIndex`, `makeSortParser`, `useUrlCursorPaging` (URL-state twin of `useCursorPagingState`) | once, 123 lines |
| Per-page contract | `files-nuqs-state.ts` (40), `scenes-nuqs-state.ts` (19) — each URL param's name, type, and default | ~3–4 lines/param |
| Page wiring | `FileTable`/`files.tsx` and `SceneTable` converted in place | ≈ replaces the local-state code it displaces |

The Scenes commit is the marginal-cost demo: a 19-line state file plus a net **−3 line** component diff — the URL wiring replaces five `useState`s, two lodash debounce memos, the cursor-caching effect, and the hand-rolled page-change handler.

## Behavior

- Deep links hydrate filters, sort, page position, and the open drawer; a pristine page keeps a clean URL (defaults are elided)
- Typing in a filter debounces the URL write (300 ms) and atomically resets paging in the same history entry (`replace`, no history spam)
- Pagination and drawer selection use `history: "push"`, so back/forward walk through them
- Known cursor-paging limitation (inherent, not nuqs-specific): previous-page cursors are ephemeral server tokens kept in session state, so the previous button is disabled on a fresh deep link until the user pages forward

## Testing

- `FileTable` and `SceneTable` suites run under `NuqsTestingAdapter`; existing behavior tests unchanged, plus deep-link tests each: URL hydration → inputs + outgoing API params, filter-resets-paging as one replace update, next-page push with cursor
- Parser unit tests for the shared and per-page state libs
- Full suite: 17 suites / 100 tests pass; `tsc --noEmit` shows only the 6 pre-existing errors; lint clean