### PR TITLE
[PLAT-9058] Establish shared methodRouter pattern for API handlers

### DIFF
--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -1,7 +1,13 @@
 import { logError, VertexError } from "@vertexvis/api-client-node";
 import { NextApiResponse } from "next";
 
-import { ErrorRes, MethodNotAllowed, ServerError, toErrorRes } from "./api";
+import {
+  ErrorRes,
+  MethodNotAllowed,
+  Res,
+  ServerError,
+  toErrorRes,
+} from "./api";
 import { NextIronRequest } from "./with-session";
 
 /**
@@ -10,12 +16,15 @@ import { NextIronRequest } from "./with-session";
  */
 export function handleVertexError(error: unknown): ErrorRes {
   const obj = error as Record<string, unknown> | null;
-  const isVertexError = typeof obj === "object" && obj != null && "vertexError" in obj;
+  const isVertexError =
+    typeof obj === "object" && obj != null && "vertexError" in obj;
 
   if (isVertexError) {
     const e = error as VertexError;
     logError(e);
-    return e.vertexError?.res ? toErrorRes({ failure: e.vertexError.res }) : ServerError;
+    return e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError.res })
+      : ServerError;
   }
 
   console.error(error);
@@ -24,8 +33,8 @@ export function handleVertexError(error: unknown): ErrorRes {
 
 type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
-/** A per-method handler: run the logic, return a JSON-serializable payload. */
-export type MethodHandler = (req: NextIronRequest) => Promise<unknown>;
+/** A per-method handler: run the logic and return an API response payload. */
+export type MethodHandler = (req: NextIronRequest) => Promise<Res>;
 
 /**
  * Builds an inner API handler that:

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -1,0 +1,59 @@
+import { logError, VertexError } from "@vertexvis/api-client-node";
+import { NextApiResponse } from "next";
+
+import { ErrorRes, MethodNotAllowed, ServerError, toErrorRes } from "./api";
+import { NextIronRequest } from "./with-session";
+
+/**
+ * Normalizes a thrown VertexError into our ErrorRes shape. Collapses the
+ * try/catch block that was previously copied into every route handler.
+ */
+export function handleVertexError(error: unknown): ErrorRes {
+  const e = error as VertexError;
+  logError(e);
+  return e.vertexError?.res
+    ? toErrorRes({ failure: e.vertexError.res })
+    : ServerError;
+}
+
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/** A per-method handler: run the logic, return a JSON-serializable payload. */
+export type MethodHandler = (req: NextIronRequest) => Promise<unknown>;
+
+/**
+ * Builds an inner API handler that:
+ *  - dispatches by HTTP method to the matching handler,
+ *  - returns 405 for any method that isn't provided,
+ *  - serializes the returned payload as JSON using its `status` (or 200), and
+ *  - converts any thrown VertexError into a logged ErrorRes.
+ *
+ * Wrap the result in `withSession` for the route's default export, e.g.:
+ *
+ *   export const handleThing = methodRouter({ GET: get, DELETE: del });
+ *   export default withSession(handleThing);
+ */
+export function methodRouter(handlers: Partial<Record<Method, MethodHandler>>) {
+  return async function handle(
+    req: NextIronRequest,
+    res: NextApiResponse
+  ): Promise<void> {
+    const handler = handlers[req.method as Method];
+    if (handler == null) {
+      return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await handler(req);
+    } catch (error) {
+      payload = handleVertexError(error);
+    }
+
+    const status =
+      typeof (payload as { status?: unknown } | null)?.status === "number"
+        ? (payload as { status: number }).status
+        : 200;
+    return res.status(status).json(payload);
+  };
+}

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -9,11 +9,17 @@ import { NextIronRequest } from "./with-session";
  * try/catch block that was previously copied into every route handler.
  */
 export function handleVertexError(error: unknown): ErrorRes {
-  const e = error as VertexError;
-  logError(e);
-  return e.vertexError?.res
-    ? toErrorRes({ failure: e.vertexError.res })
-    : ServerError;
+  const obj = error as Record<string, unknown> | null;
+  const isVertexError = typeof obj === "object" && obj != null && "vertexError" in obj;
+
+  if (isVertexError) {
+    const e = error as VertexError;
+    logError(e);
+    return e.vertexError?.res ? toErrorRes({ failure: e.vertexError.res }) : ServerError;
+  }
+
+  console.error(error);
+  return ServerError;
 }
 
 type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";

--- a/src/pages/api/file-collections/[id]/files.ts
+++ b/src/pages/api/file-collections/[id]/files.ts
@@ -1,63 +1,33 @@
-import {
-  FileMetadataData,
-  getPage,
-  head,
-  logError,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { NextApiResponse } from "next";
+import { FileMetadataData, getPage, head } from "@vertexvis/api-client-node";
 
-import {
-  ErrorRes,
-  GetRes,
-  MethodNotAllowed,
-  ServerError,
-  toErrorRes,
-} from "../../../../lib/api";
+import { ErrorRes, GetRes } from "../../../../lib/api";
+import { methodRouter } from "../../../../lib/api-handler";
 import { getFileCollectionsApi } from "../../../../lib/file-collections";
 import { parsePositiveQueryInt } from "../../../../lib/query-params";
 import { getClientFromSession } from "../../../../lib/vertex-api";
 import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
-export async function handleFileCollectionFiles(
-  req: NextIronRequest,
-  res: NextApiResponse<GetRes<FileMetadataData> | ErrorRes>
-): Promise<void> {
-  if (req.method === "GET") {
-    const r = await get(req);
-    return res.status(r.status).json(r);
-  }
-
-  return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
-}
+export const handleFileCollectionFiles = methodRouter({ GET: get });
 
 export default withSession(handleFileCollectionFiles);
 
 async function get(
   req: NextIronRequest
 ): Promise<ErrorRes | GetRes<FileMetadataData>> {
-  try {
-    const id = head(req.query.id);
-    if (id == null)
-      return { message: "File Collection ID required.", status: 400 };
+  const id = head(req.query.id);
+  if (id == null)
+    return { message: "File Collection ID required.", status: 400 };
 
-    const pageSize = head(req.query.pageSize);
-    const cursor = head(req.query.cursor);
-    const c = getFileCollectionsApi(await getClientFromSession(req.session));
-    const { cursors, page } = await getPage(() =>
-      c.listFileCollectionFiles({
-        id,
-        pageCursor: cursor,
-        pageSize: parsePositiveQueryInt(pageSize, 10),
-      })
-    );
+  const pageSize = head(req.query.pageSize);
+  const cursor = head(req.query.cursor);
+  const c = getFileCollectionsApi(await getClientFromSession(req.session));
+  const { cursors, page } = await getPage(() =>
+    c.listFileCollectionFiles({
+      id,
+      pageCursor: cursor,
+      pageSize: parsePositiveQueryInt(pageSize, 10),
+    })
+  );
 
-    return { cursors, data: page.data, status: 200 };
-  } catch (error) {
-    const e = error as VertexError;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError?.res })
-      : ServerError;
-  }
+  return { cursors, data: page.data, status: 200 };
 }


### PR DESCRIPTION
## Summary

Establishes a shared pattern for `src/pages/api` handlers so each one can drop the
three repeated blocks of boilerplate — HTTP method dispatch, a 405 fallback, and an
identical `VertexError` try/catch.

Adds a single `methodRouter({ GET, POST, ... })` factory plus a `handleVertexError`
helper in `src/lib/api-handler.ts`, and converts **one** handler —
`file-collections/[id]/files.ts` — as the reference implementation:

```ts
export const handleFileCollectionFiles = methodRouter({ GET: get });
export default withSession(handleFileCollectionFiles);

async function get(req): Promise<ErrorRes | GetRes<FileMetadataData>> {
  // ...pure happy-path logic, returns a payload with a `status`
}
```

The router dispatches by method, returns 405 for anything unhandled, serializes the
returned payload as JSON using its `status` (default 200), and converts any thrown
`VertexError` into a logged `ErrorRes`.

## Scope — first of two PRs

This PR is deliberately small (**2 files, +77 / −48**) so the pattern itself can be
reviewed in isolation. The repo-wide rollout follows in
**[PLAT-9059](https://vertexvis.atlassian.net/browse/PLAT-9059) → #350**, which applies
this pattern to the remaining 18 handlers.

Across the two PRs the change removes a **net −432 lines over 20 files** — and nearly
all of that reduction (**net −461 across 18 handlers**) lands in the PLAT-9059 rollout.
This first PR is a small net add; the payoff shows up once the rollout merges on top of it.

The rollout also **resolves several inconsistencies that already existed** in the
handlers, surfaced by centralizing error handling:

- `scenes/[id]`, `scene-items/[id]`, and `part-revisions/[id]` previously sent error
  bodies with a hardcoded **HTTP 200**; they will respond with the error's real status.
- `parts.ts` and `scenes.ts` create/update/delete previously let thrown `VertexError`s
  escape **unlogged** (Next's default 500); they will be caught and logged centrally.

## Test plan

- [x] `prettier --check` — clean
- [x] `tsc --noEmit` — no source errors (only the pre-existing `__tests__` harness
      type errors remain, unchanged from `main`)
- [x] `next lint` — no warnings or errors
- [x] `jest` — `file-collection-files` handler suite passes (4/4)

Ticket: [PLAT-9058](https://vertexvis.atlassian.net/browse/PLAT-9058)


[PLAT-9059]: https://vertexvis.atlassian.net/browse/PLAT-9059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ