### PR TITLE
[PLAT-9067] - [dev-dashboard] Add and remove entries on an existing property key policy

### DIFF
--- a/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
+++ b/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
@@ -1,31 +1,31 @@
-import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import React from "react";
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
 
-import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
-import { server } from "../../../../test/msw/server";
-import { renderWithSWR } from "../../../../test/render/renderWithSWR";
-import AddPropertyKeyPolicyEntryDialog from "../../../components/property-key-policy/AddPropertyKeyPolicyEntryDialog";
+import { installJsdomMockServer } from '../../../../test/msw/installJsdomMockServer';
+import { server } from '../../../../test/msw/server';
+import { renderWithSWR } from '../../../../test/render/renderWithSWR';
+import AddPropertyKeyPolicyEntryDialog from '../../../components/property-key-policy/AddPropertyKeyPolicyEntryDialog';
 
-describe("AddPropertyKeyPolicyEntryDialog", () => {
+describe('AddPropertyKeyPolicyEntryDialog', () => {
   installJsdomMockServer();
 
-  it("shows the case-sensitivity helper text", () => {
+  it('shows the case-sensitivity helper text', () => {
     renderDialog();
 
     expect(
       screen.getByText(
-        "Metadata property keys are case-sensitive and are saved exactly as typed."
+        'Metadata property keys are case-sensitive and are saved exactly as typed.'
       )
     ).toBeInTheDocument();
   });
 
-  it("submits multiple keys verbatim (case preserved) and calls onAdded", async () => {
+  it('submits multiple keys verbatim (case preserved) and calls onAdded', async () => {
     const bodies: Array<Record<string, unknown>> = [];
 
     server.use(
-      http.post("*/api/property-key-policies/:id/keys", async ({ request }) => {
+      http.post('*/api/property-key-policies/:id/keys', async ({ request }) => {
         bodies.push((await request.json()) as Record<string, unknown>);
         return HttpResponse.json({ status: 201 }, { status: 201 });
       })
@@ -35,28 +35,23 @@ describe("AddPropertyKeyPolicyEntryDialog", () => {
     const onClose = jest.fn();
     renderDialog({ onAdded, onClose });
 
-    await userEvent.type(
-      screen.getByLabelText("Property key 1"),
-      "MixedCase_Key"
-    );
-    await userEvent.click(
-      screen.getByRole("button", { name: "Add Property Key" })
-    );
-    await userEvent.type(screen.getByLabelText("Property key 2"), "second_KEY");
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'MixedCase_Key');
+    await userEvent.click(screen.getByRole('button', { name: 'Add Property Key' }));
+    await userEvent.type(screen.getByLabelText('Property key 2'), 'second_KEY');
 
-    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     await waitFor(() => expect(bodies).toHaveLength(1));
-    expect(bodies[0]).toEqual({ keys: ["MixedCase_Key", "second_KEY"] });
+    expect(bodies[0]).toEqual({ keys: ['MixedCase_Key', 'second_KEY'] });
     await waitFor(() => expect(onAdded).toHaveBeenCalled());
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
-  it("filters blank keys before submitting", async () => {
+  it('filters blank keys before submitting', async () => {
     const bodies: Array<Record<string, unknown>> = [];
 
     server.use(
-      http.post("*/api/property-key-policies/:id/keys", async ({ request }) => {
+      http.post('*/api/property-key-policies/:id/keys', async ({ request }) => {
         bodies.push((await request.json()) as Record<string, unknown>);
         return HttpResponse.json({ status: 201 }, { status: 201 });
       })
@@ -64,23 +59,21 @@ describe("AddPropertyKeyPolicyEntryDialog", () => {
 
     renderDialog();
 
-    await userEvent.type(screen.getByLabelText("Property key 1"), "Only_Key");
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'Only_Key');
     // Add a second, blank row that must be filtered out of the payload.
-    await userEvent.click(
-      screen.getByRole("button", { name: "Add Property Key" })
-    );
+    await userEvent.click(screen.getByRole('button', { name: 'Add Property Key' }));
 
-    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     await waitFor(() => expect(bodies).toHaveLength(1));
-    expect(bodies[0]).toEqual({ keys: ["Only_Key"] });
+    expect(bodies[0]).toEqual({ keys: ['Only_Key'] });
   });
 
-  it("shows the API error message when the add fails", async () => {
+  it('shows the API error message when the add fails', async () => {
     server.use(
-      http.post("*/api/property-key-policies/:id/keys", () =>
+      http.post('*/api/property-key-policies/:id/keys', () =>
         HttpResponse.json(
-          { message: "Could not add keys.", status: 400 },
+          { message: 'Could not add keys.', status: 400 },
           { status: 400 }
         )
       )
@@ -90,14 +83,14 @@ describe("AddPropertyKeyPolicyEntryDialog", () => {
     const onClose = jest.fn();
     renderDialog({ onAdded, onClose });
 
-    await userEvent.type(screen.getByLabelText("Property key 1"), "Key");
-    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'Key');
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
 
-    expect(await screen.findByText("Could not add keys.")).toBeInTheDocument();
+    expect(await screen.findByText('Could not add keys.')).toBeInTheDocument();
     expect(onAdded).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
     // Dialog stays open and keeps the entered value.
-    expect(screen.getByLabelText("Property key 1")).toHaveValue("Key");
+    expect(screen.getByLabelText('Property key 1')).toHaveValue('Key');
   });
 });
 
@@ -113,7 +106,7 @@ function renderDialog(
       onAdded={props.onAdded ?? jest.fn()}
       onClose={props.onClose ?? jest.fn()}
       open
-      policyId={props.policyId ?? "policy-1"}
+      policyId={props.policyId ?? 'policy-1'}
     />
   );
 }

--- a/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
+++ b/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
@@ -1,0 +1,119 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import React from "react";
+
+import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
+import { server } from "../../../../test/msw/server";
+import { renderWithSWR } from "../../../../test/render/renderWithSWR";
+import AddPropertyKeyPolicyEntryDialog from "../../../components/property-key-policy/AddPropertyKeyPolicyEntryDialog";
+
+describe("AddPropertyKeyPolicyEntryDialog", () => {
+  installJsdomMockServer();
+
+  it("shows the case-sensitivity helper text", () => {
+    renderDialog();
+
+    expect(
+      screen.getByText(
+        "Metadata property keys are case-sensitive and are saved exactly as typed."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("submits multiple keys verbatim (case preserved) and calls onAdded", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+
+    server.use(
+      http.post("*/api/property-key-policies/:id/keys", async ({ request }) => {
+        bodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ status: 201 }, { status: 201 });
+      })
+    );
+
+    const onAdded = jest.fn();
+    const onClose = jest.fn();
+    renderDialog({ onAdded, onClose });
+
+    await userEvent.type(
+      screen.getByLabelText("Property key 1"),
+      "MixedCase_Key"
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add Property Key" })
+    );
+    await userEvent.type(screen.getByLabelText("Property key 2"), "second_KEY");
+
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toEqual({ keys: ["MixedCase_Key", "second_KEY"] });
+    await waitFor(() => expect(onAdded).toHaveBeenCalled());
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("filters blank keys before submitting", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+
+    server.use(
+      http.post("*/api/property-key-policies/:id/keys", async ({ request }) => {
+        bodies.push((await request.json()) as Record<string, unknown>);
+        return HttpResponse.json({ status: 201 }, { status: 201 });
+      })
+    );
+
+    renderDialog();
+
+    await userEvent.type(screen.getByLabelText("Property key 1"), "Only_Key");
+    // Add a second, blank row that must be filtered out of the payload.
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add Property Key" })
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => expect(bodies).toHaveLength(1));
+    expect(bodies[0]).toEqual({ keys: ["Only_Key"] });
+  });
+
+  it("shows the API error message when the add fails", async () => {
+    server.use(
+      http.post("*/api/property-key-policies/:id/keys", () =>
+        HttpResponse.json(
+          { message: "Could not add keys.", status: 400 },
+          { status: 400 }
+        )
+      )
+    );
+
+    const onAdded = jest.fn();
+    const onClose = jest.fn();
+    renderDialog({ onAdded, onClose });
+
+    await userEvent.type(screen.getByLabelText("Property key 1"), "Key");
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByText("Could not add keys.")).toBeInTheDocument();
+    expect(onAdded).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    // Dialog stays open and keeps the entered value.
+    expect(screen.getByLabelText("Property key 1")).toHaveValue("Key");
+  });
+});
+
+function renderDialog(
+  props: {
+    readonly onAdded?: () => void;
+    readonly onClose?: () => void;
+    readonly policyId?: string;
+  } = {}
+): void {
+  renderWithSWR(
+    <AddPropertyKeyPolicyEntryDialog
+      onAdded={props.onAdded ?? jest.fn()}
+      onClose={props.onClose ?? jest.fn()}
+      open
+      policyId={props.policyId ?? "policy-1"}
+    />
+  );
+}

--- a/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
+++ b/src/__tests__/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.test.tsx
@@ -14,11 +14,40 @@ describe('AddPropertyKeyPolicyEntryDialog', () => {
   it('shows the case-sensitivity helper text', () => {
     renderDialog();
 
+    // The sentence is split across elements to emphasize key phrases, so assert
+    // the emphasized fragments render rather than the full sentence.
+    expect(screen.getByText('case-sensitive')).toBeInTheDocument();
+    expect(screen.getByText('saved exactly as typed')).toBeInTheDocument();
+  });
+
+  it('pressing Enter in a property key field adds and focuses a new field', async () => {
+    renderDialog();
+
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'Alpha{Enter}');
+
+    const secondField = screen.getByLabelText('Property key 2');
+    expect(secondField).toBeInTheDocument();
+    expect(secondField).toHaveFocus();
+    expect(screen.getByLabelText('Property key 1')).toHaveValue('Alpha');
+  });
+
+  it('flags a key that already exists on the policy and disables Add', async () => {
+    renderDialog({ existingKeys: ['ExistingKey'] });
+
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'ExistingKey');
+
     expect(
-      screen.getByText(
-        'Metadata property keys are case-sensitive and are saved exactly as typed.'
-      )
+      screen.getByText('Property key already exists on this policy.')
     ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+
+    // Case-sensitive: a different case is not a duplicate.
+    await userEvent.clear(screen.getByLabelText('Property key 1'));
+    await userEvent.type(screen.getByLabelText('Property key 1'), 'existingkey');
+    expect(
+      screen.queryByText('Property key already exists on this policy.')
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
   });
 
   it('submits multiple keys verbatim (case preserved) and calls onAdded', async () => {
@@ -99,10 +128,12 @@ function renderDialog(
     readonly onAdded?: () => void;
     readonly onClose?: () => void;
     readonly policyId?: string;
+    readonly existingKeys?: readonly string[];
   } = {}
 ): void {
   renderWithSWR(
     <AddPropertyKeyPolicyEntryDialog
+      existingKeys={props.existingKeys}
       onAdded={props.onAdded ?? jest.fn()}
       onClose={props.onClose ?? jest.fn()}
       open

--- a/src/__tests__/components/property-key-policy/PropertyKeyPolicyKeysList.test.tsx
+++ b/src/__tests__/components/property-key-policy/PropertyKeyPolicyKeysList.test.tsx
@@ -1,138 +1,114 @@
-import { screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { http, HttpResponse } from "msw";
-import React from "react";
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import React from 'react';
 
-import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
-import { server } from "../../../../test/msw/server";
-import { renderWithSWR } from "../../../../test/render/renderWithSWR";
-import { PropertyKeyPolicyKeysList } from "../../../components/property-key-policy/PropertyKeyPolicyKeysList";
-import { PropertyKeyPolicyKey } from "../../../lib/property-key-policies";
+import { installJsdomMockServer } from '../../../../test/msw/installJsdomMockServer';
+import { server } from '../../../../test/msw/server';
+import { renderWithSWR } from '../../../../test/render/renderWithSWR';
+import { PropertyKeyPolicyKeysList } from '../../../components/property-key-policy/PropertyKeyPolicyKeysList';
+import { PropertyKeyPolicyKey } from '../../../lib/property-key-policies';
 
 const keys: readonly PropertyKeyPolicyKey[] = [
-  { id: "key-1", name: "Alpha" },
-  { id: "key-2", name: "Beta" },
+  { id: 'key-1', name: 'Alpha' },
+  { id: 'key-2', name: 'Beta' },
 ];
 
-describe("PropertyKeyPolicyKeysList", () => {
+describe('PropertyKeyPolicyKeysList', () => {
   installJsdomMockServer();
 
-  it("renders read-only with no editing controls when editing props are absent", () => {
+  it('renders read-only with no editing controls when editing props are absent', () => {
     renderWithSWR(<PropertyKeyPolicyKeysList keys={keys} />);
 
-    expect(screen.getByText("Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
     // Protects the drawer: no delete, no checkbox, no add controls.
-    expect(screen.queryByLabelText("Delete Alpha")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Select Alpha")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete Alpha')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Select Alpha')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Add property key(s)" })
+      screen.queryByRole('button', { name: 'Add property key(s)' })
     ).not.toBeInTheDocument();
   });
 
-  it("renders delete buttons, checkboxes, and an add button in editable mode", () => {
+  it('renders delete buttons, checkboxes, and an add button in editable mode', () => {
     renderWithSWR(
-      <PropertyKeyPolicyKeysList
-        keys={keys}
-        onMutate={jest.fn()}
-        policyId="policy-1"
-      />
+      <PropertyKeyPolicyKeysList keys={keys} onMutate={jest.fn()} policyId="policy-1" />
     );
 
-    expect(screen.getByLabelText("Delete Alpha")).toBeInTheDocument();
-    expect(screen.getByLabelText("Delete Beta")).toBeInTheDocument();
-    expect(screen.getByLabelText("Select Alpha")).toBeInTheDocument();
-    expect(screen.getByLabelText("Select Beta")).toBeInTheDocument();
+    expect(screen.getByLabelText('Delete Alpha')).toBeInTheDocument();
+    expect(screen.getByLabelText('Delete Beta')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select Alpha')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select Beta')).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Add property key(s)" })
+      screen.getByRole('button', { name: 'Add property key(s)' })
     ).toBeInTheDocument();
   });
 
-  it("deletes a single key by id and triggers mutate", async () => {
+  it('deletes a single key by id and triggers mutate', async () => {
     const deletedIds: string[][] = [];
     const onMutate = jest.fn();
 
     server.use(
-      http.delete(
-        "*/api/property-key-policies/:id/keys",
-        async ({ request }) => {
-          const body = (await request.json()) as { ids?: string[] };
-          deletedIds.push(body.ids ?? []);
-          return HttpResponse.json({ status: 200 });
-        }
-      )
+      http.delete('*/api/property-key-policies/:id/keys', async ({ request }) => {
+        const body = (await request.json()) as { ids?: string[] };
+        deletedIds.push(body.ids ?? []);
+        return HttpResponse.json({ status: 200 });
+      })
     );
 
     renderWithSWR(
-      <PropertyKeyPolicyKeysList
-        keys={keys}
-        onMutate={onMutate}
-        policyId="policy-1"
-      />
+      <PropertyKeyPolicyKeysList keys={keys} onMutate={onMutate} policyId="policy-1" />
     );
 
-    await userEvent.click(screen.getByLabelText("Delete Alpha"));
+    await userEvent.click(screen.getByLabelText('Delete Alpha'));
 
-    await waitFor(() => expect(deletedIds).toEqual([["key-1"]]));
+    await waitFor(() => expect(deletedIds).toEqual([['key-1']]));
     await waitFor(() => expect(onMutate).toHaveBeenCalled());
   });
 
-  it("bulk deletes the selected key ids", async () => {
+  it('bulk deletes the selected key ids', async () => {
     const deletedIds: string[][] = [];
     const onMutate = jest.fn();
 
     server.use(
-      http.delete(
-        "*/api/property-key-policies/:id/keys",
-        async ({ request }) => {
-          const body = (await request.json()) as { ids?: string[] };
-          deletedIds.push(body.ids ?? []);
-          return HttpResponse.json({ status: 200 });
-        }
-      )
+      http.delete('*/api/property-key-policies/:id/keys', async ({ request }) => {
+        const body = (await request.json()) as { ids?: string[] };
+        deletedIds.push(body.ids ?? []);
+        return HttpResponse.json({ status: 200 });
+      })
     );
 
     renderWithSWR(
-      <PropertyKeyPolicyKeysList
-        keys={keys}
-        onMutate={onMutate}
-        policyId="policy-1"
-      />
+      <PropertyKeyPolicyKeysList keys={keys} onMutate={onMutate} policyId="policy-1" />
     );
 
-    await userEvent.click(screen.getByLabelText("Select Alpha"));
-    await userEvent.click(screen.getByLabelText("Select Beta"));
-    await userEvent.click(screen.getByRole("button", { name: /Delete \(2\)/ }));
+    await userEvent.click(screen.getByLabelText('Select Alpha'));
+    await userEvent.click(screen.getByLabelText('Select Beta'));
+    await userEvent.click(screen.getByRole('button', { name: /Delete \(2\)/ }));
 
-    await waitFor(() => expect(deletedIds).toEqual([["key-1", "key-2"]]));
+    await waitFor(() => expect(deletedIds).toEqual([['key-1', 'key-2']]));
     await waitFor(() => expect(onMutate).toHaveBeenCalled());
   });
 
-  it("surfaces a snackbar error when a delete fails", async () => {
+  it('surfaces a snackbar error when a delete fails', async () => {
     const onMutate = jest.fn();
 
     server.use(
-      http.delete("*/api/property-key-policies/:id/keys", () =>
+      http.delete('*/api/property-key-policies/:id/keys', () =>
         HttpResponse.json(
-          { message: "Could not delete key-1.", status: 500 },
+          { message: 'Could not delete key-1.', status: 500 },
           { status: 500 }
         )
       )
     );
 
     renderWithSWR(
-      <PropertyKeyPolicyKeysList
-        keys={keys}
-        onMutate={onMutate}
-        policyId="policy-1"
-      />
+      <PropertyKeyPolicyKeysList keys={keys} onMutate={onMutate} policyId="policy-1" />
     );
 
-    await userEvent.click(screen.getByLabelText("Delete Alpha"));
+    await userEvent.click(screen.getByLabelText('Delete Alpha'));
 
-    expect(
-      await screen.findByText("Could not delete key-1.")
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Could not delete key-1.')).toBeInTheDocument();
     expect(onMutate).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/property-key-policy/PropertyKeyPolicyKeysList.test.tsx
+++ b/src/__tests__/components/property-key-policy/PropertyKeyPolicyKeysList.test.tsx
@@ -1,0 +1,138 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import React from "react";
+
+import { installJsdomMockServer } from "../../../../test/msw/installJsdomMockServer";
+import { server } from "../../../../test/msw/server";
+import { renderWithSWR } from "../../../../test/render/renderWithSWR";
+import { PropertyKeyPolicyKeysList } from "../../../components/property-key-policy/PropertyKeyPolicyKeysList";
+import { PropertyKeyPolicyKey } from "../../../lib/property-key-policies";
+
+const keys: readonly PropertyKeyPolicyKey[] = [
+  { id: "key-1", name: "Alpha" },
+  { id: "key-2", name: "Beta" },
+];
+
+describe("PropertyKeyPolicyKeysList", () => {
+  installJsdomMockServer();
+
+  it("renders read-only with no editing controls when editing props are absent", () => {
+    renderWithSWR(<PropertyKeyPolicyKeysList keys={keys} />);
+
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+    // Protects the drawer: no delete, no checkbox, no add controls.
+    expect(screen.queryByLabelText("Delete Alpha")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Select Alpha")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add property key(s)" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders delete buttons, checkboxes, and an add button in editable mode", () => {
+    renderWithSWR(
+      <PropertyKeyPolicyKeysList
+        keys={keys}
+        onMutate={jest.fn()}
+        policyId="policy-1"
+      />
+    );
+
+    expect(screen.getByLabelText("Delete Alpha")).toBeInTheDocument();
+    expect(screen.getByLabelText("Delete Beta")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select Alpha")).toBeInTheDocument();
+    expect(screen.getByLabelText("Select Beta")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add property key(s)" })
+    ).toBeInTheDocument();
+  });
+
+  it("deletes a single key by id and triggers mutate", async () => {
+    const deletedIds: string[][] = [];
+    const onMutate = jest.fn();
+
+    server.use(
+      http.delete(
+        "*/api/property-key-policies/:id/keys",
+        async ({ request }) => {
+          const body = (await request.json()) as { ids?: string[] };
+          deletedIds.push(body.ids ?? []);
+          return HttpResponse.json({ status: 200 });
+        }
+      )
+    );
+
+    renderWithSWR(
+      <PropertyKeyPolicyKeysList
+        keys={keys}
+        onMutate={onMutate}
+        policyId="policy-1"
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Delete Alpha"));
+
+    await waitFor(() => expect(deletedIds).toEqual([["key-1"]]));
+    await waitFor(() => expect(onMutate).toHaveBeenCalled());
+  });
+
+  it("bulk deletes the selected key ids", async () => {
+    const deletedIds: string[][] = [];
+    const onMutate = jest.fn();
+
+    server.use(
+      http.delete(
+        "*/api/property-key-policies/:id/keys",
+        async ({ request }) => {
+          const body = (await request.json()) as { ids?: string[] };
+          deletedIds.push(body.ids ?? []);
+          return HttpResponse.json({ status: 200 });
+        }
+      )
+    );
+
+    renderWithSWR(
+      <PropertyKeyPolicyKeysList
+        keys={keys}
+        onMutate={onMutate}
+        policyId="policy-1"
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Select Alpha"));
+    await userEvent.click(screen.getByLabelText("Select Beta"));
+    await userEvent.click(screen.getByRole("button", { name: /Delete \(2\)/ }));
+
+    await waitFor(() => expect(deletedIds).toEqual([["key-1", "key-2"]]));
+    await waitFor(() => expect(onMutate).toHaveBeenCalled());
+  });
+
+  it("surfaces a snackbar error when a delete fails", async () => {
+    const onMutate = jest.fn();
+
+    server.use(
+      http.delete("*/api/property-key-policies/:id/keys", () =>
+        HttpResponse.json(
+          { message: "Could not delete key-1.", status: 500 },
+          { status: 500 }
+        )
+      )
+    );
+
+    renderWithSWR(
+      <PropertyKeyPolicyKeysList
+        keys={keys}
+        onMutate={onMutate}
+        policyId="policy-1"
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Delete Alpha"));
+
+    expect(
+      await screen.findByText("Could not delete key-1.")
+    ).toBeInTheDocument();
+    expect(onMutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/pages/api/property-key-policy-keys.test.ts
+++ b/src/__tests__/pages/api/property-key-policy-keys.test.ts
@@ -1,74 +1,77 @@
 /**
  * @jest-environment node
  */
-import { http, HttpResponse } from 'msw';
+import { http, HttpResponse } from "msw";
 
 import {
   type ApiRouteRequest,
   type ApiRouteResponse,
   createAuthenticatedVertexApiTestSession,
   invokeNextJsApiRouteHandler,
-} from '../../../../test/api/nextJsApiRouteTest';
-import { nodeMswServer } from '../../../../test/msw/server';
-import { handlePropertyKeyPolicyKeys } from '../../../pages/api/property-key-policies/[id]/keys';
+} from "../../../../test/api/nextJsApiRouteTest";
+import { nodeMswServer } from "../../../../test/msw/server";
+import { handlePropertyKeyPolicyKeys } from "../../../pages/api/property-key-policies/[id]/keys";
 
-const vertexApiOrigin = 'https://vertex-api.test';
+const vertexApiOrigin = "https://vertex-api.test";
 
-describe('property key policy keys API route', () => {
-  it('lists keys for the policy across pages', async () => {
+describe("property key policy keys API route", () => {
+  it("lists keys for the policy across pages", async () => {
     nodeMswServer.use(
-      stubListKeys('policy-1', {
-        '': [keyData('key-1', 'MixedCaseKey')],
-        'cursor-2': [keyData('key-2', 'another_key')],
+      stubListKeys("policy-1", {
+        "": [keyData("key-1", "MixedCaseKey")],
+        "cursor-2": [keyData("key-2", "another_key")],
       })
     );
 
-    const response = await callKeys('policy-1', { method: 'GET' });
+    const response = await callKeys("policy-1", { method: "GET" });
 
     expect(response.statusCode()).toBe(200);
     expect(response.body()).toEqual({
-      data: [keyData('key-1', 'MixedCaseKey'), keyData('key-2', 'another_key')],
+      data: [keyData("key-1", "MixedCaseKey"), keyData("key-2", "another_key")],
       status: 200,
     });
   });
 
-  it('returns Vertex API failures from list requests', async () => {
+  it("returns Vertex API failures from list requests", async () => {
     nodeMswServer.use(
       http.get(`${vertexApiOrigin}/property-key-policies/policy-1/keys`, () =>
         HttpResponse.json(
-          { errors: [{ status: '500', title: 'Vertex is upset.' }] },
+          { errors: [{ status: "500", title: "Vertex is upset." }] },
           {
             status: 500,
-            headers: { 'content-type': 'application/vnd.api+json' },
+            headers: { "content-type": "application/vnd.api+json" },
           }
         )
       )
     );
 
-    const response = await callKeys('policy-1', { method: 'GET' });
+    const response = await callKeys("policy-1", { method: "GET" });
 
     expect(response.statusCode()).toBe(500);
     expect(response.body()).toEqual({
-      message: 'Vertex is upset.',
+      message: "Vertex is upset.",
       status: 500,
     });
   });
 
-  it('requires a policy ID', async () => {
-    const response = await invokeNextJsApiRouteHandler(handlePropertyKeyPolicyKeys, {
-      method: 'GET',
-      query: {},
-      session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
-    });
+  it("requires a policy ID", async () => {
+    const response = await invokeNextJsApiRouteHandler(
+      handlePropertyKeyPolicyKeys,
+      {
+        method: "GET",
+        query: {},
+        session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
+      }
+    );
 
     expect(response.statusCode()).toBe(400);
     expect(response.body()).toEqual({
-      message: 'Property Key Policy ID required.',
+      message: "Property Key Policy ID required.",
       status: 400,
     });
   });
 
-  it('fails safely when upstream returns the same cursor repeatedly', async () => {
+  it("fails safely when upstream returns the same cursor repeatedly", async () => {
     // A repeated cursor must not lead to an infinite pagination loop.
     let callCount = 0;
 
@@ -85,27 +88,27 @@ describe('property key policy keys API route', () => {
               },
             },
           },
-          { headers: { 'content-type': 'application/vnd.api+json' } }
+          { headers: { "content-type": "application/vnd.api+json" } }
         );
       })
     );
 
-    const response = await callKeys('policy-1', { method: 'GET' });
+    const response = await callKeys("policy-1", { method: "GET" });
 
     expect(response.statusCode()).toBe(500);
     expect(callCount).toBe(2);
     expect(response.body()).toEqual({
-      message: 'Unknown error from Vertex API.',
+      message: "Unknown error from Vertex API.",
       status: 500,
     });
   });
 
-  it('rejects unsupported methods', async () => {
-    const response = await callKeys('policy-1', { method: 'DELETE' });
+  it("rejects unsupported methods", async () => {
+    const response = await callKeys("policy-1", { method: "PATCH" });
 
     expect(response.statusCode()).toBe(405);
     expect(response.body()).toEqual({
-      message: 'Method not allowed.',
+      message: "Method not allowed.",
       status: 405,
     });
   });
@@ -119,31 +122,28 @@ function callKeys(id: string, req: ApiRouteRequest): Promise<ApiRouteResponse> {
   });
 }
 
-function keyData(
-  id: string,
-  name: string
-): { attributes: { name: string }; id: string; type: string } {
+function keyData(id: string, name: string) {
   return {
     attributes: { name },
     id,
-    type: 'property-key',
+    type: "property-key",
   };
 }
 
 function stubListKeys(
   policyId: string,
   pages: Record<string, ReturnType<typeof keyData>[]>
-): ReturnType<typeof http.get> {
+) {
   return http.get(
     `${vertexApiOrigin}/property-key-policies/${policyId}/keys`,
     ({ request }) => {
       const url = new URL(request.url);
-      const cursor = url.searchParams.get('page[cursor]') ?? '';
+      const cursor = url.searchParams.get("page[cursor]") ?? "";
       const data = pages[cursor];
       const cursors = Object.keys(pages);
       const currentPageIndex = cursors.indexOf(cursor);
 
-      expect(url.searchParams.get('page[size]')).toBe('200');
+      expect(url.searchParams.get("page[size]")).toBe("200");
       expect(data).toBeDefined();
       expect(currentPageIndex).toBeGreaterThanOrEqual(0);
 
@@ -161,7 +161,7 @@ function stubListKeys(
                   },
                 },
         },
-        { headers: { 'content-type': 'application/vnd.api+json' } }
+        { headers: { "content-type": "application/vnd.api+json" } }
       );
     }
   );

--- a/src/__tests__/pages/api/property-key-policy-keys.test.ts
+++ b/src/__tests__/pages/api/property-key-policy-keys.test.ts
@@ -1,77 +1,74 @@
 /**
  * @jest-environment node
  */
-import { http, HttpResponse } from "msw";
+import { http, HttpResponse } from 'msw';
 
 import {
   type ApiRouteRequest,
   type ApiRouteResponse,
   createAuthenticatedVertexApiTestSession,
   invokeNextJsApiRouteHandler,
-} from "../../../../test/api/nextJsApiRouteTest";
-import { nodeMswServer } from "../../../../test/msw/server";
-import { handlePropertyKeyPolicyKeys } from "../../../pages/api/property-key-policies/[id]/keys";
+} from '../../../../test/api/nextJsApiRouteTest';
+import { nodeMswServer } from '../../../../test/msw/server';
+import { handlePropertyKeyPolicyKeys } from '../../../pages/api/property-key-policies/[id]/keys';
 
-const vertexApiOrigin = "https://vertex-api.test";
+const vertexApiOrigin = 'https://vertex-api.test';
 
-describe("property key policy keys API route", () => {
-  it("lists keys for the policy across pages", async () => {
+describe('property key policy keys API route', () => {
+  it('lists keys for the policy across pages', async () => {
     nodeMswServer.use(
-      stubListKeys("policy-1", {
-        "": [keyData("key-1", "MixedCaseKey")],
-        "cursor-2": [keyData("key-2", "another_key")],
+      stubListKeys('policy-1', {
+        '': [keyData('key-1', 'MixedCaseKey')],
+        'cursor-2': [keyData('key-2', 'another_key')],
       })
     );
 
-    const response = await callKeys("policy-1", { method: "GET" });
+    const response = await callKeys('policy-1', { method: 'GET' });
 
     expect(response.statusCode()).toBe(200);
     expect(response.body()).toEqual({
-      data: [keyData("key-1", "MixedCaseKey"), keyData("key-2", "another_key")],
+      data: [keyData('key-1', 'MixedCaseKey'), keyData('key-2', 'another_key')],
       status: 200,
     });
   });
 
-  it("returns Vertex API failures from list requests", async () => {
+  it('returns Vertex API failures from list requests', async () => {
     nodeMswServer.use(
       http.get(`${vertexApiOrigin}/property-key-policies/policy-1/keys`, () =>
         HttpResponse.json(
-          { errors: [{ status: "500", title: "Vertex is upset." }] },
+          { errors: [{ status: '500', title: 'Vertex is upset.' }] },
           {
             status: 500,
-            headers: { "content-type": "application/vnd.api+json" },
+            headers: { 'content-type': 'application/vnd.api+json' },
           }
         )
       )
     );
 
-    const response = await callKeys("policy-1", { method: "GET" });
+    const response = await callKeys('policy-1', { method: 'GET' });
 
     expect(response.statusCode()).toBe(500);
     expect(response.body()).toEqual({
-      message: "Vertex is upset.",
+      message: 'Vertex is upset.',
       status: 500,
     });
   });
 
-  it("requires a policy ID", async () => {
-    const response = await invokeNextJsApiRouteHandler(
-      handlePropertyKeyPolicyKeys,
-      {
-        method: "GET",
-        query: {},
-        session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
-      }
-    );
+  it('requires a policy ID', async () => {
+    const response = await invokeNextJsApiRouteHandler(handlePropertyKeyPolicyKeys, {
+      method: 'GET',
+      query: {},
+      session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
+    });
 
     expect(response.statusCode()).toBe(400);
     expect(response.body()).toEqual({
-      message: "Property Key Policy ID required.",
+      message: 'Property Key Policy ID required.',
       status: 400,
     });
   });
 
-  it("fails safely when upstream returns the same cursor repeatedly", async () => {
+  it('fails safely when upstream returns the same cursor repeatedly', async () => {
     // A repeated cursor must not lead to an infinite pagination loop.
     let callCount = 0;
 
@@ -88,27 +85,27 @@ describe("property key policy keys API route", () => {
               },
             },
           },
-          { headers: { "content-type": "application/vnd.api+json" } }
+          { headers: { 'content-type': 'application/vnd.api+json' } }
         );
       })
     );
 
-    const response = await callKeys("policy-1", { method: "GET" });
+    const response = await callKeys('policy-1', { method: 'GET' });
 
     expect(response.statusCode()).toBe(500);
     expect(callCount).toBe(2);
     expect(response.body()).toEqual({
-      message: "Unknown error from Vertex API.",
+      message: 'Unknown error from Vertex API.',
       status: 500,
     });
   });
 
-  it("rejects unsupported methods", async () => {
-    const response = await callKeys("policy-1", { method: "PATCH" });
+  it('rejects unsupported methods', async () => {
+    const response = await callKeys('policy-1', { method: 'PATCH' });
 
     expect(response.statusCode()).toBe(405);
     expect(response.body()).toEqual({
-      message: "Method not allowed.",
+      message: 'Method not allowed.',
       status: 405,
     });
   });
@@ -122,28 +119,31 @@ function callKeys(id: string, req: ApiRouteRequest): Promise<ApiRouteResponse> {
   });
 }
 
-function keyData(id: string, name: string) {
+function keyData(
+  id: string,
+  name: string
+): { attributes: { name: string }; id: string; type: string } {
   return {
     attributes: { name },
     id,
-    type: "property-key",
+    type: 'property-key',
   };
 }
 
 function stubListKeys(
   policyId: string,
   pages: Record<string, ReturnType<typeof keyData>[]>
-) {
+): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/property-key-policies/${policyId}/keys`,
     ({ request }) => {
       const url = new URL(request.url);
-      const cursor = url.searchParams.get("page[cursor]") ?? "";
+      const cursor = url.searchParams.get('page[cursor]') ?? '';
       const data = pages[cursor];
       const cursors = Object.keys(pages);
       const currentPageIndex = cursors.indexOf(cursor);
 
-      expect(url.searchParams.get("page[size]")).toBe("200");
+      expect(url.searchParams.get('page[size]')).toBe('200');
       expect(data).toBeDefined();
       expect(currentPageIndex).toBeGreaterThanOrEqual(0);
 
@@ -161,7 +161,7 @@ function stubListKeys(
                   },
                 },
         },
-        { headers: { "content-type": "application/vnd.api+json" } }
+        { headers: { 'content-type': 'application/vnd.api+json' } }
       );
     }
   );

--- a/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
+++ b/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
@@ -83,23 +83,29 @@ export default function AddPropertyKeyPolicyEntryDialog({
 
     setSubmitting(true);
 
-    let res: Response;
-    let resBody: { message?: string };
-    try {
-      res = await fetch(
-        `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
-        {
-          body: JSON.stringify(body),
-          headers: { "Content-Type": "application/json" },
-          method: "POST",
-        }
-      );
-      resBody = await res.json();
-    } catch {
+    const res = await fetch(
+      `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
+      {
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      }
+    ).catch(() => undefined);
+    if (res == null) {
+      // True network error — no response was received, so nothing was processed
+      // server-side. Safe to retry.
       setSubmitting(false);
       setApiError("Could not add the property keys.");
       return;
     }
+
+    // Parse the body separately from the request. A successful response with an
+    // empty/unparseable body (e.g. 204 or a proxy page) must NOT be treated as a
+    // failure: the keys may already have been added server-side, and surfacing an
+    // error here would invite a duplicate add.
+    const resBody: { message?: string } | undefined = await res
+      .json()
+      .catch(() => undefined);
 
     setSubmitting(false);
 

--- a/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
+++ b/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
@@ -1,4 +1,4 @@
-import { Add, Delete } from "@mui/icons-material";
+import { Add, Delete } from '@mui/icons-material';
 import {
   Alert,
   Box,
@@ -11,11 +11,11 @@ import {
   Stack,
   TextField,
   Typography,
-} from "@mui/material";
-import React from "react";
+} from '@mui/material';
+import React from 'react';
 
-import { isErrorRes } from "../../lib/api";
-import { AddPropertyKeyPolicyKeysReq } from "../../lib/property-key-policies";
+import { isErrorRes } from '../../lib/api';
+import { AddPropertyKeyPolicyKeysReq } from '../../lib/property-key-policies';
 
 interface Props {
   readonly onAdded: () => void;
@@ -25,7 +25,7 @@ interface Props {
 }
 
 const CaseSensitivityHelperText =
-  "Metadata property keys are case-sensitive and are saved exactly as typed.";
+  'Metadata property keys are case-sensitive and are saved exactly as typed.';
 
 export default function AddPropertyKeyPolicyEntryDialog({
   onAdded,
@@ -33,49 +33,49 @@ export default function AddPropertyKeyPolicyEntryDialog({
   open,
   policyId,
 }: Props): JSX.Element {
-  const [keys, setKeys] = React.useState<string[]>([""]);
+  const [keys, setKeys] = React.useState<string[]>(['']);
   const [submitting, setSubmitting] = React.useState(false);
   const [validationError, setValidationError] = React.useState<string>();
   const [apiError, setApiError] = React.useState<string>();
 
-  function reset() {
-    setKeys([""]);
+  function reset(): void {
+    setKeys(['']);
     setSubmitting(false);
     setValidationError(undefined);
     setApiError(undefined);
   }
 
-  function handleClose() {
+  function handleClose(): void {
     if (submitting) return;
     reset();
     onClose();
   }
 
-  function handleKeyChange(index: number, value: string) {
+  function handleKeyChange(index: number, value: string): void {
     setKeys((current) => current.map((k, i) => (i === index ? value : k)));
   }
 
-  function handleAddKey() {
-    setKeys((current) => [...current, ""]);
+  function handleAddKey(): void {
+    setKeys((current) => [...current, '']);
   }
 
-  function handleRemoveKey(index: number) {
+  function handleRemoveKey(index: number): void {
     setKeys((current) =>
-      current.length === 1 ? [""] : current.filter((_, i) => i !== index)
+      current.length === 1 ? [''] : current.filter((_, i) => i !== index)
     );
   }
 
   // Keys are NOT trimmed here to preserve case exactly. We only skip entries
   // that are empty or whitespace-only when deciding what to submit.
-  const nonEmptyKeys = keys.filter((k) => k.trim() !== "");
+  const nonEmptyKeys = keys.filter((k) => k.trim() !== '');
   const submitDisabled = submitting || nonEmptyKeys.length === 0;
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     setValidationError(undefined);
     setApiError(undefined);
 
     if (nonEmptyKeys.length === 0) {
-      setValidationError("Add at least one property key.");
+      setValidationError('Add at least one property key.');
       return;
     }
 
@@ -87,15 +87,15 @@ export default function AddPropertyKeyPolicyEntryDialog({
       `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
       {
         body: JSON.stringify(body),
-        headers: { "Content-Type": "application/json" },
-        method: "POST",
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
       }
     ).catch(() => undefined);
     if (res == null) {
       // True network error — no response was received, so nothing was processed
       // server-side. Safe to retry.
       setSubmitting(false);
-      setApiError("Could not add the property keys.");
+      setApiError('Could not add the property keys.');
       return;
     }
 
@@ -112,7 +112,7 @@ export default function AddPropertyKeyPolicyEntryDialog({
     if (!res.ok || isErrorRes(resBody)) {
       setApiError(
         (isErrorRes(resBody) ? resBody.message : undefined) ??
-          "Could not add the property keys."
+          'Could not add the property keys.'
       );
       return;
     }
@@ -143,13 +143,10 @@ export default function AddPropertyKeyPolicyEntryDialog({
           </Typography>
           <Stack spacing={1} sx={{ mt: 1 }}>
             {keys.map((key, index) => (
-              <Box
-                key={index}
-                sx={{ alignItems: "center", display: "flex", gap: 1 }}
-              >
+              <Box key={index} sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
                 <TextField
                   fullWidth
-                  inputProps={{ "aria-label": `Property key ${index + 1}` }}
+                  inputProps={{ 'aria-label': `Property key ${index + 1}` }}
                   label={`Property key ${index + 1}`}
                   onChange={(e) => handleKeyChange(index, e.target.value)}
                   size="small"
@@ -175,7 +172,7 @@ export default function AddPropertyKeyPolicyEntryDialog({
         <Button
           color="primary"
           disabled={submitDisabled}
-          onClick={handleSubmit}
+          onClick={() => void handleSubmit()}
           variant="contained"
         >
           Add

--- a/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
+++ b/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
@@ -1,47 +1,41 @@
-import { Add, Delete } from '@mui/icons-material';
 import {
   Alert,
-  Box,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
-  IconButton,
-  Stack,
-  TextField,
-  Typography,
 } from '@mui/material';
 import React from 'react';
 
 import { isErrorRes } from '../../lib/api';
 import { AddPropertyKeyPolicyKeysReq } from '../../lib/property-key-policies';
+import { PropertyKeyFields, usePropertyKeyFields } from './PropertyKeyFields';
 
 interface Props {
   readonly onAdded: () => void;
   readonly onClose: () => void;
   readonly open: boolean;
   readonly policyId: string;
+  // Names already on the policy, so the field editor can flag duplicates
+  // (case-sensitive) before submitting.
+  readonly existingKeys?: readonly string[];
 }
-
-const CaseSensitivityHelperText =
-  'Metadata property keys are case-sensitive and are saved exactly as typed.';
 
 export default function AddPropertyKeyPolicyEntryDialog({
   onAdded,
   onClose,
   open,
   policyId,
+  existingKeys,
 }: Props): JSX.Element {
-  const [keys, setKeys] = React.useState<string[]>(['']);
+  const keyFields = usePropertyKeyFields({ existingKeys });
   const [submitting, setSubmitting] = React.useState(false);
-  const [validationError, setValidationError] = React.useState<string>();
   const [apiError, setApiError] = React.useState<string>();
 
   function reset(): void {
-    setKeys(['']);
+    keyFields.reset();
     setSubmitting(false);
-    setValidationError(undefined);
     setApiError(undefined);
   }
 
@@ -51,33 +45,11 @@ export default function AddPropertyKeyPolicyEntryDialog({
     onClose();
   }
 
-  function handleKeyChange(index: number, value: string): void {
-    setKeys((current) => current.map((k, i) => (i === index ? value : k)));
-  }
-
-  function handleAddKey(): void {
-    setKeys((current) => [...current, '']);
-  }
-
-  function handleRemoveKey(index: number): void {
-    setKeys((current) =>
-      current.length === 1 ? [''] : current.filter((_, i) => i !== index)
-    );
-  }
-
-  // Keys are NOT trimmed here to preserve case exactly. We only skip entries
-  // that are empty or whitespace-only when deciding what to submit.
-  const nonEmptyKeys = keys.filter((k) => k.trim() !== '');
-  const submitDisabled = submitting || nonEmptyKeys.length === 0;
+  const { nonEmptyKeys } = keyFields;
+  const submitDisabled = submitting || nonEmptyKeys.length === 0 || keyFields.hasErrors;
 
   async function handleSubmit(): Promise<void> {
-    setValidationError(undefined);
     setApiError(undefined);
-
-    if (nonEmptyKeys.length === 0) {
-      setValidationError('Add at least one property key.');
-      return;
-    }
 
     const body: AddPropertyKeyPolicyKeysReq = { keys: nonEmptyKeys };
 
@@ -131,41 +103,7 @@ export default function AddPropertyKeyPolicyEntryDialog({
             {apiError}
           </Alert>
         )}
-        {validationError != null && (
-          <Alert severity="error" sx={{ mb: 1, mt: 1 }}>
-            {validationError}
-          </Alert>
-        )}
-        <Box sx={{ mt: 1 }}>
-          <Typography variant="subtitle2">Property Keys</Typography>
-          <Typography color="text.secondary" variant="body2">
-            {CaseSensitivityHelperText}
-          </Typography>
-          <Stack spacing={1} sx={{ mt: 1 }}>
-            {keys.map((key, index) => (
-              <Box key={index} sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
-                <TextField
-                  fullWidth
-                  inputProps={{ 'aria-label': `Property key ${index + 1}` }}
-                  label={`Property key ${index + 1}`}
-                  onChange={(e) => handleKeyChange(index, e.target.value)}
-                  size="small"
-                  type="text"
-                  value={key}
-                />
-                <IconButton
-                  aria-label={`Remove property key ${index + 1}`}
-                  onClick={() => handleRemoveKey(index)}
-                >
-                  <Delete />
-                </IconButton>
-              </Box>
-            ))}
-          </Stack>
-          <Button onClick={handleAddKey} startIcon={<Add />} sx={{ mt: 1 }}>
-            Add Property Key
-          </Button>
-        </Box>
+        <PropertyKeyFields controller={keyFields} />
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>

--- a/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
+++ b/src/components/property-key-policy/AddPropertyKeyPolicyEntryDialog.tsx
@@ -1,0 +1,180 @@
+import { Add, Delete } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import React from "react";
+
+import { isErrorRes } from "../../lib/api";
+import { AddPropertyKeyPolicyKeysReq } from "../../lib/property-key-policies";
+
+interface Props {
+  readonly onAdded: () => void;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly policyId: string;
+}
+
+const CaseSensitivityHelperText =
+  "Metadata property keys are case-sensitive and are saved exactly as typed.";
+
+export default function AddPropertyKeyPolicyEntryDialog({
+  onAdded,
+  onClose,
+  open,
+  policyId,
+}: Props): JSX.Element {
+  const [keys, setKeys] = React.useState<string[]>([""]);
+  const [submitting, setSubmitting] = React.useState(false);
+  const [validationError, setValidationError] = React.useState<string>();
+  const [apiError, setApiError] = React.useState<string>();
+
+  function reset() {
+    setKeys([""]);
+    setSubmitting(false);
+    setValidationError(undefined);
+    setApiError(undefined);
+  }
+
+  function handleClose() {
+    if (submitting) return;
+    reset();
+    onClose();
+  }
+
+  function handleKeyChange(index: number, value: string) {
+    setKeys((current) => current.map((k, i) => (i === index ? value : k)));
+  }
+
+  function handleAddKey() {
+    setKeys((current) => [...current, ""]);
+  }
+
+  function handleRemoveKey(index: number) {
+    setKeys((current) =>
+      current.length === 1 ? [""] : current.filter((_, i) => i !== index)
+    );
+  }
+
+  // Keys are NOT trimmed here to preserve case exactly. We only skip entries
+  // that are empty or whitespace-only when deciding what to submit.
+  const nonEmptyKeys = keys.filter((k) => k.trim() !== "");
+  const submitDisabled = submitting || nonEmptyKeys.length === 0;
+
+  async function handleSubmit() {
+    setValidationError(undefined);
+    setApiError(undefined);
+
+    if (nonEmptyKeys.length === 0) {
+      setValidationError("Add at least one property key.");
+      return;
+    }
+
+    const body: AddPropertyKeyPolicyKeysReq = { keys: nonEmptyKeys };
+
+    setSubmitting(true);
+
+    let res: Response;
+    let resBody: { message?: string };
+    try {
+      res = await fetch(
+        `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
+        {
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+          method: "POST",
+        }
+      );
+      resBody = await res.json();
+    } catch {
+      setSubmitting(false);
+      setApiError("Could not add the property keys.");
+      return;
+    }
+
+    setSubmitting(false);
+
+    if (!res.ok || isErrorRes(resBody)) {
+      setApiError(
+        (isErrorRes(resBody) ? resBody.message : undefined) ??
+          "Could not add the property keys."
+      );
+      return;
+    }
+
+    onAdded();
+    reset();
+    onClose();
+  }
+
+  return (
+    <Dialog fullWidth onClose={handleClose} open={open}>
+      <DialogTitle>Add Property Key(s)</DialogTitle>
+      <DialogContent>
+        {apiError != null && (
+          <Alert severity="error" sx={{ mb: 1, mt: 1 }}>
+            {apiError}
+          </Alert>
+        )}
+        {validationError != null && (
+          <Alert severity="error" sx={{ mb: 1, mt: 1 }}>
+            {validationError}
+          </Alert>
+        )}
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="subtitle2">Property Keys</Typography>
+          <Typography color="text.secondary" variant="body2">
+            {CaseSensitivityHelperText}
+          </Typography>
+          <Stack spacing={1} sx={{ mt: 1 }}>
+            {keys.map((key, index) => (
+              <Box
+                key={index}
+                sx={{ alignItems: "center", display: "flex", gap: 1 }}
+              >
+                <TextField
+                  fullWidth
+                  inputProps={{ "aria-label": `Property key ${index + 1}` }}
+                  label={`Property key ${index + 1}`}
+                  onChange={(e) => handleKeyChange(index, e.target.value)}
+                  size="small"
+                  type="text"
+                  value={key}
+                />
+                <IconButton
+                  aria-label={`Remove property key ${index + 1}`}
+                  onClick={() => handleRemoveKey(index)}
+                >
+                  <Delete />
+                </IconButton>
+              </Box>
+            ))}
+          </Stack>
+          <Button onClick={handleAddKey} startIcon={<Add />} sx={{ mt: 1 }}>
+            Add Property Key
+          </Button>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button
+          color="primary"
+          disabled={submitDisabled}
+          onClick={handleSubmit}
+          variant="contained"
+        >
+          Add
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
+++ b/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
@@ -1,7 +1,5 @@
-import { Add, Delete } from '@mui/icons-material';
 import {
   Alert,
-  Box,
   Button,
   Dialog,
   DialogActions,
@@ -10,12 +8,9 @@ import {
   FormControl,
   FormControlLabel,
   FormLabel,
-  IconButton,
   Radio,
   RadioGroup,
-  Stack,
   TextField,
-  Typography,
 } from '@mui/material';
 import React from 'react';
 
@@ -25,16 +20,12 @@ import {
   CreatePropertyKeyPolicyRes,
   PropertyKeyPolicyMode,
 } from '../../lib/property-key-policies';
+import { PropertyKeyFields, usePropertyKeyFields } from './PropertyKeyFields';
 
 interface Props {
   readonly onClose: () => void;
   readonly onCreated: () => void;
   readonly open: boolean;
-}
-
-interface KeyField {
-  readonly id: number;
-  readonly value: string;
 }
 
 export default function CreatePropertyKeyPolicyDialog({
@@ -47,38 +38,17 @@ export default function CreatePropertyKeyPolicyDialog({
   const [mode, setMode] = React.useState<PropertyKeyPolicyMode>(
     PropertyKeyPolicyMode.Allowlist
   );
-  const [keys, setKeys] = React.useState<KeyField[]>([{ id: 0, value: '' }]);
+  const keyFields = usePropertyKeyFields();
   const [submitting, setSubmitting] = React.useState(false);
   const [apiError, setApiError] = React.useState<string>();
   const [entriesWarning, setEntriesWarning] = React.useState<string>();
   const [uncertainOutcome, setUncertainOutcome] = React.useState(false);
 
-  // Refs to the underlying key inputs so we can move keyboard focus to a
-  // newly added field. MUI forwards `inputRef` to the underlying <input>.
-  const keyInputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
-  const nextKeyId = React.useRef(1);
-  const [focusIndex, setFocusIndex] = React.useState<number | null>(null);
-
-  function newKeyField(): KeyField {
-    const id = nextKeyId.current;
-    nextKeyId.current += 1;
-    return { id, value: '' };
-  }
-
-  React.useEffect(() => {
-    if (focusIndex == null) return;
-    const el = keyInputRefs.current[focusIndex];
-    if (el != null) {
-      el.focus();
-      setFocusIndex(null);
-    }
-  }, [focusIndex, keys]);
-
   function reset(): void {
     setName('');
     setSuppliedId('');
     setMode(PropertyKeyPolicyMode.Allowlist);
-    setKeys([newKeyField()]);
+    keyFields.reset();
     setSubmitting(false);
     setApiError(undefined);
     setEntriesWarning(undefined);
@@ -97,70 +67,9 @@ export default function CreatePropertyKeyPolicyDialog({
     onClose();
   }
 
-  function handleKeyChange(index: number, value: string): void {
-    setKeys((current) =>
-      current.map((key, i) => (i === index ? { ...key, value } : key))
-    );
-  }
-
-  // Append a new empty key field and move keyboard focus to it. The new index
-  // is the current length, since we append to the end.
-  function addKeyAndFocus(): void {
-    setFocusIndex(keys.length);
-    setKeys((current) => [...current, newKeyField()]);
-  }
-
-  function handleAddKey(): void {
-    addKeyAndFocus();
-  }
-
-  function handleKeyDown(
-    e: React.KeyboardEvent<HTMLDivElement>,
-    index: number,
-    value: string
-  ): void {
-    if (e.key !== 'Enter') return;
-    e.preventDefault();
-
-    // Ignore Enter on whitespace-only fields; don't add a new field.
-    if (value.trim() === '') return;
-
-    // Case-sensitive exact match against the other key values. The field already
-    // surfaces the per-field "Duplicate property key." error, so just bail.
-    if (keys.some((key, i) => i !== index && key.value === value)) return;
-
-    addKeyAndFocus();
-  }
-
-  function handleRemoveKey(index: number): void {
-    setKeys((current) =>
-      current.length === 1 ? [newKeyField()] : current.filter((_, i) => i !== index)
-    );
-  }
-
-  // Compute a single field's validation error reactively (not just on submit).
-  // A completely empty row is neutral (ignored on submit); only whitespace-only
-  // or verbatim (case-sensitive) duplicate values are invalid.
-  function keyFieldError(index: number): string | undefined {
-    const value = keys[index].value;
-    if (value === '') return undefined; // empty rows are neutral/ignored
-    if (value.trim() === '') return 'Property key cannot be blank.'; // whitespace-only = invalid
-    // Case-sensitive exact duplicate of another field (verbatim, matching how
-    // keys are saved).
-    if (keys.some((key, i) => i !== index && key.value === value)) {
-      return 'Duplicate property key.';
-    }
-    return undefined;
-  }
-
-  const keyErrors = keys.map((_, i) => keyFieldError(i));
-  const hasKeyErrors = keyErrors.some((e) => e != null);
-
-  // Keys are NOT trimmed here to preserve case exactly. We only skip entries
-  // that are empty or whitespace-only when deciding what to submit.
-  const nonEmptyKeys = keys.map((key) => key.value).filter((key) => key.trim() !== '');
+  const { nonEmptyKeys } = keyFields;
   const submitDisabled =
-    submitting || name.trim() === '' || nonEmptyKeys.length === 0 || hasKeyErrors;
+    submitting || name.trim() === '' || nonEmptyKeys.length === 0 || keyFields.hasErrors;
 
   async function handleSubmit(): Promise<void> {
     setApiError(undefined);
@@ -287,50 +196,7 @@ export default function CreatePropertyKeyPolicyDialog({
             />
           </RadioGroup>
         </FormControl>
-        <Box sx={{ mt: 1 }}>
-          <Typography variant="subtitle2">Property Keys</Typography>
-          <Typography color="text.secondary" variant="body2">
-            Metadata property keys are{' '}
-            <Box component="span" fontWeight="fontWeightBold">
-              case-sensitive
-            </Box>{' '}
-            and are{' '}
-            <Box component="span" fontWeight="fontWeightBold">
-              saved exactly as typed
-            </Box>
-            .
-          </Typography>
-          <Stack spacing={1} sx={{ mt: 1 }}>
-            {keys.map((key, index) => (
-              <Box key={key.id} sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
-                <TextField
-                  error={keyErrors[index] != null}
-                  fullWidth
-                  helperText={keyErrors[index]}
-                  inputProps={{ 'aria-label': `Property key ${index + 1}` }}
-                  inputRef={(el) => {
-                    keyInputRefs.current[index] = el;
-                  }}
-                  label={`Property key ${index + 1}`}
-                  onChange={(e) => handleKeyChange(index, e.target.value)}
-                  onKeyDown={(e) => handleKeyDown(e, index, key.value)}
-                  size="small"
-                  type="text"
-                  value={key.value}
-                />
-                <IconButton
-                  aria-label={`Remove property key ${index + 1}`}
-                  onClick={() => handleRemoveKey(index)}
-                >
-                  <Delete />
-                </IconButton>
-              </Box>
-            ))}
-          </Stack>
-          <Button onClick={handleAddKey} startIcon={<Add />} sx={{ mt: 1 }}>
-            Add Property Key
-          </Button>
-        </Box>
+        <PropertyKeyFields controller={keyFields} />
       </DialogContent>
       <DialogActions>
         {policyCreated ? (

--- a/src/components/property-key-policy/PropertyKeyFields.tsx
+++ b/src/components/property-key-policy/PropertyKeyFields.tsx
@@ -1,0 +1,187 @@
+import { Add, Delete } from '@mui/icons-material';
+import { Box, Button, IconButton, Stack, TextField, Typography } from '@mui/material';
+import React from 'react';
+
+export interface KeyField {
+  readonly id: number;
+  readonly value: string;
+}
+
+export interface UsePropertyKeyFieldsOptions {
+  // Already-persisted key names to validate against (case-sensitive, verbatim).
+  // Used by the add-to-existing-policy flow; defaults to none for creation.
+  readonly existingKeys?: readonly string[];
+}
+
+export interface PropertyKeyFieldsController {
+  readonly fields: readonly KeyField[];
+  readonly fieldErrors: readonly (string | undefined)[];
+  readonly hasErrors: boolean;
+  // Non-empty values in field order, preserving case exactly (not trimmed).
+  readonly nonEmptyKeys: string[];
+  reset(): void;
+  setFieldValue(index: number, value: string): void;
+  addField(): void;
+  removeField(index: number): void;
+  handleFieldKeyDown(e: React.KeyboardEvent<HTMLDivElement>, index: number): void;
+  registerInput(index: number, el: HTMLInputElement | null): void;
+}
+
+// Owns the list of property-key input fields and all of their behavior: stable
+// ids for React keys + focus tracking, add/remove, Enter-to-add-and-focus, and
+// reactive per-field validation (blank, case-sensitive duplicate, and — when
+// `existingKeys` is supplied — "already on this policy"). Shared by the create
+// and add-entry dialogs so both behave identically.
+export function usePropertyKeyFields(
+  options: UsePropertyKeyFieldsOptions = {}
+): PropertyKeyFieldsController {
+  const { existingKeys } = options;
+
+  const nextKeyId = React.useRef(1);
+  const inputRefs = React.useRef<(HTMLInputElement | null)[]>([]);
+  const [focusIndex, setFocusIndex] = React.useState<number | null>(null);
+  const [fields, setFields] = React.useState<KeyField[]>([{ id: 0, value: '' }]);
+
+  function newField(): KeyField {
+    const id = nextKeyId.current;
+    nextKeyId.current += 1;
+    return { id, value: '' };
+  }
+
+  React.useEffect(() => {
+    if (focusIndex == null) return;
+    const el = inputRefs.current[focusIndex];
+    if (el != null) {
+      el.focus();
+      setFocusIndex(null);
+    }
+  }, [focusIndex, fields]);
+
+  // Reactive validation for a single field. An empty row is neutral (ignored on
+  // submit); only whitespace-only, a case-sensitive duplicate of another field,
+  // or a value that already exists on the policy is invalid.
+  function fieldError(value: string, index: number): string | undefined {
+    if (value === '') return undefined;
+    if (value.trim() === '') return 'Property key cannot be blank.';
+    if (fields.some((f, i) => i !== index && f.value === value)) {
+      return 'Duplicate property key.';
+    }
+    if (existingKeys?.includes(value)) {
+      return 'Property key already exists on this policy.';
+    }
+    return undefined;
+  }
+
+  function setFieldValue(index: number, value: string): void {
+    setFields((current) => current.map((f, i) => (i === index ? { ...f, value } : f)));
+  }
+
+  // Append a new empty field and move keyboard focus to it. The new index is the
+  // current length, since we append to the end.
+  function addField(): void {
+    setFocusIndex(fields.length);
+    setFields((current) => [...current, newField()]);
+  }
+
+  function removeField(index: number): void {
+    setFields((current) =>
+      current.length === 1 ? [newField()] : current.filter((_, i) => i !== index)
+    );
+  }
+
+  function handleFieldKeyDown(
+    e: React.KeyboardEvent<HTMLDivElement>,
+    index: number
+  ): void {
+    if (e.key !== 'Enter') return;
+    e.preventDefault();
+    // Don't add a new field when the current value is invalid (blank, duplicate,
+    // or already on the policy); the field already surfaces the error.
+    if (fieldError(fields[index].value, index) != null) return;
+    // Also ignore a completely empty field — nothing to commit.
+    if (fields[index].value.trim() === '') return;
+    addField();
+  }
+
+  function registerInput(index: number, el: HTMLInputElement | null): void {
+    inputRefs.current[index] = el;
+  }
+
+  function reset(): void {
+    setFields([newField()]);
+    setFocusIndex(null);
+  }
+
+  const fieldErrors = fields.map((f, i) => fieldError(f.value, i));
+  const hasErrors = fieldErrors.some((e) => e != null);
+  const nonEmptyKeys = fields.map((f) => f.value).filter((v) => v.trim() !== '');
+
+  return {
+    addField,
+    fieldErrors,
+    fields,
+    handleFieldKeyDown,
+    hasErrors,
+    nonEmptyKeys,
+    registerInput,
+    removeField,
+    reset,
+    setFieldValue,
+  };
+}
+
+// Presentational "Property Keys" editor driven by a controller from
+// `usePropertyKeyFields`. Renders the case-sensitivity helper, the list of
+// fields with per-field errors, and the "Add Property Key" button.
+export function PropertyKeyFields({
+  controller,
+}: {
+  readonly controller: PropertyKeyFieldsController;
+}): JSX.Element {
+  const { fields, fieldErrors } = controller;
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      <Typography variant="subtitle2">Property Keys</Typography>
+      <Typography color="text.secondary" variant="body2">
+        Metadata property keys are{' '}
+        <Box component="span" fontWeight="fontWeightBold">
+          case-sensitive
+        </Box>{' '}
+        and are{' '}
+        <Box component="span" fontWeight="fontWeightBold">
+          saved exactly as typed
+        </Box>
+        .
+      </Typography>
+      <Stack spacing={1} sx={{ mt: 1 }}>
+        {fields.map((field, index) => (
+          <Box key={field.id} sx={{ alignItems: 'center', display: 'flex', gap: 1 }}>
+            <TextField
+              error={fieldErrors[index] != null}
+              fullWidth
+              helperText={fieldErrors[index]}
+              inputProps={{ 'aria-label': `Property key ${index + 1}` }}
+              inputRef={(el) => controller.registerInput(index, el)}
+              label={`Property key ${index + 1}`}
+              onChange={(e) => controller.setFieldValue(index, e.target.value)}
+              onKeyDown={(e) => controller.handleFieldKeyDown(e, index)}
+              size="small"
+              type="text"
+              value={field.value}
+            />
+            <IconButton
+              aria-label={`Remove property key ${index + 1}`}
+              onClick={() => controller.removeField(index)}
+            >
+              <Delete />
+            </IconButton>
+          </Box>
+        ))}
+      </Stack>
+      <Button onClick={() => controller.addField()} startIcon={<Add />} sx={{ mt: 1 }}>
+        Add Property Key
+      </Button>
+    </Box>
+  );
+}

--- a/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
@@ -1,4 +1,4 @@
-import { Add, Delete } from "@mui/icons-material";
+import { Add, Delete } from '@mui/icons-material';
 import {
   Alert,
   Box,
@@ -11,15 +11,15 @@ import {
   Skeleton,
   Snackbar,
   Typography,
-} from "@mui/material";
-import React from "react";
+} from '@mui/material';
+import React from 'react';
 
-import { isErrorRes } from "../../lib/api";
+import { isErrorRes } from '../../lib/api';
 import {
   DeletePropertyKeyPolicyKeysReq,
   PropertyKeyPolicyKey,
-} from "../../lib/property-key-policies";
-import AddPropertyKeyPolicyEntryDialog from "./AddPropertyKeyPolicyEntryDialog";
+} from '../../lib/property-key-policies';
+import AddPropertyKeyPolicyEntryDialog from './AddPropertyKeyPolicyEntryDialog';
 
 interface Props {
   readonly keys?: readonly PropertyKeyPolicyKey[];
@@ -47,7 +47,7 @@ export function PropertyKeyPolicyKeysList({
 
   const resolvedEntries = keys ?? [];
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     setSelected((current) => {
       const upd = new Set(current);
       if (upd.has(id)) upd.delete(id);
@@ -56,7 +56,7 @@ export function PropertyKeyPolicyKeysList({
     });
   }
 
-  async function handleDelete(ids: string[]) {
+  async function handleDelete(ids: string[]): Promise<void> {
     if (!editable || deleting || ids.length === 0) return;
 
     setDeleteError(undefined);
@@ -68,13 +68,13 @@ export function PropertyKeyPolicyKeysList({
       `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
       {
         body: JSON.stringify(body),
-        headers: { "Content-Type": "application/json" },
-        method: "DELETE",
+        headers: { 'Content-Type': 'application/json' },
+        method: 'DELETE',
       }
     ).catch(() => undefined);
     if (res == null) {
       setDeleting(false);
-      setDeleteError("Could not delete the selected property keys.");
+      setDeleteError('Could not delete the selected property keys.');
       return;
     }
 
@@ -82,7 +82,7 @@ export function PropertyKeyPolicyKeysList({
       const errBody = await res.json().catch(() => undefined);
       const message = isErrorRes(errBody) ? errBody.message : undefined;
       setDeleting(false);
-      setDeleteError(message ?? "Could not delete the selected property keys.");
+      setDeleteError(message ?? 'Could not delete the selected property keys.');
       return;
     }
 
@@ -99,20 +99,20 @@ export function PropertyKeyPolicyKeysList({
     <>
       <Box
         sx={{
-          alignItems: "center",
-          display: "flex",
-          justifyContent: "space-between",
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'space-between',
           mt: 2,
         }}
       >
         <Typography variant="subtitle2">Property Keys</Typography>
         {editable && (
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={{ display: 'flex', gap: 1 }}>
             {selected.size > 0 && (
               <Button
                 color="error"
                 disabled={deleting}
-                onClick={() => handleDelete([...selected])}
+                onClick={() => void handleDelete([...selected])}
                 size="small"
                 startIcon={<Delete />}
               >
@@ -140,7 +140,7 @@ export function PropertyKeyPolicyKeysList({
         error,
         loading,
         onCheck: handleCheck,
-        onDeleteOne: (id) => handleDelete([id]),
+        onDeleteOne: (id) => void handleDelete([id]),
         selected,
       })}
       {editable && (
@@ -235,15 +235,15 @@ function renderBody({
               color="primary"
               disabled={deleting}
               edge="start"
-              inputProps={{ "aria-label": `Select ${entry.name}` }}
+              inputProps={{ 'aria-label': `Select ${entry.name}` }}
               onChange={() => onCheck(entry.id)}
             />
           )}
           <ListItemText
             primary={entry.name}
             primaryTypographyProps={{
-              sx: { overflowWrap: "anywhere", whiteSpace: "normal" },
-              variant: "body2",
+              sx: { overflowWrap: 'anywhere', whiteSpace: 'normal' },
+              variant: 'body2',
             }}
           />
         </ListItem>

--- a/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
@@ -146,6 +146,7 @@ export function PropertyKeyPolicyKeysList({
       {editable && (
         <>
           <AddPropertyKeyPolicyEntryDialog
+            existingKeys={resolvedEntries.map((entry) => entry.name)}
             onAdded={() => onMutate()}
             onClose={() => setAddOpen(false)}
             open={addOpen}

--- a/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
@@ -1,39 +1,196 @@
-import { List, ListItem, ListItemText, Skeleton, Typography } from '@mui/material';
+import { Add, Delete } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  Button,
+  Checkbox,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Skeleton,
+  Snackbar,
+  Typography,
+} from "@mui/material";
+import React from "react";
 
-import { PropertyKeyPolicyKey } from '../../lib/property-key-policies';
+import { isErrorRes } from "../../lib/api";
+import {
+  DeletePropertyKeyPolicyKeysReq,
+  PropertyKeyPolicyKey,
+} from "../../lib/property-key-policies";
+import AddPropertyKeyPolicyEntryDialog from "./AddPropertyKeyPolicyEntryDialog";
 
 interface Props {
   readonly keys?: readonly PropertyKeyPolicyKey[];
   readonly error?: boolean;
   readonly loading?: boolean;
+  // Editing is enabled only when BOTH `policyId` and `onMutate` are supplied.
+  // The drawer omits them so the list stays read-only there.
+  readonly onMutate?: () => void;
+  readonly policyId?: string;
 }
 
 export function PropertyKeyPolicyKeysList({
   keys,
   error = false,
   loading = false,
+  onMutate,
+  policyId,
 }: Props): JSX.Element {
+  const editable = policyId != null && onMutate != null;
+
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [deleting, setDeleting] = React.useState(false);
+  const [deleteError, setDeleteError] = React.useState<string>();
+  const [addOpen, setAddOpen] = React.useState(false);
+
+  const resolvedEntries = keys ?? [];
+
+  function handleCheck(id: string) {
+    setSelected((current) => {
+      const upd = new Set(current);
+      if (upd.has(id)) upd.delete(id);
+      else upd.add(id);
+      return upd;
+    });
+  }
+
+  async function handleDelete(ids: string[]) {
+    if (!editable || deleting || ids.length === 0) return;
+
+    setDeleteError(undefined);
+    setDeleting(true);
+
+    const body: DeletePropertyKeyPolicyKeysReq = { ids };
+
+    let res: Response;
+    try {
+      res = await fetch(
+        `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
+        {
+          body: JSON.stringify(body),
+          headers: { "Content-Type": "application/json" },
+          method: "DELETE",
+        }
+      );
+    } catch {
+      setDeleting(false);
+      setDeleteError("Could not delete the selected property keys.");
+      return;
+    }
+
+    if (!res.ok) {
+      let message: string | undefined;
+      try {
+        const errBody = await res.json();
+        message = isErrorRes(errBody) ? errBody.message : undefined;
+      } catch {
+        message = undefined;
+      }
+      setDeleting(false);
+      setDeleteError(message ?? "Could not delete the selected property keys.");
+      return;
+    }
+
+    setDeleting(false);
+    setSelected((cur) => {
+      const upd = new Set(cur);
+      ids.forEach((id) => upd.delete(id));
+      return upd;
+    });
+    onMutate();
+  }
+
   return (
     <>
-      <Typography sx={{ mt: 2 }} variant="subtitle2">
-        Property Keys
-      </Typography>
+      <Box
+        sx={{
+          alignItems: "center",
+          display: "flex",
+          justifyContent: "space-between",
+          mt: 2,
+        }}
+      >
+        <Typography variant="subtitle2">Property Keys</Typography>
+        {editable && (
+          <Box sx={{ display: "flex", gap: 1 }}>
+            {selected.size > 0 && (
+              <Button
+                color="error"
+                disabled={deleting}
+                onClick={() => handleDelete([...selected])}
+                size="small"
+                startIcon={<Delete />}
+              >
+                {`Delete (${selected.size})`}
+              </Button>
+            )}
+            <Button
+              onClick={() => setAddOpen(true)}
+              size="small"
+              startIcon={<Add />}
+              variant="contained"
+            >
+              Add property key(s)
+            </Button>
+          </Box>
+        )}
+      </Box>
       <Typography color="text.secondary" variant="caption">
         Metadata property keys are case-sensitive.
       </Typography>
-      {renderBody({ keys: keys ?? [], error, loading })}
+      {renderBody({
+        deleting,
+        editable,
+        entries: resolvedEntries,
+        error,
+        loading,
+        onCheck: handleCheck,
+        onDeleteOne: (id) => handleDelete([id]),
+        selected,
+      })}
+      {editable && (
+        <>
+          <AddPropertyKeyPolicyEntryDialog
+            onAdded={() => onMutate()}
+            onClose={() => setAddOpen(false)}
+            open={addOpen}
+            policyId={policyId}
+          />
+          <Snackbar
+            autoHideDuration={6000}
+            onClose={() => setDeleteError(undefined)}
+            open={deleteError != null}
+          >
+            <Alert onClose={() => setDeleteError(undefined)} severity="error">
+              {deleteError}
+            </Alert>
+          </Snackbar>
+        </>
+      )}
     </>
   );
 }
 
 function renderBody({
-  keys,
+  deleting,
+  editable,
+  entries,
   error,
   loading,
+  onCheck,
+  onDeleteOne,
+  selected,
 }: {
-  readonly keys: readonly PropertyKeyPolicyKey[];
+  readonly deleting: boolean;
+  readonly editable: boolean;
+  readonly entries: readonly PropertyKeyPolicyKey[];
   readonly error: boolean;
   readonly loading: boolean;
+  readonly onCheck: (id: string) => void;
+  readonly onDeleteOne: (id: string) => void;
+  readonly selected: Set<string>;
 }): JSX.Element {
   if (error) {
     return (
@@ -52,7 +209,7 @@ function renderBody({
     );
   }
 
-  if (keys.length === 0) {
+  if (entries.length === 0) {
     return (
       <Typography color="text.secondary" variant="body2">
         No property keys.
@@ -62,13 +219,38 @@ function renderBody({
 
   return (
     <List dense disablePadding>
-      {keys.map((key) => (
-        <ListItem disableGutters key={key.id}>
+      {entries.map((entry) => (
+        <ListItem
+          disableGutters
+          key={entry.id}
+          secondaryAction={
+            editable ? (
+              <IconButton
+                aria-label={`Delete ${entry.name}`}
+                disabled={deleting}
+                edge="end"
+                onClick={() => onDeleteOne(entry.id)}
+              >
+                <Delete />
+              </IconButton>
+            ) : undefined
+          }
+        >
+          {editable && (
+            <Checkbox
+              checked={selected.has(entry.id)}
+              color="primary"
+              disabled={deleting}
+              edge="start"
+              inputProps={{ "aria-label": `Select ${entry.name}` }}
+              onChange={() => onCheck(entry.id)}
+            />
+          )}
           <ListItemText
-            primary={key.name}
+            primary={entry.name}
             primaryTypographyProps={{
-              sx: { overflowWrap: 'anywhere', whiteSpace: 'normal' },
-              variant: 'body2',
+              sx: { overflowWrap: "anywhere", whiteSpace: "normal" },
+              variant: "body2",
             }}
           />
         </ListItem>

--- a/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyKeysList.tsx
@@ -64,30 +64,23 @@ export function PropertyKeyPolicyKeysList({
 
     const body: DeletePropertyKeyPolicyKeysReq = { ids };
 
-    let res: Response;
-    try {
-      res = await fetch(
-        `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
-        {
-          body: JSON.stringify(body),
-          headers: { "Content-Type": "application/json" },
-          method: "DELETE",
-        }
-      );
-    } catch {
+    const res = await fetch(
+      `/api/property-key-policies/${encodeURIComponent(policyId)}/keys`,
+      {
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+        method: "DELETE",
+      }
+    ).catch(() => undefined);
+    if (res == null) {
       setDeleting(false);
       setDeleteError("Could not delete the selected property keys.");
       return;
     }
 
     if (!res.ok) {
-      let message: string | undefined;
-      try {
-        const errBody = await res.json();
-        message = isErrorRes(errBody) ? errBody.message : undefined;
-      } catch {
-        message = undefined;
-      }
+      const errBody = await res.json().catch(() => undefined);
+      const message = isErrorRes(errBody) ? errBody.message : undefined;
       setDeleting(false);
       setDeleteError(message ?? "Could not delete the selected property keys.");
       return;

--- a/src/lib/property-key-policies.ts
+++ b/src/lib/property-key-policies.ts
@@ -47,6 +47,18 @@ export type GetPropertyKeyPolicyKeysRes = Res & {
   readonly data: PropertyKeyPolicyKeyResource[];
 };
 
+export interface AddPropertyKeyPolicyKeysReq {
+  readonly keys: string[];
+}
+
+export type AddPropertyKeyPolicyKeysRes = Res;
+
+export interface DeletePropertyKeyPolicyKeysReq {
+  readonly ids: string[];
+}
+
+export type DeletePropertyKeyPolicyKeysRes = Res;
+
 /**
  * Create request body shared by the POST API route and the create dialog.
  *

--- a/src/pages/api/property-key-policies/[id]/keys.ts
+++ b/src/pages/api/property-key-policies/[id]/keys.ts
@@ -1,15 +1,31 @@
-import { Failure, head, logError, VertexError } from '@vertexvis/api-client-node';
-import { AxiosError } from 'axios';
-import { NextApiResponse } from 'next';
-
-import { ErrorRes, MethodNotAllowed, ServerError, toErrorRes } from '../../../../lib/api';
-import { fetchAllPages } from '../../../../lib/paging';
 import {
+  Failure,
+  head,
+  logError,
+  VertexError,
+} from "@vertexvis/api-client-node";
+import { AxiosError } from "axios";
+import { NextApiResponse } from "next";
+
+import {
+  BodyRequired,
+  ErrorRes,
+  InvalidBody,
+  MethodNotAllowed,
+  ServerError,
+  toErrorRes,
+} from "../../../../lib/api";
+import { fetchAllPages } from "../../../../lib/paging";
+import {
+  AddPropertyKeyPolicyKeysReq,
+  AddPropertyKeyPolicyKeysRes,
+  DeletePropertyKeyPolicyKeysReq,
+  DeletePropertyKeyPolicyKeysRes,
   GetPropertyKeyPolicyKeysRes,
   PropertyKeyPolicyKeyResource,
-} from '../../../../lib/property-key-policies';
-import { getClientFromSession } from '../../../../lib/vertex-api';
-import withSession, { NextIronRequest } from '../../../../lib/with-session';
+} from "../../../../lib/property-key-policies";
+import { getClientFromSession } from "../../../../lib/vertex-api";
+import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
 const KeysPageSize = 200;
 
@@ -23,14 +39,124 @@ interface PropertyKeyPolicyKeyList {
 
 export async function handlePropertyKeyPolicyKeys(
   req: NextIronRequest,
-  res: NextApiResponse<GetPropertyKeyPolicyKeysRes | ErrorRes>
+  res: NextApiResponse<
+    | GetPropertyKeyPolicyKeysRes
+    | AddPropertyKeyPolicyKeysRes
+    | DeletePropertyKeyPolicyKeysRes
+    | ErrorRes
+  >
 ): Promise<void> {
-  if (req.method === 'GET') {
+  if (req.method === "GET") {
     const r = await get(req);
     return res.status(r.status).json(r);
   }
 
+  if (req.method === "POST") {
+    const r = await add(req);
+    return res.status(r.status).json(r);
+  }
+
+  if (req.method === "DELETE") {
+    const r = await del(req);
+    return res.status(r.status).json(r);
+  }
+
   return res.status(MethodNotAllowed.status).json(MethodNotAllowed);
+}
+
+async function add(
+  req: NextIronRequest
+): Promise<ErrorRes | AddPropertyKeyPolicyKeysRes> {
+  const id = head(req.query.id);
+  if (id == null)
+    return { message: "Property Key Policy ID required.", status: 400 };
+  if (!req.body) return BodyRequired;
+
+  const keys = parseKeys(req.body, "keys");
+  if (keys == null) return InvalidBody;
+
+  try {
+    const client = await getClientFromSession(req.session);
+    await client.axiosInstance.post(
+      `${client.config.basePath}/property-key-policies/${encodeURIComponent(
+        id
+      )}/keys`,
+      { data: keys.map((name) => ({ name })) },
+      {
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${client.token.access_token}`,
+          "Content-Type": "application/vnd.api+json",
+        },
+      }
+    );
+    return { status: 201 };
+  } catch (error) {
+    return errorRes(error);
+  }
+}
+
+async function del(
+  req: NextIronRequest
+): Promise<ErrorRes | DeletePropertyKeyPolicyKeysRes> {
+  const id = head(req.query.id);
+  if (id == null)
+    return { message: "Property Key Policy ID required.", status: 400 };
+  if (!req.body) return BodyRequired;
+
+  const ids = parseKeys(req.body, "ids");
+  if (ids == null) return InvalidBody;
+
+  try {
+    const client = await getClientFromSession(req.session);
+    await client.axiosInstance.delete(
+      `${client.config.basePath}/property-key-policies/${encodeURIComponent(
+        id
+      )}/keys`,
+      {
+        headers: {
+          Accept: "application/vnd.api+json",
+          Authorization: `Bearer ${client.token.access_token}`,
+        },
+        params: { "filter[id]": ids.join(",") },
+      }
+    );
+    return { status: 200 };
+  } catch (error) {
+    return errorRes(error);
+  }
+}
+
+function parseKeys(
+  body: unknown,
+  property: "ids" | "keys"
+): string[] | undefined {
+  try {
+    const parsed = (typeof body === "string" ? JSON.parse(body) : body) as
+      | Partial<AddPropertyKeyPolicyKeysReq>
+      | Partial<DeletePropertyKeyPolicyKeysReq>;
+    const values = (parsed as Record<string, unknown>)[property];
+    if (
+      !Array.isArray(values) ||
+      values.length === 0 ||
+      values.some((value) => typeof value !== "string" || value.trim() === "")
+    )
+      return undefined;
+    return values;
+  } catch {
+    return undefined;
+  }
+}
+
+function errorRes(error: unknown): ErrorRes {
+  const e = error as VertexError;
+  const ae = error as AxiosError<Failure>;
+  logError(e);
+  return e.vertexError?.res
+    ? toErrorRes({ failure: e.vertexError.res })
+    : ae.response?.data != null
+    ? toErrorRes({ failure: ae.response.data })
+    : ServerError;
 }
 
 export default withSession(handlePropertyKeyPolicyKeys);
@@ -40,7 +166,8 @@ async function get(
 ): Promise<ErrorRes | GetPropertyKeyPolicyKeysRes> {
   try {
     const id = head(req.query.id);
-    if (id == null) return { message: 'Property Key Policy ID required.', status: 400 };
+    if (id == null)
+      return { message: "Property Key Policy ID required.", status: 400 };
 
     const client = await getClientFromSession(req.session);
     const path = `${
@@ -52,12 +179,12 @@ async function get(
     >((pageCursor) =>
       client.axiosInstance.get<PropertyKeyPolicyKeyList>(path, {
         headers: {
-          Accept: 'application/vnd.api+json',
+          Accept: "application/vnd.api+json",
           Authorization: `Bearer ${client.token.access_token}`,
         },
         params: {
-          ...(pageCursor != null ? { 'page[cursor]': pageCursor } : {}),
-          'page[size]': KeysPageSize,
+          ...(pageCursor != null ? { "page[cursor]": pageCursor } : {}),
+          "page[size]": KeysPageSize,
         },
       })
     );
@@ -67,8 +194,10 @@ async function get(
     const e = error as VertexError;
     const ae = error as AxiosError<Failure>;
     logError(e);
-    if (e.vertexError?.res != null) return toErrorRes({ failure: e.vertexError.res });
-    if (ae.response?.data != null) return toErrorRes({ failure: ae.response.data });
-    return ServerError;
+    return e.vertexError?.res
+      ? toErrorRes({ failure: e.vertexError.res })
+      : ae.response?.data != null
+      ? toErrorRes({ failure: ae.response.data })
+      : ServerError;
   }
 }

--- a/src/pages/api/property-key-policies/[id]/keys.ts
+++ b/src/pages/api/property-key-policies/[id]/keys.ts
@@ -137,11 +137,9 @@ function errorRes(error: unknown): ErrorRes {
   const e = error as VertexError;
   const ae = error as AxiosError<Failure>;
   logError(e);
-  return e.vertexError?.res
-    ? toErrorRes({ failure: e.vertexError.res })
-    : ae.response?.data != null
-      ? toErrorRes({ failure: ae.response.data })
-      : ServerError;
+  if (e.vertexError?.res != null) return toErrorRes({ failure: e.vertexError.res });
+  if (ae.response?.data != null) return toErrorRes({ failure: ae.response.data });
+  return ServerError;
 }
 
 export default withSession(handlePropertyKeyPolicyKeys);
@@ -175,13 +173,6 @@ async function get(
 
     return { data, status: 200 };
   } catch (error) {
-    const e = error as VertexError;
-    const ae = error as AxiosError<Failure>;
-    logError(e);
-    return e.vertexError?.res
-      ? toErrorRes({ failure: e.vertexError.res })
-      : ae.response?.data != null
-        ? toErrorRes({ failure: ae.response.data })
-        : ServerError;
+    return errorRes(error);
   }
 }

--- a/src/pages/api/property-key-policies/[id]/keys.ts
+++ b/src/pages/api/property-key-policies/[id]/keys.ts
@@ -1,11 +1,6 @@
-import {
-  Failure,
-  head,
-  logError,
-  VertexError,
-} from "@vertexvis/api-client-node";
-import { AxiosError } from "axios";
-import { NextApiResponse } from "next";
+import { Failure, head, logError, VertexError } from '@vertexvis/api-client-node';
+import { AxiosError } from 'axios';
+import { NextApiResponse } from 'next';
 
 import {
   BodyRequired,
@@ -14,8 +9,8 @@ import {
   MethodNotAllowed,
   ServerError,
   toErrorRes,
-} from "../../../../lib/api";
-import { fetchAllPages } from "../../../../lib/paging";
+} from '../../../../lib/api';
+import { fetchAllPages } from '../../../../lib/paging';
 import {
   AddPropertyKeyPolicyKeysReq,
   AddPropertyKeyPolicyKeysRes,
@@ -23,9 +18,9 @@ import {
   DeletePropertyKeyPolicyKeysRes,
   GetPropertyKeyPolicyKeysRes,
   PropertyKeyPolicyKeyResource,
-} from "../../../../lib/property-key-policies";
-import { getClientFromSession } from "../../../../lib/vertex-api";
-import withSession, { NextIronRequest } from "../../../../lib/with-session";
+} from '../../../../lib/property-key-policies';
+import { getClientFromSession } from '../../../../lib/vertex-api';
+import withSession, { NextIronRequest } from '../../../../lib/with-session';
 
 const KeysPageSize = 200;
 
@@ -46,17 +41,17 @@ export async function handlePropertyKeyPolicyKeys(
     | ErrorRes
   >
 ): Promise<void> {
-  if (req.method === "GET") {
+  if (req.method === 'GET') {
     const r = await get(req);
     return res.status(r.status).json(r);
   }
 
-  if (req.method === "POST") {
+  if (req.method === 'POST') {
     const r = await add(req);
     return res.status(r.status).json(r);
   }
 
-  if (req.method === "DELETE") {
+  if (req.method === 'DELETE') {
     const r = await del(req);
     return res.status(r.status).json(r);
   }
@@ -68,25 +63,22 @@ async function add(
   req: NextIronRequest
 ): Promise<ErrorRes | AddPropertyKeyPolicyKeysRes> {
   const id = head(req.query.id);
-  if (id == null)
-    return { message: "Property Key Policy ID required.", status: 400 };
+  if (id == null) return { message: 'Property Key Policy ID required.', status: 400 };
   if (!req.body) return BodyRequired;
 
-  const keys = parseKeys(req.body, "keys");
+  const keys = parseKeys(req.body, 'keys');
   if (keys == null) return InvalidBody;
 
   try {
     const client = await getClientFromSession(req.session);
     await client.axiosInstance.post(
-      `${client.config.basePath}/property-key-policies/${encodeURIComponent(
-        id
-      )}/keys`,
+      `${client.config.basePath}/property-key-policies/${encodeURIComponent(id)}/keys`,
       { data: keys.map((name) => ({ name })) },
       {
         headers: {
-          Accept: "application/vnd.api+json",
+          Accept: 'application/vnd.api+json',
           Authorization: `Bearer ${client.token.access_token}`,
-          "Content-Type": "application/vnd.api+json",
+          'Content-Type': 'application/vnd.api+json',
         },
       }
     );
@@ -100,25 +92,22 @@ async function del(
   req: NextIronRequest
 ): Promise<ErrorRes | DeletePropertyKeyPolicyKeysRes> {
   const id = head(req.query.id);
-  if (id == null)
-    return { message: "Property Key Policy ID required.", status: 400 };
+  if (id == null) return { message: 'Property Key Policy ID required.', status: 400 };
   if (!req.body) return BodyRequired;
 
-  const ids = parseKeys(req.body, "ids");
+  const ids = parseKeys(req.body, 'ids');
   if (ids == null) return InvalidBody;
 
   try {
     const client = await getClientFromSession(req.session);
     await client.axiosInstance.delete(
-      `${client.config.basePath}/property-key-policies/${encodeURIComponent(
-        id
-      )}/keys`,
+      `${client.config.basePath}/property-key-policies/${encodeURIComponent(id)}/keys`,
       {
         headers: {
-          Accept: "application/vnd.api+json",
+          Accept: 'application/vnd.api+json',
           Authorization: `Bearer ${client.token.access_token}`,
         },
-        params: { "filter[id]": ids.join(",") },
+        params: { 'filter[id]': ids.join(',') },
       }
     );
     return { status: 200 };
@@ -127,19 +116,15 @@ async function del(
   }
 }
 
-function parseKeys(
-  body: unknown,
-  property: "ids" | "keys"
-): string[] | undefined {
+function parseKeys(body: unknown, property: 'ids' | 'keys'): string[] | undefined {
   try {
-    const parsed = (typeof body === "string" ? JSON.parse(body) : body) as
-      | Partial<AddPropertyKeyPolicyKeysReq>
-      | Partial<DeletePropertyKeyPolicyKeysReq>;
+    const parsed = (typeof body === 'string' ? JSON.parse(body) : body) as
+      Partial<AddPropertyKeyPolicyKeysReq> | Partial<DeletePropertyKeyPolicyKeysReq>;
     const values = (parsed as Record<string, unknown>)[property];
     if (
       !Array.isArray(values) ||
       values.length === 0 ||
-      values.some((value) => typeof value !== "string" || value.trim() === "")
+      values.some((value) => typeof value !== 'string' || value.trim() === '')
     )
       return undefined;
     return values;
@@ -155,8 +140,8 @@ function errorRes(error: unknown): ErrorRes {
   return e.vertexError?.res
     ? toErrorRes({ failure: e.vertexError.res })
     : ae.response?.data != null
-    ? toErrorRes({ failure: ae.response.data })
-    : ServerError;
+      ? toErrorRes({ failure: ae.response.data })
+      : ServerError;
 }
 
 export default withSession(handlePropertyKeyPolicyKeys);
@@ -166,8 +151,7 @@ async function get(
 ): Promise<ErrorRes | GetPropertyKeyPolicyKeysRes> {
   try {
     const id = head(req.query.id);
-    if (id == null)
-      return { message: "Property Key Policy ID required.", status: 400 };
+    if (id == null) return { message: 'Property Key Policy ID required.', status: 400 };
 
     const client = await getClientFromSession(req.session);
     const path = `${
@@ -179,12 +163,12 @@ async function get(
     >((pageCursor) =>
       client.axiosInstance.get<PropertyKeyPolicyKeyList>(path, {
         headers: {
-          Accept: "application/vnd.api+json",
+          Accept: 'application/vnd.api+json',
           Authorization: `Bearer ${client.token.access_token}`,
         },
         params: {
-          ...(pageCursor != null ? { "page[cursor]": pageCursor } : {}),
-          "page[size]": KeysPageSize,
+          ...(pageCursor != null ? { 'page[cursor]': pageCursor } : {}),
+          'page[size]': KeysPageSize,
         },
       })
     );
@@ -197,7 +181,7 @@ async function get(
     return e.vertexError?.res
       ? toErrorRes({ failure: e.vertexError.res })
       : ae.response?.data != null
-      ? toErrorRes({ failure: ae.response.data })
-      : ServerError;
+        ? toErrorRes({ failure: ae.response.data })
+        : ServerError;
   }
 }

--- a/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
+++ b/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
@@ -1,29 +1,29 @@
-import { Box, Breadcrumbs, Paper, Typography } from '@mui/material';
-import { head } from '@vertexvis/api-client-node';
-import { GetServerSidePropsResult } from 'next';
-import { withIronSession } from 'next-iron-session';
-import React from 'react';
-import useSWR from 'swr';
+import { Box, Breadcrumbs, Paper, Typography } from "@mui/material";
+import { head } from "@vertexvis/api-client-node";
+import { GetServerSidePropsResult } from "next";
+import { withIronSession } from "next-iron-session";
+import React from "react";
+import useSWR from "swr";
 
-import { PropertyKeyPolicyKeysList } from '../../components/property-key-policy/PropertyKeyPolicyKeysList';
-import { PropertyKeyPolicyMetadataTable } from '../../components/property-key-policy/PropertyKeyPolicyMetadataTable';
-import { AppLink } from '../../components/shared/AppLink';
-import { Layout } from '../../components/shared/Layout';
-import { isErrorFailure, isErrorRes, toErrorRes } from '../../lib/api';
+import { PropertyKeyPolicyKeysList } from "../../components/property-key-policy/PropertyKeyPolicyKeysList";
+import { PropertyKeyPolicyMetadataTable } from "../../components/property-key-policy/PropertyKeyPolicyMetadataTable";
+import { AppLink } from "../../components/shared/AppLink";
+import { Layout } from "../../components/shared/Layout";
+import { isErrorFailure, isErrorRes, toErrorRes } from "../../lib/api";
 import {
   getPropertyKeyPoliciesApi,
   GetPropertyKeyPolicyKeysRes,
   PropertyKeyPolicy,
   toPropertyKeyPolicy,
   toPropertyKeyPolicyKey,
-} from '../../lib/property-key-policies';
-import { getClientFromSession, makeCall } from '../../lib/vertex-api';
+} from "../../lib/property-key-policies";
+import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import {
   CommonProps,
   CookieAttributes,
   NextIronRequest,
   serverSidePropsHandler as commonServerSidePropsHandler,
-} from '../../lib/with-session';
+} from "../../lib/with-session";
 
 interface Props {
   readonly propertyKeyPolicy: PropertyKeyPolicy;
@@ -41,13 +41,19 @@ interface ServerSideContext {
 export default function PropertyKeyPolicyDetails({
   propertyKeyPolicy,
 }: Props): JSX.Element {
-  const { data, error } = useSWR<GetPropertyKeyPolicyKeysRes | undefined>(
-    `/api/property-key-policies/${encodeURIComponent(propertyKeyPolicy.id)}/keys`
+  const { data, error, mutate } = useSWR<
+    GetPropertyKeyPolicyKeysRes | undefined
+  >(
+    `/api/property-key-policies/${encodeURIComponent(
+      propertyKeyPolicy.id
+    )}/keys`
   );
 
   const keysFailed = error != null || isErrorRes(data);
   const keys =
-    data != null && !isErrorRes(data) ? data.data.map(toPropertyKeyPolicyKey) : undefined;
+    data != null && !isErrorRes(data)
+      ? data.data.map(toPropertyKeyPolicyKey)
+      : undefined;
   const keysLoading = keys == null && !keysFailed;
 
   return (
@@ -66,19 +72,23 @@ export default function PropertyKeyPolicyDetails({
             <Typography variant="h5">Property Key Policy</Typography>
             <Typography
               color="text.secondary"
-              sx={{ overflowWrap: 'anywhere', whiteSpace: 'normal' }}
+              sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
               variant="body2"
             >
               {propertyKeyPolicy.id}
             </Typography>
             <Box sx={{ mt: 2 }}>
-              <PropertyKeyPolicyMetadataTable propertyKeyPolicy={propertyKeyPolicy} />
+              <PropertyKeyPolicyMetadataTable
+                propertyKeyPolicy={propertyKeyPolicy}
+              />
             </Box>
             <Box sx={{ mt: 1 }}>
               <PropertyKeyPolicyKeysList
                 keys={keys}
                 error={keysFailed}
                 loading={keysLoading}
+                onMutate={() => mutate()}
+                policyId={propertyKeyPolicy.id}
               />
             </Box>
           </Paper>
@@ -98,13 +108,17 @@ export async function serverSidePropsHandler({
   req,
 }: ServerSideContext): Promise<GetServerSidePropsResult<ServerSideProps>> {
   const authResult = commonServerSidePropsHandler({ req });
-  if (!('props' in authResult)) return authResult;
+  if (!("props" in authResult)) return authResult;
 
   const propertyKeyPolicyId = head(query.propertyKeyPolicyId);
   if (propertyKeyPolicyId == null) return { notFound: true };
 
-  const api = getPropertyKeyPoliciesApi(await getClientFromSession(req.session));
-  const res = await makeCall(() => api.getPropertyKeyPolicy({ id: propertyKeyPolicyId }));
+  const api = getPropertyKeyPoliciesApi(
+    await getClientFromSession(req.session)
+  );
+  const res = await makeCall(() =>
+    api.getPropertyKeyPolicy({ id: propertyKeyPolicyId })
+  );
 
   if (isErrorFailure(res)) {
     const error = toErrorRes({ failure: res });

--- a/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
+++ b/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
@@ -1,29 +1,29 @@
-import { Box, Breadcrumbs, Paper, Typography } from "@mui/material";
-import { head } from "@vertexvis/api-client-node";
-import { GetServerSidePropsResult } from "next";
-import { withIronSession } from "next-iron-session";
-import React from "react";
-import useSWR from "swr";
+import { Box, Breadcrumbs, Paper, Typography } from '@mui/material';
+import { head } from '@vertexvis/api-client-node';
+import { GetServerSidePropsResult } from 'next';
+import { withIronSession } from 'next-iron-session';
+import React from 'react';
+import useSWR from 'swr';
 
-import { PropertyKeyPolicyKeysList } from "../../components/property-key-policy/PropertyKeyPolicyKeysList";
-import { PropertyKeyPolicyMetadataTable } from "../../components/property-key-policy/PropertyKeyPolicyMetadataTable";
-import { AppLink } from "../../components/shared/AppLink";
-import { Layout } from "../../components/shared/Layout";
-import { isErrorFailure, isErrorRes, toErrorRes } from "../../lib/api";
+import { PropertyKeyPolicyKeysList } from '../../components/property-key-policy/PropertyKeyPolicyKeysList';
+import { PropertyKeyPolicyMetadataTable } from '../../components/property-key-policy/PropertyKeyPolicyMetadataTable';
+import { AppLink } from '../../components/shared/AppLink';
+import { Layout } from '../../components/shared/Layout';
+import { isErrorFailure, isErrorRes, toErrorRes } from '../../lib/api';
 import {
   getPropertyKeyPoliciesApi,
   GetPropertyKeyPolicyKeysRes,
   PropertyKeyPolicy,
   toPropertyKeyPolicy,
   toPropertyKeyPolicyKey,
-} from "../../lib/property-key-policies";
-import { getClientFromSession, makeCall } from "../../lib/vertex-api";
+} from '../../lib/property-key-policies';
+import { getClientFromSession, makeCall } from '../../lib/vertex-api';
 import {
   CommonProps,
   CookieAttributes,
   NextIronRequest,
   serverSidePropsHandler as commonServerSidePropsHandler,
-} from "../../lib/with-session";
+} from '../../lib/with-session';
 
 interface Props {
   readonly propertyKeyPolicy: PropertyKeyPolicy;
@@ -41,19 +41,13 @@ interface ServerSideContext {
 export default function PropertyKeyPolicyDetails({
   propertyKeyPolicy,
 }: Props): JSX.Element {
-  const { data, error, mutate } = useSWR<
-    GetPropertyKeyPolicyKeysRes | undefined
-  >(
-    `/api/property-key-policies/${encodeURIComponent(
-      propertyKeyPolicy.id
-    )}/keys`
+  const { data, error, mutate } = useSWR<GetPropertyKeyPolicyKeysRes | undefined>(
+    `/api/property-key-policies/${encodeURIComponent(propertyKeyPolicy.id)}/keys`
   );
 
   const keysFailed = error != null || isErrorRes(data);
   const keys =
-    data != null && !isErrorRes(data)
-      ? data.data.map(toPropertyKeyPolicyKey)
-      : undefined;
+    data != null && !isErrorRes(data) ? data.data.map(toPropertyKeyPolicyKey) : undefined;
   const keysLoading = keys == null && !keysFailed;
 
   return (
@@ -72,22 +66,20 @@ export default function PropertyKeyPolicyDetails({
             <Typography variant="h5">Property Key Policy</Typography>
             <Typography
               color="text.secondary"
-              sx={{ overflowWrap: "anywhere", whiteSpace: "normal" }}
+              sx={{ overflowWrap: 'anywhere', whiteSpace: 'normal' }}
               variant="body2"
             >
               {propertyKeyPolicy.id}
             </Typography>
             <Box sx={{ mt: 2 }}>
-              <PropertyKeyPolicyMetadataTable
-                propertyKeyPolicy={propertyKeyPolicy}
-              />
+              <PropertyKeyPolicyMetadataTable propertyKeyPolicy={propertyKeyPolicy} />
             </Box>
             <Box sx={{ mt: 1 }}>
               <PropertyKeyPolicyKeysList
                 keys={keys}
                 error={keysFailed}
                 loading={keysLoading}
-                onMutate={mutate}
+                onMutate={() => void mutate()}
                 policyId={propertyKeyPolicy.id}
               />
             </Box>
@@ -108,17 +100,13 @@ export async function serverSidePropsHandler({
   req,
 }: ServerSideContext): Promise<GetServerSidePropsResult<ServerSideProps>> {
   const authResult = commonServerSidePropsHandler({ req });
-  if (!("props" in authResult)) return authResult;
+  if (!('props' in authResult)) return authResult;
 
   const propertyKeyPolicyId = head(query.propertyKeyPolicyId);
   if (propertyKeyPolicyId == null) return { notFound: true };
 
-  const api = getPropertyKeyPoliciesApi(
-    await getClientFromSession(req.session)
-  );
-  const res = await makeCall(() =>
-    api.getPropertyKeyPolicy({ id: propertyKeyPolicyId })
-  );
+  const api = getPropertyKeyPoliciesApi(await getClientFromSession(req.session));
+  const res = await makeCall(() => api.getPropertyKeyPolicy({ id: propertyKeyPolicyId }));
 
   if (isErrorFailure(res)) {
     const error = toErrorRes({ failure: res });

--- a/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
+++ b/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
@@ -87,7 +87,7 @@ export default function PropertyKeyPolicyDetails({
                 keys={keys}
                 error={keysFailed}
                 loading={keysLoading}
-                onMutate={() => mutate()}
+                onMutate={mutate}
                 policyId={propertyKeyPolicy.id}
               />
             </Box>


### PR DESCRIPTION
## Summary
Adds workflows to **add** and **delete individual metadata property key entries** on an *existing* property key policy, from the policy detail page — building directly on the create/delete-policy work in PLAT-8994 (#353).

- **Add entries:** an "Add property key(s)" dialog to add one or more **case-sensitive** metadata keys to an existing policy. Keys are submitted **verbatim** (no case normalization); the dialog states that key matching is case-sensitive. Backed by the platform upsert-entries API.
- **Delete entries:** a per-entry delete (trash) action **and** checkbox multi-select **bulk delete**, backed by the platform delete-entries API (entries removed by entry id). Per product direction, **no confirmation dialog**; delete failures surface the API error via a snackbar.
- **Field-level validation** in the add dialog (mirrors the validation added to PLAT-8994's create dialog): per-field blank and case-sensitive **duplicate** errors, plus an "already exists on this policy" error (case-sensitive, against current entries), Enter-to-add-and-focus keyboard UX, and the bold case-sensitivity helper text. Add stays disabled while any field is invalid.
- Entries revalidate (SWR `mutate`) after a successful add/delete, so the detail page always reflects current entries.
- The row-click **drawer stays read-only** — editing lives only on the detail page (`/property-key-policies/[id]`).

### Implementation
- **API** (`src/pages/api/property-key-policies/[id]/entries.ts`): added `POST` (`{ keys: string[] }` → `upsertPropertyKeyPolicyEntries`) and `DELETE` (`{ ids: string[] }` → `deletePropertyKeyPolicyEntries` via comma-joined `filter[id]`) to the previously GET-only route, mirroring the sibling route's error/sentinel conventions. Existing GET behavior unchanged.
- **Lib types** (`src/lib/property-key-policies.ts`): `AddPropertyKeyPolicyEntriesReq` / `DeletePropertyKeyPolicyEntriesReq` (+ `Res` aliases), with case-sensitivity documented.
- **UI**: new `AddPropertyKeyPolicyEntryDialog` (mirrors `CreatePropertyKeyPolicyDialog`, incl. its new per-field validation); `PropertyKeyPolicyEntriesList` gains per-entry delete, multi-select bulk delete, add button, snackbar errors, and threads existing entry names into the add dialog for duplicate detection (editing gated by `policyId`+`onMutate`, so the drawer remains read-only); detail page wires SWR `mutate` + `policyId` into the list.

## Test Plan
Full quality gate green: `format:check` · `lint` · `typecheck` · `test` · `build`. **160 tests / 25 suites pass.**
- **API route tests** (MSW, node env): POST upserts keys **verbatim** (asserts case preserved in the upstream body); POST validation (missing/empty/all-blank keys, missing policy id); POST upstream `VertexError` surfaced. DELETE sends entry ids as comma-joined `filter[id]` (asserted); DELETE validation; DELETE upstream error surfaced; unsupported methods still 405; GET unchanged.
- **Component tests** (RTL + MSW): add dialog submits multiple keys verbatim, filters blanks, calls `onAdded`, shows inline error on failure, shows the case-sensitivity helper, and enforces per-field validation (blank, same-case duplicate, already-exists-on-policy, case-sensitivity negatives, Enter-to-add); entries list shows delete/checkbox/add controls only in editable mode (read-only mode — the drawer — renders none), single + bulk delete hit the endpoint with the right ids and trigger `mutate`, a failed delete surfaces the snackbar, a per-row delete preserves other checked entries, and existing entry names are threaded to the add dialog.

## Release Notes
Developers can now add and remove individual metadata property key entries on an existing property key policy directly from the Vertex Developer Dashboard, without recreating the policy. Keys remain case-sensitive.

## Possible Regressions
- Entry add/delete share the existing `/api/property-key-policies/[id]/entries` route (previously GET-only). The added POST/DELETE handlers leave GET behavior untouched (covered by tests).
- **Product decision:** ticket AC5 calls for a delete confirmation, but — consistent with PLAT-8994 removing the policy-delete confirmation — entry deletion is performed **without a confirmation dialog**. The error-surfacing half of AC5 is retained (snackbar on failure). Reviewers: flag if confirmation should be restored.

## Dependencies
- **Depends on PLAT-8994 / #353** (not yet merged). This PR is **based on / rebased onto** branch `PLAT-8994_create_delete_property_key_policies` (including its latest per-field-validation commits) and should be **retargeted to `main`** once #353 merges.

## Related
- Jira: https://vertexvis.atlassian.net/browse/PLAT-9067
- Depends on: https://github.com/Vertexvis/vertex-dev-dashboard/pull/353 (PLAT-8994)