### PR TITLE
[PLAT-9083] Policy API and stream-key plumbing

### DIFF
--- a/src/__tests__/pages/api/stream-keys.test.ts
+++ b/src/__tests__/pages/api/stream-keys.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ */
+import { http, HttpResponse } from 'msw';
+
+import {
+  type ApiRouteRequest,
+  type ApiRouteResponse,
+  createAuthenticatedVertexApiTestSession,
+  invokeNextJsApiRouteHandler,
+} from '../../../../test/api/nextJsApiRouteTest';
+import { nodeMswServer } from '../../../../test/msw/server';
+import { handleStreamKeys } from '../../../pages/api/stream-keys';
+
+const vertexApiOrigin = 'https://vertex-api.test';
+const sceneId = 'scene-abc';
+
+describe('stream-keys API route', () => {
+  it('forwards propertyKeyPolicyId to the upstream request when provided', async () => {
+    let capturedBody: unknown;
+    nodeMswServer.use(
+      http.post(
+        `${vertexApiOrigin}/scenes/${sceneId}/stream-keys`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(streamKeyResponse('key-with-policy'));
+        }
+      )
+    );
+
+    const response = await callStreamKeys({
+      body: JSON.stringify({ id: sceneId, propertyKeyPolicyId: 'policy-1' }),
+      method: 'POST',
+    });
+
+    expect(response.statusCode()).toBe(200);
+    expect(response.body()).toEqual({ key: 'key-with-policy', status: 200 });
+    expect(capturedBody).toEqual({
+      data: {
+        type: 'stream-key',
+        attributes: {
+          expiry: 86400,
+          propertyKeyPolicyId: 'policy-1',
+        },
+      },
+    });
+  });
+
+  it('omits propertyKeyPolicyId from the upstream request when not provided', async () => {
+    let capturedBody: unknown;
+    nodeMswServer.use(
+      http.post(
+        `${vertexApiOrigin}/scenes/${sceneId}/stream-keys`,
+        async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json(streamKeyResponse('key-without-policy'));
+        }
+      )
+    );
+
+    const response = await callStreamKeys({
+      body: JSON.stringify({ id: sceneId }),
+      method: 'POST',
+    });
+
+    expect(response.statusCode()).toBe(200);
+    expect(response.body()).toEqual({ key: 'key-without-policy', status: 200 });
+    expect(capturedBody).toEqual({
+      data: {
+        type: 'stream-key',
+        attributes: {
+          expiry: 86400,
+        },
+      },
+    });
+    expect(
+      (capturedBody as { data: { attributes: Record<string, unknown> } }).data.attributes
+    ).not.toHaveProperty('propertyKeyPolicyId');
+  });
+});
+
+function callStreamKeys(req: ApiRouteRequest): Promise<ApiRouteResponse> {
+  return invokeNextJsApiRouteHandler(handleStreamKeys, {
+    ...req,
+    session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
+  });
+}
+
+function streamKeyResponse(key: string): {
+  data: { attributes: { key: string }; id: string; type: string };
+} {
+  return {
+    data: {
+      attributes: { key },
+      id: 'stream-key-id',
+      type: 'stream-key',
+    },
+  };
+}

--- a/src/pages/api/stream-keys.ts
+++ b/src/pages/api/stream-keys.ts
@@ -12,9 +12,12 @@ export interface CreateStreamKeyRes extends Res {
   readonly key: string;
 }
 
-type CreateStreamKeyReq = Pick<StreamKeysApiCreateSceneStreamKeyRequest, 'id'>;
+type CreateStreamKeyReq = Pick<StreamKeysApiCreateSceneStreamKeyRequest, 'id'> & {
+  readonly propertyKeyPolicyId?: string;
+};
 
-export default withSession(methodRouter({ POST: create }));
+export const handleStreamKeys = methodRouter({ POST: create });
+export default withSession(handleStreamKeys);
 
 async function create(req: NextIronRequest): Promise<ErrorRes | CreateStreamKeyRes> {
   if (!req.body) return BodyRequired;
@@ -27,7 +30,15 @@ async function create(req: NextIronRequest): Promise<ErrorRes | CreateStreamKeyR
     c.streamKeys.createSceneStreamKey({
       id: b.id,
       createStreamKeyRequest: {
-        data: { type: 'stream-key', attributes: { expiry: 86400 } },
+        data: {
+          type: 'stream-key',
+          attributes: {
+            expiry: 86400,
+            ...(b.propertyKeyPolicyId != null
+              ? { propertyKeyPolicyId: b.propertyKeyPolicyId }
+              : {}),
+          },
+        },
       },
     })
   );


### PR DESCRIPTION
## What changed

Isolates the stream-key API plumbing from PLAT-8995 for focused review.

- Accepts and forwards an optional `propertyKeyPolicyId` when creating a scene stream key.
- Omits the property entirely when no policy is supplied, preserving unrestricted requests.
- Adds focused API-route coverage for both cases.

This PR contains no policy-selection UI, viewer switching, metadata comparison, table-toolbar, or delete-button changes.

## Stack

This is the first PR in the stack and targets `main`.

## Validation

- `yarn format`
- `yarn lint`
- `yarn typecheck`
- Focused stream-key API tests passed.
- Full test suite: **29 suites / 164 tests passed**
