### PR TITLE
[PLAT-9105] - Ban let declarations in production .tsx files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,21 @@ const config = [
       'simple-import-sort/exports': 'error',
     },
   },
+  // Production .tsx: prohibit `let`. Tests and all .ts files are exempt.
+  {
+    files: ['src/**/*.tsx'],
+    ignores: ['src/__tests__/**', '**/*.test.tsx', '**/*.spec.tsx'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "VariableDeclaration[kind='let']",
+          message:
+            'Use const with immutable bindings in production .tsx files; refactor control flow instead of let.',
+        },
+      ],
+    },
+  },
   // Testing Library rules for test files.
   {
     files: TEST_FILES,

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -150,20 +150,23 @@ export default function FileCollectionFilesTable({
     }
   }
 
-  let tableRows: React.ReactNode;
-  if (loadError) {
-    tableRows = <DataLoadError colSpan={headCells.length} />;
-  } else if (!page) {
-    tableRows = (
-      <SkeletonBody
-        includeCheckbox={false}
-        numCellsPerRow={headCells.length}
-        numRows={pageSize - pageLength}
-        rowHeight={DefaultRowHeight}
-      />
-    );
-  } else {
-    tableRows = page.items.map((row) => {
+  function renderTableRows(): React.ReactNode {
+    if (loadError) {
+      return <DataLoadError colSpan={headCells.length} />;
+    }
+
+    if (!page) {
+      return (
+        <SkeletonBody
+          includeCheckbox={false}
+          numCellsPerRow={headCells.length}
+          numRows={pageSize - pageLength}
+          rowHeight={DefaultRowHeight}
+        />
+      );
+    }
+
+    return page.items.map((row) => {
       const isActive = activeFileId === row.id;
       const isAvailable = isFileAvailable(row);
 
@@ -222,6 +225,8 @@ export default function FileCollectionFilesTable({
       );
     });
   }
+
+  const tableRows = renderTableRows();
 
   return (
     <>

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -197,20 +197,23 @@ export default function FileCollectionTable({
     mutate();
   }
 
-  let tableRows: React.ReactNode;
-  if (error) {
-    tableRows = <DataLoadError colSpan={headCells.length + 1} />;
-  } else if (!page) {
-    tableRows = (
-      <SkeletonBody
-        includeCheckbox={true}
-        numCellsPerRow={headCells.length}
-        numRows={pageSize - pageLength}
-        rowHeight={DefaultRowHeight}
-      />
-    );
-  } else {
-    tableRows = page.items.map((row) => {
+  function renderTableRows(): React.ReactNode {
+    if (error) {
+      return <DataLoadError colSpan={headCells.length + 1} />;
+    }
+
+    if (!page) {
+      return (
+        <SkeletonBody
+          includeCheckbox={true}
+          numCellsPerRow={headCells.length}
+          numRows={pageSize - pageLength}
+          rowHeight={DefaultRowHeight}
+        />
+      );
+    }
+
+    return page.items.map((row) => {
       const isSel = selected.has(row.id);
       const isActive = activeFileCollectionId === row.id;
 
@@ -254,6 +257,8 @@ export default function FileCollectionTable({
       );
     });
   }
+
+  const tableRows = renderTableRows();
 
   return (
     <>

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -264,20 +264,23 @@ export default function FileTable({
     }
   }
 
-  let tableRows: React.ReactNode;
-  if (loadError) {
-    tableRows = <DataLoadError colSpan={headCells.length + 1} />;
-  } else if (!visiblePage) {
-    tableRows = (
-      <SkeletonBody
-        includeCheckbox={true}
-        numCellsPerRow={8}
-        numRows={pageSize - pageLength}
-        rowHeight={DefaultRowHeight}
-      />
-    );
-  } else {
-    tableRows = visiblePage.items.map((row) => {
+  function renderTableRows(): React.ReactNode {
+    if (loadError) {
+      return <DataLoadError colSpan={headCells.length + 1} />;
+    }
+
+    if (!visiblePage) {
+      return (
+        <SkeletonBody
+          includeCheckbox={true}
+          numCellsPerRow={8}
+          numRows={pageSize - pageLength}
+          rowHeight={DefaultRowHeight}
+        />
+      );
+    }
+
+    return visiblePage.items.map((row) => {
       const isSel = selected.has(row.id);
       const isActive = activeFileId === row.id;
       const isAvailable = isFileAvailable(row);
@@ -353,6 +356,8 @@ export default function FileTable({
       );
     });
   }
+
+  const tableRows = renderTableRows();
 
   return (
     <>

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -70,6 +70,40 @@ interface ServerSideContext {
   readonly req: NextIronRequest;
 }
 
+function delay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+
+    const onAbort = (): void => {
+      window.clearTimeout(timeout);
+      resolve();
+    };
+    const timeout = window.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function createFileJob(fileCollectionId: string): Promise<{
+  readonly body: FileJobRes | ErrorRes;
+  readonly res: Response;
+}> {
+  const res = await fetch("/api/file-jobs", {
+    body: JSON.stringify({ fileCollectionId }),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+  });
+  const body = (await res.json()) as FileJobRes | ErrorRes;
+
+  return { body, res };
+}
+
 interface ExportControlsProps {
   readonly archiveFileId?: string;
   readonly disabledReason?: string;
@@ -449,17 +483,20 @@ export default function FileCollectionDetails({
       return;
 
     const currentJobId = jobId;
-    let active = true;
-    let timeout: number | undefined;
+    const controller = new AbortController();
+    const { signal } = controller;
 
     async function pollJob(): Promise<void> {
-      try {
+      while (!signal.aborted) {
+        await delay(1000, signal);
+        if (signal.aborted) return;
+
         const res = await fetch(
           `/api/file-jobs/${encodeURIComponent(currentJobId)}`
         );
         const body = (await res.json()) as FileJobRes | ErrorRes;
 
-        if (!active) return;
+        if (signal.aborted) return;
 
         if (!res.ok || "message" in body) {
           setJobStatus("error");
@@ -474,26 +511,25 @@ export default function FileCollectionDetails({
         if (status === "complete") {
           setJobStatus("complete");
           setArchiveReadyMessageVisible(true);
-        } else if (status === "error") {
-          setJobStatus("error");
-          setExportError("Archive job failed.");
-        } else {
-          timeout = window.setTimeout(pollJob, 1000);
+          return;
         }
-      } catch {
-        if (active) {
+
+        if (status === "error") {
           setJobStatus("error");
           setExportError("Archive job failed.");
+          return;
         }
       }
     }
 
-    timeout = window.setTimeout(pollJob, 1000);
+    pollJob().catch(() => {
+      if (!signal.aborted) {
+        setJobStatus("error");
+        setExportError("Archive job failed.");
+      }
+    });
 
-    return () => {
-      active = false;
-      if (timeout != null) window.clearTimeout(timeout);
-    };
+    return () => controller.abort();
   }, [exportStateIsCurrent, jobId, jobStatus]);
 
   async function handleExport(): Promise<void> {
@@ -508,22 +544,20 @@ export default function FileCollectionDetails({
     setJobId(undefined);
     setJobStatus("creating");
 
-    let res: Response;
-    let body: FileJobRes | ErrorRes;
-    try {
-      res = await fetch("/api/file-jobs", {
-        body: JSON.stringify({ fileCollectionId: fileCollection.id }),
-        headers: { "Content-Type": "application/json" },
-        method: "POST",
-      });
-      body = (await res.json()) as FileJobRes | ErrorRes;
-    } catch {
+    const created = await createFileJob(currentFileCollectionId).catch(
+      () => undefined
+    );
+
+    if (created == null) {
       if (fileCollectionIdRef.current === currentFileCollectionId) {
         setJobStatus("error");
         setExportError("Could not start archive export.");
       }
+
       return;
     }
+
+    const { body, res } = created;
 
     if (fileCollectionIdRef.current !== currentFileCollectionId) return;
 


### PR DESCRIPTION
Part 3/6 of the PLAT-9101 ESLint-tightening stack · base: `PLAT-9104_eslint_stack_2_return_types`

## What
Enables a file-scoped `no-restricted-syntax` ban on `let` in production `.tsx` (tests and all `.ts` files exempt — matches connect-app's established React convention) and refactors the 7 existing sites:
- 3× `let tableRows: React.ReactNode` if/else chains → in-component `renderTableRows()` helpers with early returns (FileCollectionFilesTable, FileCollectionTable, FileTable).
- `[fileCollectionId].tsx` polling: `let active`/`let timeout` self-rescheduling setTimeout → `AbortController` + async loop with a `delay(ms, signal)` helper (resolves immediately on pre-aborted signals; abort listener removed on normal expiry). `let res`/`let body` → extracted `createFileJob()` async helper with const destructuring.

## Config delta
Add the let-ban block for `src/**/*.tsx` (ignores tests).

## Why green independently
Exactly the 7 findings existed under this config; all refactored with behavior parity (poll cadence, error paths, and branch parity independently reviewed on the reference PR).

## Validation
lint · format:check · typecheck · test (151) · build — all green.

## Related
[PLAT-9105](https://vertexvis.atlassian.net/browse/PLAT-9105) (parent [PLAT-9101](https://vertexvis.atlassian.net/browse/PLAT-9101)) · reference #370

[PLAT-9105]: https://vertexvis.atlassian.net/browse/PLAT-9105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ