### PR TITLE
[PLAT-9084] Keep left navigation active on detail routes

### DIFF
--- a/src/__tests__/components/shared/LeftDrawer.test.tsx
+++ b/src/__tests__/components/shared/LeftDrawer.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { LeftDrawer } from "../../../components/shared/LeftDrawer";
+
+let mockRoute = "/";
+const mockPush = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: mockPush, route: mockRoute }),
+}));
+
+describe("LeftDrawer", () => {
+  afterEach(() => {
+    cleanup();
+    mockRoute = "/";
+  });
+
+  function selectedButton(name: string): HTMLElement {
+    return screen.getByRole("button", { name });
+  }
+
+  it("highlights File Collections on the detail route", () => {
+    mockRoute = "/file-collections/[fileCollectionId]";
+    render(<LeftDrawer />);
+
+    expect(selectedButton("File Collections")).toHaveClass("Mui-selected");
+  });
+
+  it("highlights Scenes on the scene detail route", () => {
+    mockRoute = "/scene-viewer/[sceneId]";
+    render(<LeftDrawer />);
+
+    expect(selectedButton("Scenes")).toHaveClass("Mui-selected");
+  });
+
+  it("highlights Scenes on the root route", () => {
+    mockRoute = "/";
+    render(<LeftDrawer />);
+
+    expect(selectedButton("Scenes")).toHaveClass("Mui-selected");
+    expect(selectedButton("Files")).not.toHaveClass("Mui-selected");
+  });
+});

--- a/src/__tests__/components/shared/LeftDrawer.test.tsx
+++ b/src/__tests__/components/shared/LeftDrawer.test.tsx
@@ -13,6 +13,7 @@ jest.mock("next/router", () => ({
 describe("LeftDrawer", () => {
   afterEach(() => {
     cleanup();
+    mockPush.mockClear();
     mockRoute = "/";
   });
 

--- a/src/components/shared/LeftDrawer.tsx
+++ b/src/components/shared/LeftDrawer.tsx
@@ -24,6 +24,12 @@ export type Content = "settings" | "instructions" | "parts";
 export function LeftDrawer(): JSX.Element {
   const router = useRouter();
 
+  const isSectionActive = React.useCallback(
+    (base: string) =>
+      router.route === base || router.route.startsWith(`${base}/`),
+    [router.route]
+  );
+
   return (
     <Drawer
       anchor="left"
@@ -42,7 +48,7 @@ export function LeftDrawer(): JSX.Element {
       >
         <ListItemButton
           onClick={() => router.push("/")}
-          selected={router.route === "/"}
+          selected={router.route === "/" || isSectionActive("/scene-viewer")}
         >
           <ListItemIcon>
             <LocalLibraryOutlined />
@@ -51,7 +57,7 @@ export function LeftDrawer(): JSX.Element {
         </ListItemButton>
         <ListItemButton
           onClick={() => router.push("/files")}
-          selected={router.route === "/files"}
+          selected={isSectionActive("/files")}
         >
           <ListItemIcon>
             <DescriptionOutlined />
@@ -60,7 +66,7 @@ export function LeftDrawer(): JSX.Element {
         </ListItemButton>
         <ListItemButton
           onClick={() => router.push("/file-collections")}
-          selected={router.route === "/file-collections"}
+          selected={isSectionActive("/file-collections")}
         >
           <ListItemIcon>
             <CollectionsBookmarkOutlined />
@@ -69,7 +75,7 @@ export function LeftDrawer(): JSX.Element {
         </ListItemButton>
         <ListItemButton
           onClick={() => router.push("/parts")}
-          selected={router.route === "/parts"}
+          selected={isSectionActive("/parts")}
         >
           <ListItemIcon>
             <DatasetOutlined />
@@ -78,7 +84,7 @@ export function LeftDrawer(): JSX.Element {
         </ListItemButton>
         <ListItemButton
           onClick={() => router.push("/translations")}
-          selected={router.route === "/translations"}
+          selected={isSectionActive("/translations")}
         >
           <ListItemIcon>
             <PendingOutlined />


### PR DESCRIPTION
## What changed

- Treat each existing left-navigation route as active for both its list route and nested detail routes.
- Keep Scenes active on `/scene-viewer/*` routes.
- Add focused tests for File Collections and Scenes list/detail route selection.

## Why

The drawer previously used exact route equality. Navigating from a section list to a dynamic detail route therefore removed the selected state even though the user was still inside the same section.

## Impact

Users retain clear section context while viewing resource details. This PR intentionally excludes the Property Key Policies navigation item introduced by PLAT-8994; that feature-specific item remains in its own PR.

## Validation

The full pre-commit quality suite passed:

- staged formatting
- Next.js lint
- TypeScript typecheck
- Jest: 16 suites, 87 tests