### PR TITLE
[PLAT-9104] - Enforce explicit function return types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,12 +92,6 @@ const config = [
       'testing-library/no-unnecessary-act': 'error',
     },
   },
-  // TEMP(PLAT-9101 stack): re-enabled in layer 2
-  {
-    rules: {
-      '@typescript-eslint/explicit-function-return-type': 'off',
-    },
-  },
 ];
 
 export default config;

--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -305,7 +305,17 @@ function fileResource({
   readonly status: string;
   readonly suppliedId: string;
   readonly uploaded?: string;
-}) {
+}): {
+  readonly type: string;
+  readonly id: string;
+  readonly attributes: {
+    readonly created: string;
+    readonly name: string;
+    readonly status: string;
+    readonly suppliedId: string;
+    readonly uploaded: string;
+  };
+} {
   return {
     type: "file",
     id,

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -152,7 +152,7 @@ function getSceneRow(name = "Scene One"): HTMLTableRowElement {
 function renderTable(
   scene?: Scene,
   props: Partial<React.ComponentProps<typeof SceneTable>> = {}
-) {
+): ReturnType<typeof renderWithSWR> {
   return renderWithSWR(renderTableElement(scene, props));
 }
 

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -393,7 +393,11 @@ function fileCollectionData(
   id: string,
   created = "2026-06-10T15:30:00Z",
   name = "Collection One"
-) {
+): {
+  attributes: { created: string; name: string; suppliedId: string };
+  id: string;
+  type: string;
+} {
   return {
     attributes: {
       created,
@@ -405,7 +409,20 @@ function fileCollectionData(
   };
 }
 
-function fileData(id: string, status: string) {
+function fileData(
+  id: string,
+  status: string
+): {
+  attributes: {
+    created: string;
+    name: string;
+    status: string;
+    suppliedId: string;
+    uploaded: string;
+  };
+  id: string;
+  type: string;
+} {
   return {
     attributes: {
       created: "2026-06-12T15:30:00Z",
@@ -419,13 +436,19 @@ function fileData(id: string, status: string) {
   };
 }
 
-function failureBody(status: string, title: string) {
+function failureBody(
+  status: string,
+  title: string
+): { errors: Array<{ status: string; title: string }> } {
   return {
     errors: [{ status, title }],
   };
 }
 
-function fileCollectionsList(data: ReturnType<typeof fileCollectionData>[]) {
+function fileCollectionsList(data: ReturnType<typeof fileCollectionData>[]): {
+  data: ReturnType<typeof fileCollectionData>[];
+  links: { next: { href: string }; self: { href: string } };
+} {
   return {
     data,
     links: {
@@ -448,7 +471,7 @@ function stubListFileCollections(
     };
   },
   assertRequest?: (request: URL) => void
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-collections`, ({ request }) => {
     const url = new URL(request.url);
     assertRequest?.(url);
@@ -467,7 +490,7 @@ function stubDeleteCollection(
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
   deletedIds?: string[]
-) {
+): ReturnType<typeof http.delete> {
   return http.delete(`${vertexApiOrigin}/file-collections/${id}`, () => {
     deletedIds?.push(id);
 
@@ -493,7 +516,7 @@ function stubGetFileCollection(
         links: Record<string, never>;
       },
   status = 200
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-collections/${id}`, () => {
     return HttpResponse.json(body, {
       status,
@@ -508,7 +531,7 @@ function stubListFileCollectionFiles(
   id: string,
   body: { data: ReturnType<typeof fileData>[]; links: Record<string, never> },
   assertRequest?: (request: URL) => void
-) {
+): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/file-collections/${id}/files`,
     ({ request }) => {

--- a/src/__tests__/pages/api/file-download.test.ts
+++ b/src/__tests__/pages/api/file-download.test.ts
@@ -52,7 +52,11 @@ describe("file download route", () => {
   });
 });
 
-function createResponse() {
+function createResponse(): {
+  json: jest.Mock;
+  redirect: jest.Mock;
+  status: jest.Mock;
+} {
   const res = {
     json: jest.fn(),
     redirect: jest.fn(),

--- a/src/__tests__/pages/api/file-jobs.test.ts
+++ b/src/__tests__/pages/api/file-jobs.test.ts
@@ -179,7 +179,7 @@ function callApi(
 function stubListFileCollectionFiles(
   id: string,
   pages: Record<string, ReturnType<typeof fileData>[]>
-) {
+): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/file-collections/${id}/files`,
     ({ request }) => {
@@ -210,7 +210,10 @@ function stubListFileCollectionFiles(
   );
 }
 
-function stubCreateFile(fileCollectionId: string, name: string) {
+function stubCreateFile(
+  fileCollectionId: string,
+  name: string
+): ReturnType<typeof http.post> {
   return http.post(`${vertexApiOrigin}/files`, async ({ request }) => {
     expect(await request.json()).toEqual({
       data: {
@@ -227,7 +230,7 @@ function stubCreateFile(fileCollectionId: string, name: string) {
   });
 }
 
-function stubCreateFileJob(fileIds: string[]) {
+function stubCreateFileJob(fileIds: string[]): ReturnType<typeof http.post> {
   return http.post(`${vertexApiOrigin}/file-jobs`, async ({ request }) => {
     expect(await request.json()).toEqual({
       data: {
@@ -255,7 +258,7 @@ function stubCreateFileJob(fileIds: string[]) {
 function stubGetFileJob(
   id: string,
   body: { data: ReturnType<typeof queuedJobData> }
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-jobs/${id}`, () => {
     return HttpResponse.json(body);
   });
@@ -264,7 +267,11 @@ function stubGetFileJob(
 function queuedJobData(
   id: string,
   dataOverrides: Record<string, unknown> = {}
-) {
+): {
+  attributes: { created: string; status: string };
+  id: string;
+  type: string;
+} & Record<string, unknown> {
   return {
     attributes: {
       created: "2026-06-29T15:30:00Z",
@@ -276,7 +283,20 @@ function queuedJobData(
   };
 }
 
-function fileData(id: string, status: string) {
+function fileData(
+  id: string,
+  status: string
+): {
+  attributes: {
+    created: string;
+    name: string;
+    status: string;
+    suppliedId: string;
+    uploaded: string;
+  };
+  id: string;
+  type: string;
+} {
   return {
     attributes: {
       created: "2026-06-12T15:30:00Z",

--- a/src/__tests__/pages/api/files.test.ts
+++ b/src/__tests__/pages/api/files.test.ts
@@ -67,7 +67,7 @@ function stubListFiles(
     };
   },
   assertRequest: (request: URL) => void
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/files`, ({ request }) => {
     assertRequest(new URL(request.url));
 
@@ -79,7 +79,17 @@ function stubListFiles(
   });
 }
 
-function fileData(id: string) {
+function fileData(id: string): {
+  attributes: {
+    created: string;
+    name: string;
+    status: string;
+    suppliedId: string;
+    uploaded: string;
+  };
+  id: string;
+  type: string;
+} {
   return {
     attributes: {
       created: "2026-06-10T15:30:00Z",

--- a/src/__tests__/pages/api/property-key-policies.test.ts
+++ b/src/__tests__/pages/api/property-key-policies.test.ts
@@ -479,7 +479,16 @@ function policyData(
   id: string,
   createdAt = "2026-06-10T15:30:00Z",
   name = "Policy One"
-) {
+): {
+  attributes: {
+    createdAt: string;
+    mode: string;
+    name: string;
+    suppliedId: string;
+  };
+  id: string;
+  type: string;
+} {
   return {
     attributes: {
       createdAt,
@@ -492,7 +501,10 @@ function policyData(
   };
 }
 
-function policyList(data: ReturnType<typeof policyData>[]) {
+function policyList(data: ReturnType<typeof policyData>[]): {
+  data: ReturnType<typeof policyData>[];
+  links: { next: { href: string }; self: { href: string } };
+} {
   return {
     data,
     links: {
@@ -506,7 +518,10 @@ function policyList(data: ReturnType<typeof policyData>[]) {
   };
 }
 
-function failureBody(status: string, title: string) {
+function failureBody(
+  status: string,
+  title: string
+): { errors: Array<{ status: string; title: string }> } {
   return { errors: [{ status, title }] };
 }
 
@@ -516,7 +531,7 @@ function stubListPolicies(
     links: { next?: { href: string }; self?: { href: string } };
   },
   assertRequest?: (request: URL) => void
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/property-key-policies`, ({ request }) => {
     assertRequest?.(new URL(request.url));
 
@@ -535,7 +550,7 @@ function stubGetPolicy(
         links: Record<string, never>;
       },
   status = 200
-) {
+): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/property-key-policies/${id}`, () => {
     return HttpResponse.json(body, {
       status,
@@ -550,7 +565,7 @@ function stubCreatePolicy(
   failure:
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined
-) {
+): ReturnType<typeof http.post> {
   return http.post(
     `${vertexApiOrigin}/property-key-policies`,
     async ({ request }) => {
@@ -577,7 +592,7 @@ function stubUpsertKeys(
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
   assertRequest?: (request: Request) => Promise<void> | void
-) {
+): ReturnType<typeof http.post> {
   return http.post(
     `${vertexApiOrigin}/property-key-policies/${id}/keys`,
     async ({ request }) => {
@@ -601,7 +616,7 @@ function stubDeletePolicy(
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
   deletedIds?: string[]
-) {
+): ReturnType<typeof http.delete> {
   return http.delete(`${vertexApiOrigin}/property-key-policies/${id}`, () => {
     deletedIds?.push(id);
 

--- a/src/__tests__/pages/api/property-key-policy-keys.test.ts
+++ b/src/__tests__/pages/api/property-key-policy-keys.test.ts
@@ -122,7 +122,10 @@ function callKeys(id: string, req: ApiRouteRequest): Promise<ApiRouteResponse> {
   });
 }
 
-function keyData(id: string, name: string) {
+function keyData(
+  id: string,
+  name: string
+): { attributes: { name: string }; id: string; type: string } {
   return {
     attributes: { name },
     id,
@@ -133,7 +136,7 @@ function keyData(id: string, name: string) {
 function stubListKeys(
   policyId: string,
   pages: Record<string, ReturnType<typeof keyData>[]>
-) {
+): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/property-key-policies/${policyId}/keys`,
     ({ request }) => {

--- a/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
+++ b/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
@@ -650,7 +650,14 @@ function createSession({
   } as unknown as Session;
 }
 
-function fileCollection() {
+function fileCollection(): {
+  id: string;
+  name: string;
+  suppliedId: string;
+  created: string;
+  expiresAt: string;
+  metadata: { source: string };
+} {
   return {
     id: "collection-1",
     name: "Collection One",

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -12,7 +12,7 @@ import {
   TableRow,
 } from "@mui/material";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
@@ -56,7 +56,7 @@ function useCollectionFiles({
   apiPath,
   cursor,
   pageSize,
-}: UseCollectionFilesProps) {
+}: UseCollectionFilesProps): SWRResponse {
   return useSWR(
     buildQuery(apiPath, {
       cursor,
@@ -122,11 +122,11 @@ export default function FileCollectionFilesTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     handlePageChange(num);
   }
 
-  async function handleDownload(id: string) {
+  async function handleDownload(id: string): Promise<void> {
     setDownloadError(undefined);
 
     const res = await fetch(

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -14,7 +14,7 @@ import {
 } from "@mui/material";
 import debounce from "lodash.debounce";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { toLocaleString } from "../../lib/dates";
 import {
@@ -58,7 +58,7 @@ function useFileCollections({
   pageSize,
   sort,
   suppliedId,
-}: UseFileCollectionsProps) {
+}: UseFileCollectionsProps): SWRResponse {
   return useSWR(
     buildQuery("/api/file-collections", {
       createdAtEnd,
@@ -138,12 +138,12 @@ export default function FileCollectionTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
-  function handleCreatedAtChange(filters: CreatedAtDateRange) {
+  function handleCreatedAtChange(filters: CreatedAtDateRange): void {
     resetPaging();
     setCreatedAtFilters(filters);
   }
 
-  function handleSortChange(field: string) {
+  function handleSortChange(field: string): void {
     if (field !== "created" && field !== "name") return;
 
     setSort((current) =>
@@ -152,7 +152,7 @@ export default function FileCollectionTable({
     resetPaging();
   }
 
-  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (page == null) return;
 
     const upd = new Set<string>();
@@ -160,7 +160,7 @@ export default function FileCollectionTable({
     setSelected(upd);
   }
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     const upd = new Set(selected);
     if (selected.has(id)) upd.delete(id);
     else upd.add(id);
@@ -171,11 +171,11 @@ export default function FileCollectionTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     handlePageChange(num);
   }
 
-  async function handleDelete() {
+  async function handleDelete(): Promise<void> {
     setDeleteError(undefined);
     const ids = [...selected];
     setSelected(new Set());

--- a/src/components/file/CreateFileDialog.tsx
+++ b/src/components/file/CreateFileDialog.tsx
@@ -38,7 +38,7 @@ export default function CreateFileDialog({
   const [progress, setProgress] = React.useState<boolean>(false);
   const router = useRouter();
 
-  async function handleUpload() {
+  async function handleUpload(): Promise<void> {
     if (file == null) return;
 
     setSubmitDisabled(true);

--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -150,7 +150,7 @@ function useFileCollections({
         : [...page.items, ...(await loadPage(body.cursors.next))];
     };
 
-    const load = async () => {
+    const load = async (): Promise<void> => {
       setFileCollections([]);
       setLoading(true);
       setError(undefined);
@@ -290,7 +290,7 @@ function FileCollectionIdsRow({
   readonly fileCollections: FileCollection[];
   readonly loading: boolean;
 }): JSX.Element {
-  async function copyId(id: string) {
+  async function copyId(id: string): Promise<void> {
     await navigator.clipboard.writeText(id);
   }
 

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mui/material";
 import debounce from "lodash.debounce";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
@@ -72,7 +72,7 @@ function useFiles({
   pageSize,
   sort,
   suppliedId,
-}: UseFilesProps) {
+}: UseFilesProps): SWRResponse {
   return useSWR(
     buildQuery("/api/files", {
       createdAtEnd,
@@ -198,7 +198,7 @@ export default function FileTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
-  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (visiblePage == null) return;
 
     const upd = new Set<string>();
@@ -206,7 +206,7 @@ export default function FileTable({
     setSelected(upd);
   }
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     const upd = new Set(selected);
     if (selected.has(id)) upd.delete(id);
     else upd.add(id);
@@ -217,21 +217,21 @@ export default function FileTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     handlePageChange(num);
   }
 
-  function handleSortChange(field: string) {
+  function handleSortChange(field: string): void {
     setSort((current) => toggleSort(current, field));
     resetPaging();
   }
 
-  function handleCreatedAtChange(filters: CreatedAtDateRange) {
+  function handleCreatedAtChange(filters: CreatedAtDateRange): void {
     resetPaging();
     setCreatedAtFilters(filters);
   }
 
-  async function handleDelete() {
+  async function handleDelete(): Promise<void> {
     setSelected(new Set());
     await fetch("/api/files", {
       body: JSON.stringify({ ids: [...selected] }),
@@ -240,7 +240,7 @@ export default function FileTable({
     mutate();
   }
 
-  async function handleDownload(id: string) {
+  async function handleDownload(id: string): Promise<void> {
     setDownloadError(undefined);
 
     const res = await fetch(

--- a/src/components/part/CreatePartDialog.tsx
+++ b/src/components/part/CreatePartDialog.tsx
@@ -14,7 +14,7 @@ import {
   Typography,
 } from "@mui/material";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { toFilePage } from "../../lib/files";
 import { CreatePartReq, CreatePartRes } from "../../pages/api/parts";
@@ -27,7 +27,7 @@ interface CreatePartDialogProps {
   readonly targetFileName?: string;
 }
 
-function useFiles() {
+function useFiles(): SWRResponse {
   return useSWR(`/api/files?pageSize=25`);
 }
 
@@ -55,7 +55,7 @@ export default function CreatePartDialog({
     setSubmitDisabled(!file || !suppliedId || !suppliedRevisionId);
   }, [file, suppliedId, suppliedRevisionId]);
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     if (!file || !suppliedId || !suppliedRevisionId) {
       return;
     }

--- a/src/components/part/PartRow.tsx
+++ b/src/components/part/PartRow.tsx
@@ -44,7 +44,7 @@ export default function PartRow({
   >();
 
   React.useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       const result = await fetch(`/api/part-revisions?partId=${part.id}`);
       setRevisions(toPartRevisionPage(await result.json()));
     };

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -16,7 +16,7 @@ import {
 import debounce from "lodash.debounce";
 import { useRouter } from "next/router";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
@@ -39,7 +39,7 @@ const headCells: readonly HeadCell[] = [
   { id: "created", label: "Created" },
 ];
 
-function useParts({ cursor, pageSize, suppliedId }: SwrProps) {
+function useParts({ cursor, pageSize, suppliedId }: SwrProps): SWRResponse {
   return useSWR(
     buildQuery("/api/parts", {
       cursor,
@@ -107,7 +107,7 @@ export default function PartTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
-  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (page == null) return;
 
     const upd = new Set<string>();
@@ -115,7 +115,7 @@ export default function PartTable({
     setSelected(upd);
   }
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     const upd = new Set(selected);
     if (selected.has(id)) upd.delete(id);
     else upd.add(id);
@@ -126,11 +126,11 @@ export default function PartTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     handlePageChange(num);
   }
 
-  async function handleDelete() {
+  async function handleDelete(): Promise<void> {
     setSelected(new Set());
     await fetch("/api/parts", {
       body: JSON.stringify({ ids: [...selected] }),

--- a/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
+++ b/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
@@ -74,7 +74,7 @@ export default function CreatePropertyKeyPolicyDialog({
     }
   }, [focusIndex, keys]);
 
-  function reset() {
+  function reset(): void {
     setName("");
     setSuppliedId("");
     setMode(PropertyKeyPolicyMode.Allowlist);
@@ -91,13 +91,13 @@ export default function CreatePropertyKeyPolicyDialog({
   // to dismiss.
   const policyCreated = entriesWarning != null || uncertainOutcome;
 
-  function handleClose() {
+  function handleClose(): void {
     if (submitting) return;
     reset();
     onClose();
   }
 
-  function handleKeyChange(index: number, value: string) {
+  function handleKeyChange(index: number, value: string): void {
     setKeys((current) =>
       current.map((key, i) => (i === index ? { ...key, value } : key))
     );
@@ -105,12 +105,12 @@ export default function CreatePropertyKeyPolicyDialog({
 
   // Append a new empty key field and move keyboard focus to it. The new index
   // is the current length, since we append to the end.
-  function addKeyAndFocus() {
+  function addKeyAndFocus(): void {
     setFocusIndex(keys.length);
     setKeys((current) => [...current, newKeyField()]);
   }
 
-  function handleAddKey() {
+  function handleAddKey(): void {
     addKeyAndFocus();
   }
 
@@ -118,7 +118,7 @@ export default function CreatePropertyKeyPolicyDialog({
     e: React.KeyboardEvent<HTMLDivElement>,
     index: number,
     value: string
-  ) {
+  ): void {
     if (e.key !== "Enter") return;
     e.preventDefault();
 
@@ -132,7 +132,7 @@ export default function CreatePropertyKeyPolicyDialog({
     addKeyAndFocus();
   }
 
-  function handleRemoveKey(index: number) {
+  function handleRemoveKey(index: number): void {
     setKeys((current) =>
       current.length === 1
         ? [newKeyField()]
@@ -169,7 +169,7 @@ export default function CreatePropertyKeyPolicyDialog({
     nonEmptyKeys.length === 0 ||
     hasKeyErrors;
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     setApiError(undefined);
     setEntriesWarning(undefined);
     setUncertainOutcome(false);

--- a/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
@@ -16,7 +16,7 @@ import {
 } from "@mui/material";
 import debounce from "lodash.debounce";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { isErrorRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
@@ -51,7 +51,7 @@ function usePropertyKeyPolicies({
   cursor,
   pageSize,
   suppliedId,
-}: UsePropertyKeyPoliciesProps) {
+}: UsePropertyKeyPoliciesProps): SWRResponse {
   return useSWR(
     buildQuery("/api/property-key-policies", {
       cursor,
@@ -119,7 +119,7 @@ export default function PropertyKeyPolicyTable({
     setCursors(page.cursors ?? undefined);
   }, [page, setCursors]);
 
-  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (page == null) return;
 
     const upd = new Set<string>();
@@ -127,7 +127,7 @@ export default function PropertyKeyPolicyTable({
     setSelected(upd);
   }
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     const upd = new Set(selected);
     if (selected.has(id)) upd.delete(id);
     else upd.add(id);
@@ -138,12 +138,12 @@ export default function PropertyKeyPolicyTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     handlePageChange(num);
     setSelected(new Set());
   }
 
-  async function handleDelete() {
+  async function handleDelete(): Promise<void> {
     if (deleting) return;
 
     setDeleteError(undefined);
@@ -188,7 +188,7 @@ export default function PropertyKeyPolicyTable({
     onPoliciesDeleted?.(ids);
   }
 
-  function handleCreated() {
+  function handleCreated(): void {
     resetPaging();
     mutate();
   }

--- a/src/components/scene/SceneDrawer.tsx
+++ b/src/components/scene/SceneDrawer.tsx
@@ -57,7 +57,7 @@ export function SceneDrawer({
   );
 
   React.useEffect(() => {
-    const fetchData = async () => {
+    const fetchData = async (): Promise<void> => {
       const result = await fetch(`/api/scenes/${scene?.id}`);
       setSceneDetails(await result.json());
     };
@@ -75,7 +75,7 @@ export function SceneDrawer({
     }
   }, [scene, sceneDetails]);
 
-  async function onSubmit(data: FormData) {
+  async function onSubmit(data: FormData): Promise<void> {
     const metadata = typeSafeMetadata(editableMetadata);
 
     // Omit camera data when saving this form, since it's not
@@ -109,7 +109,7 @@ export function SceneDrawer({
     return metadata;
   }
 
-  function copyCamera() {
+  function copyCamera(): void {
     navigator.clipboard.writeText(JSON.stringify(scene?.camera));
   }
 
@@ -458,7 +458,7 @@ export function SceneDrawer({
   );
 }
 
-const getMetadataTable = (metadata: Record<string, string>) => {
+const getMetadataTable = (metadata: Record<string, string>): JSX.Element => {
   return (
     <Table size="small">
       <TableBody>

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -19,7 +19,7 @@ import { Cursors, SceneData } from "@vertexvis/api-client-node";
 import debounce from "lodash.debounce";
 import { useRouter } from "next/router";
 import React, { useEffect } from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { ErrorRes, GetRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
@@ -51,7 +51,12 @@ const headCells: readonly HeadCell[] = [
   { id: "actions", label: "Actions" },
 ];
 
-function useScenes({ cursor, pageSize, suppliedId, name }: SwrProps) {
+function useScenes({
+  cursor,
+  pageSize,
+  suppliedId,
+  name,
+}: SwrProps): SWRResponse<GetRes<SceneData>, ErrorRes> {
   return useSWR<GetRes<SceneData>, ErrorRes>(
     `/api/scenes?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ""}${
       suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
@@ -141,7 +146,7 @@ export default function SceneTable({
     if (scene != null) setActiveSceneId(scene.id);
   }, [scene]);
 
-  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleSelectAll(e: React.ChangeEvent<HTMLInputElement>): void {
     if (page == null) return;
 
     const upd = new Set<string>();
@@ -149,7 +154,7 @@ export default function SceneTable({
     setSelected(upd);
   }
 
-  function handleCheck(id: string) {
+  function handleCheck(id: string): void {
     const upd = new Set(selected);
     if (selected.has(id)) upd.delete(id);
     else upd.add(id);
@@ -157,7 +162,7 @@ export default function SceneTable({
     setSelected(upd);
   }
 
-  function handleClick(s: Scene) {
+  function handleClick(s: Scene): void {
     setActiveSceneId(s.id);
     onClick(s);
   }
@@ -165,7 +170,7 @@ export default function SceneTable({
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
     num: number
-  ) {
+  ): void {
     if (curPage < num) {
       setPrev({ ...prev, [num - 1]: cursors?.self });
       setCursor(cursors?.next);
@@ -174,7 +179,7 @@ export default function SceneTable({
     setCurPage(num);
   }
 
-  async function handleDelete() {
+  async function handleDelete(): Promise<void> {
     setSelected(new Set());
     await fetch("/api/scenes", {
       body: JSON.stringify({ ids: [...selected] }),
@@ -183,16 +188,16 @@ export default function SceneTable({
     mutate();
   }
 
-  function handleEditClick(s: Scene) {
+  function handleEditClick(s: Scene): void {
     setActiveSceneId(s.id);
     onEditClick(s);
   }
 
-  function handleViewClick(sceneId: string) {
+  function handleViewClick(sceneId: string): void {
     router.push(`/scene-viewer/${encodeURIComponent(sceneId)}`);
   }
 
-  async function handleGetStreamKey(sceneId: string) {
+  async function handleGetStreamKey(sceneId: string): Promise<void> {
     setKeyLoadingSceneId(sceneId);
     const b = await fetch("/api/stream-keys", {
       body: JSON.stringify({ id: sceneId }),

--- a/src/components/shared/CreateSceneDialog.tsx
+++ b/src/components/shared/CreateSceneDialog.tsx
@@ -31,7 +31,7 @@ export default function CreateSceneDialog({
   const [name, setName] = React.useState<string | undefined>();
   const [submitDisabled, setSubmitDisabled] = React.useState(false);
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     if (targetRevisionId) {
       setSubmitDisabled(true);
 

--- a/src/components/shared/CreatedAtDateRangeFilter.tsx
+++ b/src/components/shared/CreatedAtDateRangeFilter.tsx
@@ -20,7 +20,7 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
   const [createdAtStartDate, setCreatedAtStartDate] = React.useState("");
   const [createdAtEndDate, setCreatedAtEndDate] = React.useState("");
 
-  function handleCreatedAtStartChange(value: string) {
+  function handleCreatedAtStartChange(value: string): void {
     const nextEndDate =
       value !== "" &&
       createdAtEndDate !== "" &&
@@ -38,7 +38,7 @@ export function CreatedAtDateRangeFilter({ onChange }: Props): JSX.Element {
     });
   }
 
-  function handleCreatedAtEndChange(value: string) {
+  function handleCreatedAtEndChange(value: string): void {
     const nextStartDate =
       value !== "" &&
       createdAtStartDate !== "" &&

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -8,7 +8,7 @@ import { AppLink } from "./AppLink";
 export function Header(): JSX.Element {
   const router = useRouter();
 
-  async function handleSignOut() {
+  async function handleSignOut(): Promise<void> {
     await fetch("/api/logout");
     router.push("/login");
   }

--- a/src/components/translation/QueuedTranslationsTable.tsx
+++ b/src/components/translation/QueuedTranslationsTable.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { toLocaleString } from "../../lib/dates";
 import { QueuedJob, toQueuedJobPage } from "../../lib/queued-jobs";
@@ -29,7 +29,7 @@ function useRunningTranslations(
   status: string,
   refreshInterval: number,
   fetchAll: boolean
-) {
+): SWRResponse {
   return useSWR(
     `/api/queued-translations?status=${status}&fetchAll=${fetchAll}`,
     {

--- a/src/components/viewer/CreateSceneViewStateDialog.tsx
+++ b/src/components/viewer/CreateSceneViewStateDialog.tsx
@@ -29,7 +29,7 @@ export default function CreatePartDialog({
   const [name, setName] = React.useState<string | undefined>();
   const [submitDisabled, setSubmitDisabled] = React.useState(false);
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     if (viewer.current) {
       setSubmitDisabled(true);
 

--- a/src/components/viewer/LeftDrawer.tsx
+++ b/src/components/viewer/LeftDrawer.tsx
@@ -28,7 +28,7 @@ export function LeftDrawer({
   viewerState,
   onItemSelected,
 }: Props): JSX.Element {
-  const getDisplayedHeader = () => {
+  const getDisplayedHeader = (): string => {
     switch (active) {
       case "scene-tree":
         return "Assembly";
@@ -37,7 +37,7 @@ export function LeftDrawer({
     }
   };
 
-  const getActiveContent = () => {
+  const getActiveContent = (): JSX.Element => {
     switch (active) {
       case "scene-tree":
         return (

--- a/src/components/viewer/ModelViews.tsx
+++ b/src/components/viewer/ModelViews.tsx
@@ -104,7 +104,7 @@ function NoData(): JSX.Element {
   );
 }
 
-function DrawerTitle({ onClear }: { onClear?: VoidFunction }) {
+function DrawerTitle({ onClear }: { onClear?: VoidFunction }): JSX.Element {
   return (
     <Title
       sx={{

--- a/src/components/viewer/RightDrawer.tsx
+++ b/src/components/viewer/RightDrawer.tsx
@@ -63,7 +63,7 @@ export function RightDrawer({
     return fallbackMaxWidth();
   }, []);
 
-  function setAndPersistWidth(nextWidth: number) {
+  function setAndPersistWidth(nextWidth: number): void {
     setWidth((currentWidth) => {
       const clampedWidth = clampWidth(nextWidth, maxWidth(currentWidth));
       window.localStorage.setItem(StorageKey, String(clampedWidth));
@@ -78,7 +78,7 @@ export function RightDrawer({
   }, [maxWidth]);
 
   React.useEffect(() => {
-    function stopDragging() {
+    function stopDragging(): void {
       if (!draggingRef.current) return;
       draggingRef.current = false;
       document.body.style.userSelect = "";
@@ -88,7 +88,7 @@ export function RightDrawer({
       });
     }
 
-    function onMouseMove(event: MouseEvent) {
+    function onMouseMove(event: MouseEvent): void {
       if (!draggingRef.current) return;
       const { clientX, width: startWidth } = dragStartRef.current;
       setWidth(
@@ -96,7 +96,7 @@ export function RightDrawer({
       );
     }
 
-    function onResize() {
+    function onResize(): void {
       setWidth((currentWidth) =>
         clampWidth(currentWidth, maxWidth(currentWidth))
       );
@@ -115,7 +115,7 @@ export function RightDrawer({
     };
   }, [maxWidth]);
 
-  function handleMouseDown(event: React.MouseEvent) {
+  function handleMouseDown(event: React.MouseEvent): void {
     if (event.button !== 0) return;
     event.preventDefault();
     draggingRef.current = true;
@@ -123,11 +123,11 @@ export function RightDrawer({
     document.body.style.userSelect = "none";
   }
 
-  function handleDoubleClick() {
+  function handleDoubleClick(): void {
     setAndPersistWidth(RightDrawerWidth);
   }
 
-  function handleKeyDown(event: React.KeyboardEvent) {
+  function handleKeyDown(event: React.KeyboardEvent): void {
     switch (event.key) {
       case "ArrowLeft":
         event.preventDefault();
@@ -155,7 +155,7 @@ export function RightDrawer({
     }
   }
 
-  const getDisplayedContent = () => {
+  const getDisplayedContent = (): JSX.Element => {
     switch (active) {
       case "properties":
         return <MetadataProperties metadata={metadata} />;

--- a/src/components/viewer/SceneViewStateList.tsx
+++ b/src/components/viewer/SceneViewStateList.tsx
@@ -18,7 +18,7 @@ export function SceneViewStateList({
 
   if (!sceneViewStates || !sceneViewStates.length) return <NoData />;
 
-  const handleListItemClick = (id: string, index: number) => {
+  const handleListItemClick = (id: string, index: number): void => {
     onViewStateSelected(id);
     setSelectedIndex(index);
   };

--- a/src/components/viewer/SidebarIcon.tsx
+++ b/src/components/viewer/SidebarIcon.tsx
@@ -17,7 +17,7 @@ export const SidebarIcon = ({
   children,
   onSelectSidebar,
 }: Props): JSX.Element => {
-  const toggleSidebar = (name: string) => {
+  const toggleSidebar = (name: string): void => {
     if (name !== active) {
       onSelectSidebar(name);
     } else {

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -90,17 +90,17 @@ function UnwrappedViewer({
 
   useHotkeys("s", () => handleShortcutS(), { keyup: true });
 
-  function handleShortcutS() {
+  function handleShortcutS(): void {
     if (ref?.current == null) return;
 
     ref.current.focus();
   }
 
-  function handleClose() {
+  function handleClose(): void {
     setKey(Date.now());
   }
 
-  async function handleUpdateBaseCamera() {
+  async function handleUpdateBaseCamera(): Promise<void> {
     const { sceneId } = router.query;
     const parsedSceneId = Array.isArray(sceneId) ? sceneId[0] : sceneId || "";
     const camera = await getCamera({ viewer: viewer.current });
@@ -267,7 +267,9 @@ function onTap<P extends ViewerProps>(
   }: P & OnSelectProps) {
     const [hit, setHit] = React.useState<vertexvis.protobuf.stream.IHit>();
 
-    async function handleTap(e: VertexViewerCustomEvent<TapEventDetails>) {
+    async function handleTap(
+      e: VertexViewerCustomEvent<TapEventDetails>
+    ): Promise<void> {
       if (props.onTap) props.onTap(e);
 
       if (!e.defaultPrevented) {

--- a/src/lib/vertex-api.ts
+++ b/src/lib/vertex-api.ts
@@ -26,7 +26,7 @@ import {
 
 const TenMinsInMs = 600_000;
 
-const basePath = (env: string, networkConfig?: NetworkConfig) => {
+const basePath = (env: string, networkConfig?: NetworkConfig): string => {
   if (env === "custom" && networkConfig != null) {
     return networkConfig.apiHost;
   }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -27,7 +27,7 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
   const routeProgressTimer = React.useRef<number>();
 
   React.useEffect(() => {
-    function handleChange(url: string) {
+    function handleChange(url: string): void {
       /* eslint-disable @typescript-eslint/ban-ts-comment */
       // @ts-ignore
       if (window.gtag) {
@@ -47,13 +47,13 @@ export default function App({ Component, pageProps }: AppProps): JSX.Element {
   }, [events]);
 
   React.useEffect(() => {
-    function handleRouteChangeStart() {
+    function handleRouteChangeStart(): void {
       routeProgressTimer.current = window.setTimeout(() => {
         setShowRouteProgress(true);
       }, RouteProgressDelayMs);
     }
 
-    function handleRouteChangeEnd() {
+    function handleRouteChangeEnd(): void {
       if (routeProgressTimer.current != null) {
         window.clearTimeout(routeProgressTimer.current);
         routeProgressTimer.current = undefined;

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -432,7 +432,7 @@ export default function FileCollectionDetails({
     return () => window.clearTimeout(timeout);
   }, [archiveReadyMessageVisible, exportStateIsCurrent, jobStatus]);
 
-  async function handleRefreshReadiness() {
+  async function handleRefreshReadiness(): Promise<void> {
     if (currentReadinessRefreshInFlight || exportInFlight) return;
 
     setExportStateCollectionId(fileCollection.id);
@@ -452,7 +452,7 @@ export default function FileCollectionDetails({
     let active = true;
     let timeout: number | undefined;
 
-    async function pollJob() {
+    async function pollJob(): Promise<void> {
       try {
         const res = await fetch(
           `/api/file-jobs/${encodeURIComponent(currentJobId)}`
@@ -496,7 +496,7 @@ export default function FileCollectionDetails({
     };
   }, [exportStateIsCurrent, jobId, jobStatus]);
 
-  async function handleExport() {
+  async function handleExport(): Promise<void> {
     if (exportDisabled) return;
 
     const currentFileCollectionId = fileCollection.id;
@@ -556,7 +556,7 @@ export default function FileCollectionDetails({
     setJobStatus("running");
   }
 
-  async function handleDownloadArchive() {
+  async function handleDownloadArchive(): Promise<void> {
     if (currentArchiveFileId == null || currentDownloadInFlight) return;
 
     const currentFileCollectionId = fileCollection.id;
@@ -596,7 +596,7 @@ export default function FileCollectionDetails({
     }
   }
 
-  function handleRetry() {
+  function handleRetry(): void {
     setExportStateCollectionId(fileCollection.id);
     setArchiveFileId(undefined);
     setArchiveReadyMessageVisible(false);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,12 +16,12 @@ export default function Home(): JSX.Element {
   const drawerOpen = Boolean(scene);
   const [invalidationCount, setInvalidationCount] = React.useState(0);
 
-  function handleClick(s: Scene) {
+  function handleClick(s: Scene): void {
     setScene(s);
     setEditing(false);
   }
 
-  function handleEditClick(s: Scene) {
+  function handleEditClick(s: Scene): void {
     setScene(s);
     setEditing(true);
   }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -92,7 +92,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     !invalidSceneTreeHost &&
     !invalidSceneViewHost;
 
-  function setLocalStorageItems() {
+  function setLocalStorageItems(): void {
     if (networkConfig != null) {
       localStorage.setItem(
         "vertexvis.network.config",
@@ -105,7 +105,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     }
   }
 
-  async function handleSubmit() {
+  async function handleSubmit(): Promise<void> {
     if (!id || !secret) return;
     setLoading(true);
     setLocalStorageItems();
@@ -142,7 +142,9 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     sceneViewHost: false,
   });
 
-  const createEditButton = (field: keyof typeof editableFields) => (
+  const createEditButton = (
+    field: keyof typeof editableFields
+  ): JSX.Element => (
     <InputAdornment position="end">
       <IconButton
         size="small"
@@ -165,7 +167,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     </InputAdornment>
   );
 
-  const handleReset = () => {
+  const handleReset = (): void => {
     setEditableFields({
       apiHost: true,
       renderingHost: true,

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -5,7 +5,7 @@ import { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import { useRouter } from "next/router";
 import { withIronSession } from "next-iron-session";
 import React from "react";
-import useSWR from "swr";
+import useSWR, { SWRResponse } from "swr";
 
 import { Header } from "../../components/shared/Header";
 import { Layout } from "../../components/viewer/Layout";
@@ -29,13 +29,21 @@ import {
 
 const ViewerId = "vertex-viewer-id";
 
-function useSceneViewStates({ viewId }: { viewId?: string }) {
+function useSceneViewStates({
+  viewId,
+}: {
+  viewId?: string;
+}): SWRResponse<GetRes<SceneViewStateData>, ErrorRes> {
   return useSWR<GetRes<SceneViewStateData>, ErrorRes>(
     viewId ? `/api/scene-view-states?view=${viewId}` : null
   );
 }
 
-function useSceneItem({ itemId }: { itemId?: string }) {
+function useSceneItem({
+  itemId,
+}: {
+  itemId?: string;
+}): SWRResponse<SceneItemData, ErrorRes> {
   return useSWR<SceneItemData, ErrorRes>(
     itemId ? `/api/scene-items/${itemId}` : null
   );
@@ -103,7 +111,7 @@ export default function SceneViewer({
   async function handleSelect(
     detail: TapEventDetails,
     hit?: vertexvis.protobuf.stream.IHit
-  ) {
+  ): Promise<void> {
     console.debug({
       hitNormal: hit?.hitNormal,
       hitPoint: hit?.hitPoint,
@@ -117,11 +125,11 @@ export default function SceneViewer({
     }
   }
 
-  function handleTreeItemSelected(itemId: string) {
+  function handleTreeItemSelected(itemId: string): void {
     setSelectedItemId(itemId);
   }
 
-  function handleViewStateSelected(id: string) {
+  function handleViewStateSelected(id: string): void {
     applySceneViewState({ id, viewer: viewerState.ref.current });
   }
 

--- a/test/render/renderWithSWR.tsx
+++ b/test/render/renderWithSWR.tsx
@@ -1,8 +1,13 @@
-import { render } from "@testing-library/react";
+import { render, RenderResult } from "@testing-library/react";
 import React from "react";
 import { SWRConfig } from "swr";
 
-export function renderWithSWR(ui: React.ReactElement) {
+export function renderWithSWR(ui: React.ReactElement): Omit<
+  RenderResult,
+  "rerender"
+> & {
+  rerender: (nextUi: React.ReactElement) => void;
+} {
   function wrap(children: React.ReactElement): React.ReactElement {
     return (
       <SWRConfig


### PR DESCRIPTION
Part 2/6 of the PLAT-9101 ESLint-tightening stack · base: `PLAT-9103_eslint_stack_1_toolchain`

## What
Removes the temporary `explicit-function-return-type: off` override from part 1/6 and adds the 130 explicit return-type annotations it had been masking, across 39 files. Conventions: components → `JSX.Element`; async → `Promise<T>`; handlers → `void`; SWR hooks → `SWRResponse<Data, Error>` where type params exist; test stubs → `ReturnType<typeof http.get>` etc.

## Config delta
Remove the temporary off-override; `@typescript-eslint/explicit-function-return-type` (from the shared Vertexvis preset) is now enforced.

## Why green independently
Exactly the 130 findings existed under this config; all annotated. `eslint . --max-warnings=0` exits 0.

## Validation
lint · format:check · typecheck · test (151) · build — all green.

## Related
[PLAT-9104](https://vertexvis.atlassian.net/browse/PLAT-9104) (parent [PLAT-9101](https://vertexvis.atlassian.net/browse/PLAT-9101)) · reference #370

[PLAT-9104]: https://vertexvis.atlassian.net/browse/PLAT-9104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-9101]: https://vertexvis.atlassian.net/browse/PLAT-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ