### PR TITLE
[PLAT-8994] - [dev-dashboard] Add shared ConfirmDialog and use it for file collection deletes

### DIFF
--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import React from "react";
@@ -203,6 +203,11 @@ describe("FileCollectionTable", () => {
     await userEvent.click(screen.getByLabelText("Select Collection One"));
     await userEvent.click(screen.getByLabelText("Delete"));
 
+    const confirmDialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Delete" })
+    );
+
     await waitFor(() => {
       expect(deletedIds).toEqual([["collection-1"]]);
     });
@@ -299,6 +304,11 @@ describe("FileCollectionTable", () => {
 
     await userEvent.click(screen.getByLabelText("Select Collection One"));
     await userEvent.click(screen.getByLabelText("Delete"));
+
+    const confirmDialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Delete" })
+    );
 
     expect(
       await screen.findByText("Could not delete collection-1.")

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -318,6 +318,38 @@ describe("FileCollectionTable", () => {
     expect(deletedIds).toEqual([["collection-1"]]);
   });
 
+  it("closes the confirm dialog and surfaces an error when the delete request rejects", async () => {
+    server.use(
+      http.get("*/api/file-collections", () => {
+        return HttpResponse.json(firstPage);
+      }),
+      http.delete("*/api/file-collections", () => {
+        return HttpResponse.error();
+      })
+    );
+
+    renderTable();
+
+    expect(await screen.findByText("Collection One")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByLabelText("Select Collection One"));
+    await userEvent.click(screen.getByLabelText("Delete"));
+
+    const confirmDialog = await screen.findByRole("dialog");
+    await userEvent.click(
+      within(confirmDialog).getByRole("button", { name: "Delete" })
+    );
+
+    expect(
+      await screen.findByText("Could not delete the selected file collections.")
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("1 selected")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select Collection One")).toBeChecked();
+  });
+
   it("filters file collections by a partial supplied ID", async () => {
     const requests: string[] = [];
 

--- a/src/__tests__/components/shared/ConfirmDialog.test.tsx
+++ b/src/__tests__/components/shared/ConfirmDialog.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+
+import { ConfirmDialog } from "../../../components/shared/ConfirmDialog";
+
+describe("ConfirmDialog", () => {
+  it("renders the title and message when open", () => {
+    render(
+      <ConfirmDialog
+        message="This cannot be undone."
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open
+        title="Delete things"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Delete things" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("This cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("invokes the callbacks for cancel and confirm", async () => {
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+
+    render(
+      <ConfirmDialog
+        cancelLabel="Cancel"
+        confirmLabel="Delete"
+        message="Are you sure?"
+        onClose={onClose}
+        onConfirm={onConfirm}
+        open
+        title="Confirm"
+      />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the actions while confirming", () => {
+    render(
+      <ConfirmDialog
+        confirmLabel="Delete"
+        confirming
+        message="Working..."
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        open
+        title="Confirm"
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
+  });
+});

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
+import { ConfirmDialog } from "../shared/ConfirmDialog";
 import {
   CreatedAtDateRange,
   CreatedAtDateRangeFilter,
@@ -99,6 +100,8 @@ export default function FileCollectionTable({
   const [createdAtFilters, setCreatedAtFilters] =
     React.useState<CreatedAtDateRange>({});
   const [deleteError, setDeleteError] = React.useState<string>();
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const [deleting, setDeleting] = React.useState(false);
 
   const { data, error, mutate } = useFileCollections({
     createdAtEnd: createdAtFilters.createdAtEnd,
@@ -175,10 +178,10 @@ export default function FileCollectionTable({
     handlePageChange(num);
   }
 
-  async function handleDelete() {
+  async function handleConfirmDelete() {
     setDeleteError(undefined);
+    setDeleting(true);
     const ids = [...selected];
-    setSelected(new Set());
 
     const res = await fetch("/api/file-collections", {
       body: JSON.stringify({ ids }),
@@ -187,14 +190,18 @@ export default function FileCollectionTable({
 
     if (!res.ok) {
       const body = await res.json();
+      setDeleting(false);
+      setConfirmOpen(false);
       setDeleteError(
         body.message ?? "Could not delete the selected file collections."
       );
-      setSelected(new Set(ids));
       return;
     }
 
+    setSelected(new Set());
     mutate();
+    setDeleting(false);
+    setConfirmOpen(false);
   }
 
   let tableRows: React.ReactNode;
@@ -260,7 +267,10 @@ export default function FileCollectionTable({
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            setDeleteError(undefined);
+            setConfirmOpen(true);
+          }}
           title="File Collections"
         />
         <Box
@@ -350,6 +360,20 @@ export default function FileCollectionTable({
           }}
         />
       </Paper>
+      <ConfirmDialog
+        confirmLabel="Delete"
+        confirming={deleting}
+        message={`Delete ${selected.size} selected file ${
+          selected.size === 1 ? "collection" : "collections"
+        }? This cannot be undone.`}
+        onClose={() => {
+          if (deleting) return;
+          setConfirmOpen(false);
+        }}
+        onConfirm={handleConfirmDelete}
+        open={confirmOpen}
+        title="Delete File Collections"
+      />
       <Snackbar
         open={deleteError != null}
         autoHideDuration={6000}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -183,25 +183,28 @@ export default function FileCollectionTable({
     setDeleting(true);
     const ids = [...selected];
 
-    const res = await fetch("/api/file-collections", {
-      body: JSON.stringify({ ids }),
-      method: "DELETE",
-    });
+    try {
+      const res = await fetch("/api/file-collections", {
+        body: JSON.stringify({ ids }),
+        method: "DELETE",
+      });
 
-    if (!res.ok) {
-      const body = await res.json();
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setDeleteError(
+          body.message ?? "Could not delete the selected file collections."
+        );
+        return;
+      }
+
+      setSelected(new Set());
+      mutate();
+    } catch {
+      setDeleteError("Could not delete the selected file collections.");
+    } finally {
       setDeleting(false);
       setConfirmOpen(false);
-      setDeleteError(
-        body.message ?? "Could not delete the selected file collections."
-      );
-      return;
     }
-
-    setSelected(new Set());
-    mutate();
-    setDeleting(false);
-    setConfirmOpen(false);
   }
 
   let tableRows: React.ReactNode;

--- a/src/components/shared/ConfirmDialog.tsx
+++ b/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,59 @@
+import {
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from "@mui/material";
+import React from "react";
+
+interface Props {
+  readonly cancelLabel?: string;
+  readonly confirmLabel?: string;
+  readonly confirming?: boolean;
+  readonly message: React.ReactNode;
+  readonly onClose: () => void;
+  readonly onConfirm: () => void;
+  readonly open: boolean;
+  readonly title: string;
+}
+
+export function ConfirmDialog({
+  cancelLabel = "Cancel",
+  confirmLabel = "Confirm",
+  confirming = false,
+  message,
+  onClose,
+  onConfirm,
+  open,
+  title,
+}: Props): JSX.Element {
+  return (
+    <Dialog onClose={confirming ? undefined : onClose} open={open}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{message}</DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button disabled={confirming} onClick={onClose}>
+          {cancelLabel}
+        </Button>
+        <Button
+          color="error"
+          disabled={confirming}
+          onClick={onConfirm}
+          startIcon={
+            confirming ? (
+              <CircularProgress color="inherit" size={16} />
+            ) : undefined
+          }
+          variant="contained"
+        >
+          {confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
First smaller slice of PLAT-8994. Introduces a reusable **`ConfirmDialog`** component and wires it into the file-collection delete flow, so destructive actions across the dashboard can share one confirmation UX. This is the shared primitive that the larger PLAT-8994 property-key-policy work (#353) builds on, landed on its own to keep that PR focused.

- New `src/components/shared/ConfirmDialog.tsx`: a MUI-based confirm dialog with configurable `title`, `message`, and `confirmLabel`/`cancelLabel` (defaulting to "Confirm"/"Cancel"). The confirm action is styled as a destructive (`error`, contained) button.
- Supports an in-flight `confirming` state: both actions are disabled, the confirm button shows a spinner, and backdrop/escape dismissal is blocked so a delete can't be interrupted mid-request.
- **File collections** now require confirmation before deleting: clicking **Delete** opens the dialog (message pluralizes and reflects the number of selected collections), and the DELETE request only fires on confirm. Selection is preserved if the user cancels or if the request fails.
- Delete error handling is unchanged in behavior (errors still surface via snackbar); the dialog closes on both success and failure.

Out of scope (follow-up): adopting `ConfirmDialog` in the property-key-policy create/delete flow (#353) and other existing delete surfaces.

## Test Plan
Automated (all green in the branch):
- `yarn typecheck` — passes.
- `yarn lint` — no warnings/errors.
- `yarn format:check` — all files match Prettier style.
- `yarn test` — **87 tests / 16 suites pass**, including:
  - New `ConfirmDialog` component tests (RTL): renders title + message when open, invokes `onClose`/`onConfirm` for cancel/confirm, and disables both actions while `confirming`.
  - Updated `FileCollectionTable` tests: delete now **requires confirmation** — no DELETE request is issued until the confirm button in the dialog is clicked (asserted on both the success path and the error-surfacing path).

Manual verification suggested for reviewers:
1. Nav → **File Collections**; select one or more collections and click **Delete**.
2. Confirm the dialog message reflects the count (singular vs. plural) and that **Cancel** dismisses without deleting.
3. Click **Delete** in the dialog; confirm the collection(s) are removed and the confirm button shows a spinner while in flight.
4. Force a delete failure and confirm the error snackbar appears and the selection is retained.

## Release Notes
Deleting file collections now shows a confirmation dialog before removing them.

## Possible Regressions
Additive and low risk. New shared component (`ConfirmDialog.tsx`); the only modified surface is `FileCollectionTable.tsx`, which gains a confirmation step before an existing delete. No API or route changes.

## Dependencies
None. Uses MUI components already in the project.
