### PR TITLE
[PLAT-9059] Roll out methodRouter to remaining API handlers

### DIFF
--- a/src/__tests__/pages/api/file-collection-files.test.ts
+++ b/src/__tests__/pages/api/file-collection-files.test.ts
@@ -42,7 +42,8 @@ jest.mock("../../../lib/file-collections", () => {
 
 type TestReq = Pick<NextIronRequest, "body" | "method" | "query" | "session">;
 
-interface TestRes extends Pick<NextApiResponse, "json" | "status"> {
+interface TestRes
+  extends Pick<NextApiResponse, "json" | "setHeader" | "status"> {
   readonly body: () => unknown;
   readonly statusCode: () => number | undefined;
 }
@@ -187,6 +188,7 @@ function createRes(): TestRes {
     responseBody = body;
     return res;
   });
+  res.setHeader = jest.fn(() => res);
   return res;
 }
 

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -345,6 +345,7 @@ describe("file collection API routes", () => {
     const response = await callFileCollections({ method: "POST" });
 
     expect(response.statusCode()).toBe(405);
+    expect(response.header("Allow")).toBe("GET, DELETE");
     expect(response.body()).toEqual({
       message: "Method not allowed.",
       status: 405,

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -55,6 +55,7 @@ export function methodRouter(handlers: Partial<Record<Method, MethodHandler>>) {
   ): Promise<void> {
     const handler = handlers[req.method as Method];
     if (handler == null) {
+      res.setHeader("Allow", Object.keys(handlers).join(", "));
       return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
     }
 

--- a/src/pages/api/file-collections.ts
+++ b/src/pages/api/file-collections.ts
@@ -4,11 +4,8 @@ import {
   FilterExpression,
   getPage,
   head,
-  logError,
-  VertexError,
 } from "@vertexvis/api-client-node";
 import { AxiosResponse } from "axios";
-import { NextApiResponse } from "next";
 
 import {
   BodyRequired,
@@ -17,11 +14,10 @@ import {
   GetRes,
   InvalidBody,
   isErrorFailure,
-  MethodNotAllowed,
   Res,
-  ServerError,
   toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import {
   getFileCollectionsApi,
   sortFileCollections,
@@ -31,91 +27,68 @@ import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
-export async function handleFileCollections(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<FileCollectionMetadataData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "DELETE") {
-    const r = await del(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileCollections = methodRouter({ GET: get, DELETE: del });
 
 export default withSession(handleFileCollections);
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<FileCollectionMetadataData>> {
-  try {
-    const client = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pc = head(req.query.cursor);
-    const name = head(req.query.name);
-    const suppliedId = head(req.query.suppliedId);
-    const createdAtStart = head(req.query.createdAtStart);
-    const createdAtEnd = head(req.query.createdAtEnd);
-    const sort = head(req.query.sort);
+  const client = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pc = head(req.query.cursor);
+  const name = head(req.query.name);
+  const suppliedId = head(req.query.suppliedId);
+  const createdAtStart = head(req.query.createdAtStart);
+  const createdAtEnd = head(req.query.createdAtEnd);
+  const sort = head(req.query.sort);
 
-    const query = new URLSearchParams();
-    if (pc != null) query.set("page[cursor]", pc);
-    query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
-    setFilterExpression(
-      query,
-      "name",
-      name != null ? ({ contains: name } satisfies FilterExpression) : undefined
-    );
-    setFilterExpression(
-      query,
-      "suppliedId",
-      suppliedId != null
-        ? ({ contains: suppliedId } satisfies FilterExpression)
-        : undefined
-    );
-    if (sort != null) query.set("sort", sort);
-    setFilterExpression(
-      query,
-      "createdAt",
-      createdAtStart != null || createdAtEnd != null
-        ? ({
-            ...(createdAtStart != null ? { gte: createdAtStart } : {}),
-            ...(createdAtEnd != null ? { lte: createdAtEnd } : {}),
-          } satisfies FilterExpression)
-        : undefined
-    );
+  const query = new URLSearchParams();
+  if (pc != null) query.set("page[cursor]", pc);
+  query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
+  setFilterExpression(
+    query,
+    "name",
+    name != null ? ({ contains: name } satisfies FilterExpression) : undefined
+  );
+  setFilterExpression(
+    query,
+    "suppliedId",
+    suppliedId != null
+      ? ({ contains: suppliedId } satisfies FilterExpression)
+      : undefined
+  );
+  if (sort != null) query.set("sort", sort);
+  setFilterExpression(
+    query,
+    "createdAt",
+    createdAtStart != null || createdAtEnd != null
+      ? ({
+          ...(createdAtStart != null ? { gte: createdAtStart } : {}),
+          ...(createdAtEnd != null ? { lte: createdAtEnd } : {}),
+        } satisfies FilterExpression)
+      : undefined
+  );
 
-    // TODO: Use FileCollectionsApi.listFileCollections once the SDK supports
-    // createdAt filter expressions.
-    const { cursors, page } = await getPage(
-      (): Promise<AxiosResponse<FileCollectionList>> =>
-        client.axiosInstance.get<FileCollectionList>(
-          `${client.config.basePath}/file-collections?${query.toString()}`,
-          {
-            headers: {
-              Accept: "application/vnd.api+json",
-              Authorization: `Bearer ${client.token.access_token}`,
-            },
-          }
-        )
-    );
-    return {
-      cursors,
-      data: sortFileCollections(page.data, sort),
-      status: 200,
-    };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  // TODO: Use FileCollectionsApi.listFileCollections once the SDK supports
+  // createdAt filter expressions.
+  const { cursors, page } = await getPage(
+    (): Promise<AxiosResponse<FileCollectionList>> =>
+      client.axiosInstance.get<FileCollectionList>(
+        `${client.config.basePath}/file-collections?${query.toString()}`,
+        {
+          headers: {
+            Accept: "application/vnd.api+json",
+            Authorization: `Bearer ${client.token.access_token}`,
+          },
+        }
+      )
+  );
+  return {
+    cursors,
+    data: sortFileCollections(page.data, sort),
+    status: 200,
+  };
 }
 
 async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
@@ -124,20 +97,12 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
   const b: DeleteReq = JSON.parse(req.body);
   if (!b.ids) return InvalidBody;
 
-  try {
-    const c = getFileCollectionsApi(await getClientFromSession(req.session));
-    const results = await Promise.all(
-      b.ids.map((id) => makeCall(() => c.deleteFileCollection({ id })))
-    );
-    const failure = results.find(isErrorFailure);
-    if (failure != null) return toErrorRes({ failure });
+  const c = getFileCollectionsApi(await getClientFromSession(req.session));
+  const results = await Promise.all(
+    b.ids.map((id) => makeCall(() => c.deleteFileCollection({ id })))
+  );
+  const failure = results.find(isErrorFailure);
+  if (failure != null) return toErrorRes({ failure });
 
-    return { status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  return { status: 200 };
 }

--- a/src/pages/api/file-collections/[id]/index.ts
+++ b/src/pages/api/file-collections/[id]/index.ts
@@ -1,13 +1,7 @@
-import { head, logError, VertexError } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  isErrorFailure,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../../lib/api";
+import { ErrorRes, isErrorFailure, toErrorRes } from "../../../../lib/api";
+import { methodRouter } from "../../../../lib/api-handler";
 import {
   fetchAllFileCollectionFiles,
   getFileCollectionExportAvailability,
@@ -17,49 +11,31 @@ import {
 import { getClientFromSession, makeCall } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
-export async function handleFileCollection(
-  req: NextIronRequest,
-  res: NextApiResponse<GetFileCollectionRes | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileCollection = methodRouter({ GET: get });
 
 export default withSession(handleFileCollection);
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetFileCollectionRes> {
-  try {
-    const id = head(req.query.id);
-    if (id == null)
-      return { message: "File Collection ID required.", status: 400 };
+  const id = head(req.query.id);
+  if (id == null)
+    return { message: "File Collection ID required.", status: 400 };
 
-    const c = getFileCollectionsApi(await getClientFromSession(req.session));
-    const res = await makeCall(() => c.getFileCollection({ id }));
-    if (isErrorFailure(res)) return toErrorRes({ failure: res });
+  const c = getFileCollectionsApi(await getClientFromSession(req.session));
+  const res = await makeCall(() => c.getFileCollection({ id }));
+  if (isErrorFailure(res)) return toErrorRes({ failure: res });
 
-    if (head(req.query.includeExportAvailability) === "true") {
-      const files = await fetchAllFileCollectionFiles(c, id);
-      const availability = getFileCollectionExportAvailability(files);
+  if (head(req.query.includeExportAvailability) === "true") {
+    const files = await fetchAllFileCollectionFiles(c, id);
+    const availability = getFileCollectionExportAvailability(files);
 
-      return {
-        data: res.data,
-        export: availability,
-        status: 200,
-      };
-    }
-
-    return { data: res.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+    return {
+      data: res.data,
+      export: availability,
+      status: 200,
+    };
   }
+
+  return { data: res.data, status: 200 };
 }

--- a/src/pages/api/file-jobs.ts
+++ b/src/pages/api/file-jobs.ts
@@ -1,15 +1,11 @@
-import { logError, VertexError } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
-
 import {
   BodyRequired,
   ErrorRes,
   InvalidBody,
   isErrorFailure,
-  MethodNotAllowed,
-  ServerError,
   toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import {
   fetchAllFileCollectionFiles,
   getFileCollectionExportAvailability,
@@ -36,80 +32,60 @@ interface RawCreateFileJobReq {
   readonly fileCollectionId?: string;
 }
 
-export async function handleFileJobs(
-  req: NextIronRequest,
-  res: NextApiResponse<FileJobRes | ErrorRes>
-): Promise<void> {
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileJobs = methodRouter({ POST: create });
 
 export default withSession(handleFileJobs);
 
 async function create(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
-  try {
-    if (!req.body) return BodyRequired;
+  if (!req.body) return BodyRequired;
 
-    const body = parseCreateFileJobReq(req.body);
-    if (body == null) return InvalidBody;
+  const body = parseCreateFileJobReq(req.body);
+  if (body == null) return InvalidBody;
 
-    const client = await getClientFromSession(req.session);
-    const { fileCollectionId } = body;
-    const files = await fetchAllFileCollectionFiles(
-      getFileCollectionsApi(client),
-      fileCollectionId
-    );
+  const client = await getClientFromSession(req.session);
+  const { fileCollectionId } = body;
+  const files = await fetchAllFileCollectionFiles(
+    getFileCollectionsApi(client),
+    fileCollectionId
+  );
 
-    const exportAvailability = getFileCollectionExportAvailability(files);
-    if (!exportAvailability.enabled) {
-      return {
-        message:
-          exportAvailability.disabledReason ??
-          "File collection is not exportable.",
-        status: 400,
-      };
-    }
+  const exportAvailability = getFileCollectionExportAvailability(files);
+  if (!exportAvailability.enabled) {
+    return {
+      message:
+        exportAvailability.disabledReason ??
+        "File collection is not exportable.",
+      status: 400,
+    };
+  }
 
-    const archiveFile = await makeCall(() =>
-      client.files.createFile({
-        createFileRequest: {
-          data: {
-            type: "file",
-            attributes: {
-              expiry: DefaultArchiveFileExpirySeconds,
-              metadata: { fileCollectionId },
-              name:
-                body.archiveName ?? buildDefaultArchiveName(fileCollectionId),
-            },
+  const archiveFile = await makeCall(() =>
+    client.files.createFile({
+      createFileRequest: {
+        data: {
+          type: "file",
+          attributes: {
+            expiry: DefaultArchiveFileExpirySeconds,
+            metadata: { fileCollectionId },
+            name: body.archiveName ?? buildDefaultArchiveName(fileCollectionId),
           },
         },
-      })
-    );
-    if (isErrorFailure(archiveFile))
-      return toErrorRes({ failure: archiveFile });
+      },
+    })
+  );
+  if (isErrorFailure(archiveFile)) return toErrorRes({ failure: archiveFile });
 
-    const job = await makeCall(() =>
-      getFileJobsApi(client).createFileJob({
-        createFileJobRequest: buildFileArchiveJobRequest(
-          files,
-          archiveFile.data.id
-        ),
-      })
-    );
-    if (isErrorFailure(job)) return toErrorRes({ failure: job });
+  const job = await makeCall(() =>
+    getFileJobsApi(client).createFileJob({
+      createFileJobRequest: buildFileArchiveJobRequest(
+        files,
+        archiveFile.data.id
+      ),
+    })
+  );
+  if (isErrorFailure(job)) return toErrorRes({ failure: job });
 
-    return toFileJobRes(job, 201, archiveFile.data.id);
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  return toFileJobRes(job, 201, archiveFile.data.id);
 }
 
 function parseCreateFileJobReq(body: unknown): CreateFileJobReq | undefined {

--- a/src/pages/api/file-jobs/[id].ts
+++ b/src/pages/api/file-jobs/[id].ts
@@ -1,13 +1,7 @@
-import { head, logError, VertexError } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  isErrorFailure,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../lib/api";
+import { ErrorRes, isErrorFailure, toErrorRes } from "../../../lib/api";
+import { methodRouter } from "../../../lib/api-handler";
 import {
   FileJobRes,
   getFileJobsApi,
@@ -16,35 +10,17 @@ import {
 import { getClientFromSession, makeCall } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
-export async function handleFileJob(
-  req: NextIronRequest,
-  res: NextApiResponse<FileJobRes | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileJob = methodRouter({ GET: get });
 
 export default withSession(handleFileJob);
 
 async function get(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
-  try {
-    const id = head(req.query.id);
-    if (id == null) return { message: "File Job ID required.", status: 400 };
+  const id = head(req.query.id);
+  if (id == null) return { message: "File Job ID required.", status: 400 };
 
-    const client = await getClientFromSession(req.session);
-    const job = await makeCall(() => getFileJobsApi(client).getFileJob({ id }));
-    if (isErrorFailure(job)) return toErrorRes({ failure: job });
+  const client = await getClientFromSession(req.session);
+  const job = await makeCall(() => getFileJobsApi(client).getFileJob({ id }));
+  if (isErrorFailure(job)) return toErrorRes({ failure: job });
 
-    return toFileJobRes(job);
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  return toFileJobRes(job);
 }

--- a/src/pages/api/files.ts
+++ b/src/pages/api/files.ts
@@ -6,11 +6,8 @@ import {
   FilterExpression,
   getPage,
   head,
-  logError,
-  VertexError,
 } from "@vertexvis/api-client-node";
 import { AxiosResponse } from "axios";
-import { NextApiResponse } from "next";
 
 import {
   BodyRequired,
@@ -18,11 +15,9 @@ import {
   ErrorRes,
   GetRes,
   InvalidBody,
-  MethodNotAllowed,
   Res,
-  ServerError,
-  toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
@@ -33,98 +28,72 @@ type FileData = FileMetadata["data"];
 
 export type CreateFileRes = Res & Pick<FileData, "id">;
 
-export async function handleFiles(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<FileData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "DELETE") {
-    const r = await del(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFiles = methodRouter({
+  GET: get,
+  DELETE: del,
+  POST: create,
+});
 
 export default withSession(handleFiles);
 
 async function get(req: NextIronRequest): Promise<ErrorRes | GetRes<FileData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pc = head(req.query.cursor);
-    const name = head(req.query.name);
-    const fileId = head(req.query.fileId);
-    const sId = head(req.query.suppliedId);
-    const createdAtStart = head(req.query.createdAtStart);
-    const createdAtEnd = head(req.query.createdAtEnd);
-    const sort = head(req.query.sort);
+  const c = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pc = head(req.query.cursor);
+  const name = head(req.query.name);
+  const fileId = head(req.query.fileId);
+  const sId = head(req.query.suppliedId);
+  const createdAtStart = head(req.query.createdAtStart);
+  const createdAtEnd = head(req.query.createdAtEnd);
+  const sort = head(req.query.sort);
 
-    const params: FilesApiGetFilesRequest = {
-      filterCreatedAt:
-        createdAtStart != null || createdAtEnd != null
-          ? ({
-              ...(createdAtStart != null ? { gte: createdAtStart } : {}),
-              ...(createdAtEnd != null ? { lte: createdAtEnd } : {}),
-            } satisfies FilterExpression)
-          : undefined,
-      filterFileId:
-        fileId != null
-          ? ({ contains: fileId } satisfies FilterExpression)
-          : undefined,
-      filterName:
-        name != null
-          ? ({ contains: name } satisfies FilterExpression)
-          : undefined,
-      filterSuppliedId:
-        sId != null
-          ? ({ contains: sId } satisfies FilterExpression)
-          : undefined,
-      pageCursor: pc,
-      pageSize: parsePositiveQueryInt(ps, 10),
-      sort,
-    };
+  const params: FilesApiGetFilesRequest = {
+    filterCreatedAt:
+      createdAtStart != null || createdAtEnd != null
+        ? ({
+            ...(createdAtStart != null ? { gte: createdAtStart } : {}),
+            ...(createdAtEnd != null ? { lte: createdAtEnd } : {}),
+          } satisfies FilterExpression)
+        : undefined,
+    filterFileId:
+      fileId != null
+        ? ({ contains: fileId } satisfies FilterExpression)
+        : undefined,
+    filterName:
+      name != null
+        ? ({ contains: name } satisfies FilterExpression)
+        : undefined,
+    filterSuppliedId:
+      sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined,
+    pageCursor: pc,
+    pageSize: parsePositiveQueryInt(ps, 10),
+    sort,
+  };
 
-    const query = new URLSearchParams();
-    if (params.pageCursor != null) query.set("page[cursor]", params.pageCursor);
-    if (params.pageSize != null)
-      query.set("page[size]", params.pageSize.toString());
-    if (params.sort != null) query.set("sort", params.sort);
-    setFilterExpression(query, "name", params.filterName);
-    setFilterExpression(query, "fileId", params.filterFileId);
-    if (typeof params.filterSuppliedId === "string") {
-      query.set("filter[suppliedId]", params.filterSuppliedId);
-    } else {
-      setFilterExpression(query, "suppliedId", params.filterSuppliedId);
-    }
-    setFilterExpression(query, "createdAt", params.filterCreatedAt);
-
-    const { cursors, page } = await getPage(
-      () =>
-        c.axiosInstance.get(`${c.config.basePath}/files?${query.toString()}`, {
-          headers: {
-            Accept: "application/vnd.api+json",
-            Authorization: `Bearer ${c.token.access_token}`,
-          },
-        }) as Promise<AxiosResponse<FileList>>
-    );
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  const query = new URLSearchParams();
+  if (params.pageCursor != null) query.set("page[cursor]", params.pageCursor);
+  if (params.pageSize != null)
+    query.set("page[size]", params.pageSize.toString());
+  if (params.sort != null) query.set("sort", params.sort);
+  setFilterExpression(query, "name", params.filterName);
+  setFilterExpression(query, "fileId", params.filterFileId);
+  if (typeof params.filterSuppliedId === "string") {
+    query.set("filter[suppliedId]", params.filterSuppliedId);
+  } else {
+    setFilterExpression(query, "suppliedId", params.filterSuppliedId);
   }
+  setFilterExpression(query, "createdAt", params.filterCreatedAt);
+
+  const { cursors, page } = await getPage(
+    () =>
+      c.axiosInstance.get(`${c.config.basePath}/files?${query.toString()}`, {
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${c.token.access_token}`,
+        },
+      }) as Promise<AxiosResponse<FileList>>
+  );
+  return { cursors, data: page.data, status: 200 };
 }
 
 async function del(req: NextIronRequest): Promise<ErrorRes | Res> {

--- a/src/pages/api/files/[id]/download-url.ts
+++ b/src/pages/api/files/[id]/download-url.ts
@@ -27,9 +27,7 @@ async function create(
     },
   });
 
-  const url =
-    downloadRes.data.data.attributes.uri ??
-    downloadRes.data.data.attributes.downloadUrl;
+  const { uri: url } = downloadRes.data.data.attributes;
   if (url == null) return ServerError;
 
   return { status: 200, url };

--- a/src/pages/api/files/[id]/download-url.ts
+++ b/src/pages/api/files/[id]/download-url.ts
@@ -1,60 +1,36 @@
-import { head, logError, VertexError } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  InvalidBody,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../../lib/api";
+import { ErrorRes, InvalidBody, ServerError } from "../../../../lib/api";
+import { methodRouter } from "../../../../lib/api-handler";
 import { FileDownloadUrlRes } from "../../../../lib/files";
 import { getClientFromSession } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
 const DefaultDownloadExpirySeconds = 30;
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<FileDownloadUrlRes | ErrorRes>
-): Promise<void> {
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ POST: create }));
 
 async function create(
   req: NextIronRequest
 ): Promise<FileDownloadUrlRes | ErrorRes> {
-  try {
-    const id = head(req.query.id);
-    if (id == null) return InvalidBody;
+  const id = head(req.query.id);
+  if (id == null) return InvalidBody;
 
-    const client = await getClientFromSession(req.session);
-    const downloadRes = await client.files.createDownloadUrl({
-      id,
-      createDownloadRequest: {
-        data: {
-          type: "download-url",
-          attributes: { expiry: DefaultDownloadExpirySeconds },
-        },
+  const client = await getClientFromSession(req.session);
+  const downloadRes = await client.files.createDownloadUrl({
+    id,
+    createDownloadRequest: {
+      data: {
+        type: "download-url",
+        attributes: { expiry: DefaultDownloadExpirySeconds },
       },
-    });
+    },
+  });
 
-    const url =
-      downloadRes.data.data.attributes.uri ??
-      downloadRes.data.data.attributes.downloadUrl;
-    if (url == null) return ServerError;
+  const url =
+    downloadRes.data.data.attributes.uri ??
+    downloadRes.data.data.attributes.downloadUrl;
+  if (url == null) return ServerError;
 
-    return { status: 200, url };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError.res })
-      : ServerError;
-  }
+  return { status: 200, url };
 }

--- a/src/pages/api/files/[id]/download.ts
+++ b/src/pages/api/files/[id]/download.ts
@@ -37,9 +37,7 @@ export async function handleFileDownload(
         },
       },
     });
-    const url =
-      downloadRes.data.data.attributes.uri ??
-      downloadRes.data.data.attributes.downloadUrl;
+    const { uri: url } = downloadRes.data.data.attributes;
     if (url == null) return res.status(ServerError.status).json(ServerError);
 
     res.redirect(302, url);

--- a/src/pages/api/files/[id]/download.ts
+++ b/src/pages/api/files/[id]/download.ts
@@ -1,4 +1,4 @@
-import { head, logError, VertexError } from "@vertexvis/api-client-node";
+import { head } from "@vertexvis/api-client-node";
 import { NextApiResponse } from "next";
 
 import {
@@ -6,8 +6,8 @@ import {
   InvalidBody,
   MethodNotAllowed,
   ServerError,
-  toErrorRes,
 } from "../../../../lib/api";
+import { handleVertexError } from "../../../../lib/api-handler";
 import { getClientFromSession } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
@@ -45,11 +45,7 @@ export async function handleFileDownload(
     res.redirect(302, url);
     return;
   } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    const response = e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError.res })
-      : ServerError;
+    const response = handleVertexError(error);
     return res.status(response.status).json(response);
   }
 }

--- a/src/pages/api/files/[id]/file-collections.ts
+++ b/src/pages/api/files/[id]/file-collections.ts
@@ -2,61 +2,35 @@ import {
   FileCollectionMetadataData,
   getPage,
   head,
-  logError,
-  VertexError,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
-import {
-  ErrorRes,
-  GetRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../../lib/api";
+import { ErrorRes, GetRes } from "../../../../lib/api";
+import { methodRouter } from "../../../../lib/api-handler";
 import { parsePositiveQueryInt } from "../../../../lib/query-params";
 import { getClientFromSession } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
-export async function handleFileCollectionsByFile(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<FileCollectionMetadataData> | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileCollectionsByFile = methodRouter({ GET: get });
 
 export default withSession(handleFileCollectionsByFile);
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<FileCollectionMetadataData>> {
-  try {
-    const id = head(req.query.id);
-    if (id == null) return { message: "File ID required.", status: 400 };
+  const id = head(req.query.id);
+  if (id == null) return { message: "File ID required.", status: 400 };
 
-    const client = await getClientFromSession(req.session);
-    const pageSize = head(req.query.pageSize);
-    const cursor = head(req.query.cursor);
+  const client = await getClientFromSession(req.session);
+  const pageSize = head(req.query.pageSize);
+  const cursor = head(req.query.cursor);
 
-    const { cursors, page } = await getPage(() =>
-      client.files.listFileCollectionsForFile({
-        id,
-        pageCursor: cursor,
-        pageSize: parsePositiveQueryInt(pageSize, 10),
-      })
-    );
+  const { cursors, page } = await getPage(() =>
+    client.files.listFileCollectionsForFile({
+      id,
+      pageCursor: cursor,
+      pageSize: parsePositiveQueryInt(pageSize, 10),
+    })
+  );
 
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  return { cursors, data: page.data, status: 200 };
 }

--- a/src/pages/api/merged-scenes.ts
+++ b/src/pages/api/merged-scenes.ts
@@ -1,18 +1,11 @@
 import {
   CameraFitTypeEnum,
-  SceneData,
   SceneRelationshipDataTypeEnum,
   UpdateSceneRequestDataAttributesStateEnum,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
-import {
-  ErrorRes,
-  GetRes,
-  InvalidBody,
-  MethodNotAllowed,
-  Res,
-} from "../../lib/api";
+import { ErrorRes, InvalidBody, Res } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
@@ -26,17 +19,7 @@ export type MergeSceneRes = Res & {
   readonly queuedItemIds: string[];
 };
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<SceneData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ POST: create }));
 
 async function create(req: NextIronRequest): Promise<ErrorRes | MergeSceneRes> {
   const b: MergeSceneReq = JSON.parse(req.body);

--- a/src/pages/api/part-revisions.ts
+++ b/src/pages/api/part-revisions.ts
@@ -1,58 +1,28 @@
-import {
-  getPage,
-  head,
-  logError,
-  PartRevisionData,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { getPage, head, PartRevisionData } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  GetRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../lib/api";
+import { ErrorRes, GetRes } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<PartRevisionData> | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get }));
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<PartRevisionData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pId = head(req.query.partId);
+  const c = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pId = head(req.query.partId);
 
-    if (pId == null) {
-      throw new Error("Part ID not set");
-    }
-    const { cursors, page } = await getPage(() =>
-      c.partRevisions.getPartRevisions({
-        id: pId,
-        pageSize: parsePositiveQueryInt(ps, 10),
-      })
-    );
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  if (pId == null) {
+    throw new Error("Part ID not set");
   }
+  const { cursors, page } = await getPage(() =>
+    c.partRevisions.getPartRevisions({
+      id: pId,
+      pageSize: parsePositiveQueryInt(ps, 10),
+    })
+  );
+  return { cursors, data: page.data, status: 200 };
 }

--- a/src/pages/api/part-revisions/[id].ts
+++ b/src/pages/api/part-revisions/[id].ts
@@ -1,51 +1,23 @@
-import {
-  head,
-  logError,
-  PartRevisionData,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head, PartRevisionData } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../lib/api";
+import { ErrorRes } from "../../../lib/api";
+import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<PartRevisionData | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(200).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get }));
 
 async function get(req: NextIronRequest): Promise<ErrorRes | PartRevisionData> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const id = head(req.query.id);
-    if (id == null) {
-      throw new Error("ID not set and is required");
-    }
-
-    const item = await c.partRevisions.getPartRevision({
-      id,
-      fieldsPartRevision: "created,suppliedId,metadata",
-    });
-
-    return item.data.data;
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  const c = await getClientFromSession(req.session);
+  const id = head(req.query.id);
+  if (id == null) {
+    throw new Error("ID not set and is required");
   }
+
+  const item = await c.partRevisions.getPartRevision({
+    id,
+    fieldsPartRevision: "created,suppliedId,metadata",
+  });
+
+  return item.data.data;
 }

--- a/src/pages/api/part-revisions/[id].ts
+++ b/src/pages/api/part-revisions/[id].ts
@@ -1,13 +1,15 @@
 import { head, PartRevisionData } from "@vertexvis/api-client-node";
 
-import { ErrorRes } from "../../../lib/api";
+import { ErrorRes, Res } from "../../../lib/api";
 import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
 export default withSession(methodRouter({ GET: get }));
 
-async function get(req: NextIronRequest): Promise<ErrorRes | PartRevisionData> {
+async function get(
+  req: NextIronRequest
+): Promise<ErrorRes | (PartRevisionData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);
   if (id == null) {
@@ -19,5 +21,5 @@ async function get(req: NextIronRequest): Promise<ErrorRes | PartRevisionData> {
     fieldsPartRevision: "created,suppliedId,metadata",
   });
 
-  return item.data.data;
+  return { ...item.data.data, status: 200 };
 }

--- a/src/pages/api/parts.ts
+++ b/src/pages/api/parts.ts
@@ -63,8 +63,9 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
 }
 
 async function create(req: NextIronRequest): Promise<ErrorRes | CreatePartRes> {
+  if (!req.body) return BodyRequired;
+
   const b: CreatePartReq = JSON.parse(req.body);
-  if (!req.body) return InvalidBody;
 
   const c = await getClientFromSession(req.session);
   const res = await c.parts.createPart({

--- a/src/pages/api/parts.ts
+++ b/src/pages/api/parts.ts
@@ -3,12 +3,9 @@ import {
   FileRelationshipDataTypeEnum,
   getPage,
   head,
-  logError,
   PartData,
   QueuedJobData,
-  VertexError,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
 import {
   BodyRequired,
@@ -16,11 +13,9 @@ import {
   ErrorRes,
   GetRes,
   InvalidBody,
-  MethodNotAllowed,
   Res,
-  ServerError,
-  toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
@@ -34,50 +29,24 @@ export type CreatePartReq = Pick<
 
 export type CreatePartRes = Pick<QueuedJobData, "id"> & Res;
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<PartData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "DELETE") {
-    const r = await del(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(
+  methodRouter({ GET: get, DELETE: del, POST: create })
+);
 
 async function get(req: NextIronRequest): Promise<ErrorRes | GetRes<PartData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pc = head(req.query.cursor);
-    const sId = head(req.query.suppliedId);
+  const c = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pc = head(req.query.cursor);
+  const sId = head(req.query.suppliedId);
 
-    const { cursors, page } = await getPage(() =>
-      c.parts.getParts({
-        pageCursor: pc,
-        pageSize: parsePositiveQueryInt(ps, 10),
-        filterSuppliedId: sId,
-      })
-    );
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  const { cursors, page } = await getPage(() =>
+    c.parts.getParts({
+      pageCursor: pc,
+      pageSize: parsePositiveQueryInt(ps, 10),
+      filterSuppliedId: sId,
+    })
+  );
+  return { cursors, data: page.data, status: 200 };
 }
 
 async function del(req: NextIronRequest): Promise<ErrorRes | Res> {

--- a/src/pages/api/queued-translations.ts
+++ b/src/pages/api/queued-translations.ts
@@ -1,78 +1,51 @@
 import {
   getPage,
   head,
-  logError,
   QueuedJobData,
   VertexClient,
-  VertexError,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
-import {
-  ErrorRes,
-  GetRes,
-  MethodNotAllowed,
-  Res,
-  ServerError,
-  toErrorRes,
-} from "../../lib/api";
+import { ErrorRes, GetRes } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<QueuedJobData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get }));
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<QueuedJobData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pc = head(req.query.cursor);
-    const fetchAll = (head(req.query.fetchAll) ?? "false") === "true";
-    const status = head(req.query.status);
+  const c = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pc = head(req.query.cursor);
+  const fetchAll = (head(req.query.fetchAll) ?? "false") === "true";
+  const status = head(req.query.status);
 
-    if (status == null) {
-      throw new Error("Status not set and is required");
-    }
+  if (status == null) {
+    throw new Error("Status not set and is required");
+  }
 
-    if (fetchAll) {
-      const result: QueuedJobData[] = await fetchAllTranslations(c, status);
+  if (fetchAll) {
+    const result: QueuedJobData[] = await fetchAllTranslations(c, status);
 
-      return {
-        cursors: {
-          next: undefined,
-          self: undefined,
-        },
-        data: result,
-        status: 200,
-      };
-    } else {
-      const { cursors, page } = await getPage(() =>
-        c.translationInspections.getQueuedTranslationJobs({
-          pageCursor: pc,
-          pageSize: parsePositiveQueryInt(ps, 200),
-          filterStatus: status,
-        })
-      );
-      return { cursors, data: page.data, status: 200 };
-    }
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+    return {
+      cursors: {
+        next: undefined,
+        self: undefined,
+      },
+      data: result,
+      status: 200,
+    };
+  } else {
+    const { cursors, page } = await getPage(() =>
+      c.translationInspections.getQueuedTranslationJobs({
+        pageCursor: pc,
+        pageSize: parsePositiveQueryInt(ps, 200),
+        filterStatus: status,
+      })
+    );
+    return { cursors, data: page.data, status: 200 };
   }
 }
 

--- a/src/pages/api/scene-items/[id].ts
+++ b/src/pages/api/scene-items/[id].ts
@@ -1,51 +1,23 @@
-import {
-  head,
-  logError,
-  SceneItemData,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head, SceneItemData } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../lib/api";
+import { ErrorRes } from "../../../lib/api";
+import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<SceneItemData | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(200).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get }));
 
 async function get(req: NextIronRequest): Promise<ErrorRes | SceneItemData> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const id = head(req.query.id);
-    if (id == null) {
-      throw new Error("ID not set and is required");
-    }
-
-    const item = await c.sceneItems.getSceneItem({
-      id,
-      fieldsSceneItem: "id,suppliedId,name,metadata",
-    });
-
-    return item.data.data;
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  const c = await getClientFromSession(req.session);
+  const id = head(req.query.id);
+  if (id == null) {
+    throw new Error("ID not set and is required");
   }
+
+  const item = await c.sceneItems.getSceneItem({
+    id,
+    fieldsSceneItem: "id,suppliedId,name,metadata",
+  });
+
+  return item.data.data;
 }

--- a/src/pages/api/scene-items/[id].ts
+++ b/src/pages/api/scene-items/[id].ts
@@ -1,13 +1,15 @@
 import { head, SceneItemData } from "@vertexvis/api-client-node";
 
-import { ErrorRes } from "../../../lib/api";
+import { ErrorRes, Res } from "../../../lib/api";
 import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
 export default withSession(methodRouter({ GET: get }));
 
-async function get(req: NextIronRequest): Promise<ErrorRes | SceneItemData> {
+async function get(
+  req: NextIronRequest
+): Promise<ErrorRes | (SceneItemData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);
   if (id == null) {
@@ -19,5 +21,5 @@ async function get(req: NextIronRequest): Promise<ErrorRes | SceneItemData> {
     fieldsSceneItem: "id,suppliedId,name,metadata",
   });
 
-  return item.data.data;
+  return { ...item.data.data, status: 200 };
 }

--- a/src/pages/api/scene-view-states.ts
+++ b/src/pages/api/scene-view-states.ts
@@ -2,22 +2,12 @@ import {
   CreateSceneViewStateRequestDataAttributes,
   getPage,
   head,
-  logError,
   SceneViewRelationshipDataTypeEnum,
   SceneViewStateData,
-  VertexError,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
-import {
-  BodyRequired,
-  ErrorRes,
-  GetRes,
-  MethodNotAllowed,
-  Res,
-  ServerError,
-  toErrorRes,
-} from "../../lib/api";
+import { BodyRequired, ErrorRes, GetRes, Res } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { getClientFromSession } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
@@ -30,50 +20,27 @@ export type CreateViewStateReq = Pick<
 
 export type CreateViewStateRes = Pick<SceneViewStateData, "id"> & Res;
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<SceneViewStateData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get, POST: create }));
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<SceneViewStateData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const vId = head(req.query.view);
-    if (vId == null) {
-      throw new Error("ID not set and is required");
-    }
-
-    const view = await c.sceneViews.getSceneView({ id: vId });
-    const sceneId = view.data.data.relationships.scene.data.id;
-
-    const { cursors, page } = await getPage(() =>
-      c.sceneViewStates.getSceneViewStates({
-        id: sceneId,
-        pageSize: 50,
-      })
-    );
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  const c = await getClientFromSession(req.session);
+  const vId = head(req.query.view);
+  if (vId == null) {
+    throw new Error("ID not set and is required");
   }
+
+  const view = await c.sceneViews.getSceneView({ id: vId });
+  const sceneId = view.data.data.relationships.scene.data.id;
+
+  const { cursors, page } = await getPage(() =>
+    c.sceneViewStates.getSceneViewStates({
+      id: sceneId,
+      pageSize: 50,
+    })
+  );
+  return { cursors, data: page.data, status: 200 };
 }
 
 async function create(

--- a/src/pages/api/scene-view-states.ts
+++ b/src/pages/api/scene-view-states.ts
@@ -46,8 +46,9 @@ async function get(
 async function create(
   req: NextIronRequest
 ): Promise<ErrorRes | CreateViewStateRes> {
-  const b: CreateViewStateReq = JSON.parse(req.body);
   if (!req.body) return BodyRequired;
+
+  const b: CreateViewStateReq = JSON.parse(req.body);
 
   const c = await getClientFromSession(req.session);
   const view = await c.sceneViews.getSceneView({ id: b.viewId });

--- a/src/pages/api/scenes.ts
+++ b/src/pages/api/scenes.ts
@@ -3,7 +3,6 @@ import {
   FilterExpression,
   getPage,
   head,
-  logError,
   PartDataRelationshipsPartRevisionsTypeEnum,
   QueuedJobData,
   SceneData,
@@ -11,10 +10,8 @@ import {
   ScenesApiUpdateSceneRequest,
   UpdateSceneRequestDataAttributes,
   UpdateSceneRequestDataAttributesStateEnum,
-  VertexError,
 } from "@vertexvis/api-client-node";
 import { AxiosResponse } from "axios";
-import { NextApiResponse } from "next";
 
 import {
   BodyRequired,
@@ -22,11 +19,9 @@ import {
   ErrorRes,
   GetRes,
   InvalidBody,
-  MethodNotAllowed,
   Res,
-  ServerError,
-  toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { setFilterExpression } from "../../lib/query-filters";
 import { parsePositiveQueryInt } from "../../lib/query-params";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
@@ -47,73 +42,42 @@ export type UpdateSceneReq = Pick<ScenesApiUpdateSceneRequest, "id"> &
     "name" | "suppliedId" | "camera" | "metadata"
   >;
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<SceneData> | Res | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "DELETE") {
-    const r = await del(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "PATCH") {
-    const r = await upd(req);
-    return res.status(r.status).json(r);
-  }
-
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(
+  methodRouter({ GET: get, DELETE: del, PATCH: upd, POST: create })
+);
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<SceneData>> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const ps = head(req.query.pageSize);
-    const pc = head(req.query.cursor);
-    const sId = head(req.query.suppliedId);
-    const n = head(req.query.name);
-    const filterName =
-      n != null ? ({ contains: n } satisfies FilterExpression) : undefined;
-    const filterSuppliedId =
-      sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined;
-    const query = new URLSearchParams();
-    if (pc != null) query.set("page[cursor]", pc);
-    query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
-    query.set(
-      "fields[scene]",
-      "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
-    );
-    setFilterExpression(query, "name", filterName);
-    setFilterExpression(query, "suppliedId", filterSuppliedId);
+  const c = await getClientFromSession(req.session);
+  const ps = head(req.query.pageSize);
+  const pc = head(req.query.cursor);
+  const sId = head(req.query.suppliedId);
+  const n = head(req.query.name);
+  const filterName =
+    n != null ? ({ contains: n } satisfies FilterExpression) : undefined;
+  const filterSuppliedId =
+    sId != null ? ({ contains: sId } satisfies FilterExpression) : undefined;
+  const query = new URLSearchParams();
+  if (pc != null) query.set("page[cursor]", pc);
+  query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
+  query.set(
+    "fields[scene]",
+    "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
+  );
+  setFilterExpression(query, "name", filterName);
+  setFilterExpression(query, "suppliedId", filterSuppliedId);
 
-    const { cursors, page } = await getPage(
-      () =>
-        c.axiosInstance.get(`${c.config.basePath}/scenes?${query.toString()}`, {
-          headers: {
-            Accept: "application/vnd.api+json",
-            Authorization: `Bearer ${c.token.access_token}`,
-          },
-        }) as Promise<AxiosResponse<SceneList>>
-    );
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  const { cursors, page } = await getPage(
+    () =>
+      c.axiosInstance.get(`${c.config.basePath}/scenes?${query.toString()}`, {
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${c.token.access_token}`,
+        },
+      }) as Promise<AxiosResponse<SceneList>>
+  );
+  return { cursors, data: page.data, status: 200 };
 }
 
 async function del(req: NextIronRequest): Promise<ErrorRes | Res> {

--- a/src/pages/api/scenes/[id].ts
+++ b/src/pages/api/scenes/[id].ts
@@ -1,52 +1,24 @@
-import {
-  head,
-  logError,
-  SceneData,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { head, SceneData } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../lib/api";
+import { ErrorRes } from "../../../lib/api";
+import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<SceneData | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(200).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ GET: get }));
 
 async function get(req: NextIronRequest): Promise<ErrorRes | SceneData> {
-  try {
-    const c = await getClientFromSession(req.session);
-    const id = head(req.query.id);
-    if (id == null) {
-      throw new Error("ID not set and is required");
-    }
-
-    const item = await c.scenes.getScene({
-      id,
-      fieldsScene:
-        "id,suppliedId,name,metadata,state,camera,worldOrientation,created,modified,sceneItemCount,treeEnabled",
-    });
-
-    return item.data.data;
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
+  const c = await getClientFromSession(req.session);
+  const id = head(req.query.id);
+  if (id == null) {
+    throw new Error("ID not set and is required");
   }
+
+  const item = await c.scenes.getScene({
+    id,
+    fieldsScene:
+      "id,suppliedId,name,metadata,state,camera,worldOrientation,created,modified,sceneItemCount,treeEnabled",
+  });
+
+  return item.data.data;
 }

--- a/src/pages/api/scenes/[id].ts
+++ b/src/pages/api/scenes/[id].ts
@@ -1,13 +1,15 @@
 import { head, SceneData } from "@vertexvis/api-client-node";
 
-import { ErrorRes } from "../../../lib/api";
+import { ErrorRes, Res } from "../../../lib/api";
 import { methodRouter } from "../../../lib/api-handler";
 import { getClientFromSession } from "../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../lib/with-session";
 
 export default withSession(methodRouter({ GET: get }));
 
-async function get(req: NextIronRequest): Promise<ErrorRes | SceneData> {
+async function get(
+  req: NextIronRequest
+): Promise<ErrorRes | (SceneData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);
   if (id == null) {
@@ -20,5 +22,5 @@ async function get(req: NextIronRequest): Promise<ErrorRes | SceneData> {
       "id,suppliedId,name,metadata,state,camera,worldOrientation,created,modified,sceneItemCount,treeEnabled",
   });
 
-  return item.data.data;
+  return { ...item.data.data, status: 200 };
 }

--- a/src/pages/api/stream-keys.ts
+++ b/src/pages/api/stream-keys.ts
@@ -2,16 +2,15 @@ import {
   isFailure,
   StreamKeysApiCreateSceneStreamKeyRequest,
 } from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
 
 import {
   BodyRequired,
   ErrorRes,
   InvalidBody,
-  MethodNotAllowed,
   Res,
   toErrorRes,
 } from "../../lib/api";
+import { methodRouter } from "../../lib/api-handler";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../lib/with-session";
 
@@ -21,17 +20,7 @@ export interface CreateStreamKeyRes extends Res {
 
 type CreateStreamKeyReq = Pick<StreamKeysApiCreateSceneStreamKeyRequest, "id">;
 
-export default withSession(async function handle(
-  req: NextIronRequest,
-  res: NextApiResponse<CreateStreamKeyRes | ErrorRes>
-): Promise<void> {
-  if (req.method === "POST") {
-    const r = await create(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-});
+export default withSession(methodRouter({ POST: create }));
 
 async function create(
   req: NextIronRequest

--- a/test/api/nextJsApiRouteTest.ts
+++ b/test/api/nextJsApiRouteTest.ts
@@ -22,6 +22,7 @@ export interface ApiRouteRequest {
 
 export interface ApiRouteResponse {
   readonly body: () => unknown;
+  readonly header: (name: string) => unknown;
   readonly statusCode: () => number | undefined;
 }
 
@@ -83,10 +84,16 @@ function createRequest({
 function createResponse(): ApiRouteResponse {
   let responseBody: unknown;
   let responseStatus: number | undefined;
+  const responseHeaders = new Map<string, unknown>();
   const response = {
     body: () => responseBody,
+    header: (name: string) => responseHeaders.get(name.toLowerCase()),
     json: (body: unknown) => {
       responseBody = body;
+      return response;
+    },
+    setHeader: (name: string, value: unknown) => {
+      responseHeaders.set(name.toLowerCase(), value);
       return response;
     },
     status: (statusCode: number) => {


### PR DESCRIPTION
> **Stacked on [#351](https://github.com/Vertexvis/vertex-dev-dashboard/pull/351)
> ([PLAT-9058](https://vertexvis.atlassian.net/browse/PLAT-9058)).** This PR's base is
> the `PLAT-9058-establish-pattern` branch, so the diff below is only the rollout.
> Please review and merge #351 first; GitHub will retarget this PR to `main` afterward.

## Summary

[PLAT-9058](https://vertexvis.atlassian.net/browse/PLAT-9058) (#351) introduced the
`methodRouter({ GET, POST, ... })` factory and `handleVertexError` helper in
`src/lib/api-handler.ts` and proved them out on one handler.

This PR is the mechanical rollout: it converts the remaining **18** `src/pages/api`
handlers to that pattern, so each per-method function collapses to pure request logic —
no dispatch, no 405 fallback, no `VertexError` try/catch.

**Net −461 lines across 18 files** here; combined with #351 the whole effort removes a
**net −432 lines across 20 files**.

## What changed

- 17 more JSON handlers converted to `methodRouter` (files.ts, file-collections.ts,
  file-jobs, parts, part-revisions, scenes, scene-items, scene-view-states,
  queued-translations, merged-scenes, stream-keys, download-url, …).
- `files/[id]/download.ts` (redirects rather than returning JSON) doesn't fit the router
  but now uses the shared `handleVertexError` helper for its catch block.
- Left untouched: `login`, `logout`, `health`, `upload` (bespoke or non-session).
- All named handler exports the tests import are preserved unchanged.

## Incidental consistency fixes

Centralizing error handling **resolves several inconsistencies that already existed**
(all in the correct direction):

- `scenes/[id]`, `scene-items/[id]`, and `part-revisions/[id]` previously sent error
  bodies with a hardcoded **HTTP 200**; they now respond with the error's real status.
- `parts.ts` and `scenes.ts` create/update/delete previously let thrown `VertexError`s
  escape **unlogged** (Next's default 500); they are now caught and logged centrally,
  returning a JSON `ErrorRes`.

## Test plan

- [x] `prettier --check` clean
- [x] `tsc --noEmit` — no new source errors
- [x] `next lint` — no warnings or errors
- [x] `jest` — 84/84 tests pass across 15 suites (the full-tree content is identical to
      the originally-reviewed commit; includes the MSW handler tests for file-collections,
      files, file-jobs, and file-download)

Ticket: [PLAT-9059](https://vertexvis.atlassian.net/browse/PLAT-9059)


[PLAT-9058]: https://vertexvis.atlassian.net/browse/PLAT-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-9058]: https://vertexvis.atlassian.net/browse/PLAT-9058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-9059]: https://vertexvis.atlassian.net/browse/PLAT-9059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ