### PR TITLE
[PLAT-9106] - Enable typed async-safety rules and resolve promise findings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,6 +93,21 @@ const config = [
       ],
     },
   },
+  // Type-aware rules for all TypeScript (src, tests, scripts, test helpers —
+  // root tsconfig.json includes **/*.ts(x), so projectService covers them all).
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: __dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
+    },
+  },
   // Testing Library rules for test files.
   {
     files: TEST_FILES,

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -22,6 +22,7 @@ import {
   toFileCollectionPage,
 } from "../../lib/file-collections";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { reportError } from "../../lib/report-error";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import {
   CreatedAtDateRange,
@@ -194,7 +195,7 @@ export default function FileCollectionTable({
       return;
     }
 
-    mutate();
+    mutate().catch(reportError("Failed to refresh file collections"));
   }
 
   function renderTableRows(): React.ReactNode {
@@ -265,7 +266,11 @@ export default function FileCollectionTable({
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            handleDelete().catch(() => {
+              setDeleteError("Could not delete the selected file collections.");
+            });
+          }}
           title="File Collections"
         />
         <Box

--- a/src/components/file/CreateFileDialog.tsx
+++ b/src/components/file/CreateFileDialog.tsx
@@ -17,6 +17,7 @@ import { CreateFileRequestDataAttributes } from "@vertexvis/api-client-node";
 import { useRouter } from "next/router";
 import React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { CreateFileRes } from "../../pages/api/files";
 
 interface CreateFileDialogProps {
@@ -70,7 +71,7 @@ export default function CreateFileDialog({
     onFileCreated(fileRes.id);
 
     if (createPart) {
-      router.push(`/parts?create=${fileRes.id}&n=${file?.name}`);
+      await router.push(`/parts?create=${fileRes.id}&n=${file?.name}`);
     }
 
     setFile(undefined);
@@ -149,7 +150,9 @@ export default function CreateFileDialog({
         <Button
           disabled={submitDisabled}
           startIcon={<CloudUploadOutlined />}
-          onClick={handleUpload}
+          onClick={() => {
+            handleUpload().catch(reportError("Failed to upload the file"));
+          }}
           color="primary"
           variant="contained"
         >

--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/file-collections";
 import { File } from "../../lib/files";
 import { toDisplayValue, toFileSizeDisplay } from "../../lib/formatting";
+import { reportError } from "../../lib/report-error";
 import { AppLink } from "../shared/AppLink";
 import { DefaultPageSize, RightDrawerWidth } from "../shared/Layout";
 
@@ -174,7 +175,7 @@ function useFileCollections({
       }
     };
 
-    load();
+    load().catch(reportError("Failed to load file collections"));
 
     return () => {
       controller.abort();
@@ -363,7 +364,11 @@ function FileCollectionIdsRow({
                       <Tooltip title="Copy file collection ID">
                         <IconButton
                           aria-label={`Copy ${collection.id}`}
-                          onClick={() => copyId(collection.id)}
+                          onClick={() => {
+                            copyId(collection.id).catch(
+                              reportError("Failed to copy file collection ID")
+                            );
+                          }}
                           size="small"
                           sx={{ flexShrink: 0 }}
                         >

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -29,6 +29,7 @@ import {
   toFilePage,
 } from "../../lib/files";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
+import { reportError } from "../../lib/report-error";
 import { SortState, toggleSort, toSortParam } from "../../lib/sorting";
 import {
   CreatedAtDateRange,
@@ -237,7 +238,7 @@ export default function FileTable({
       body: JSON.stringify({ ids: [...selected] }),
       method: "DELETE",
     });
-    mutate();
+    await mutate();
   }
 
   async function handleDownload(id: string): Promise<void> {
@@ -377,7 +378,9 @@ export default function FileTable({
             ) : undefined
           }
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            handleDelete().catch(reportError("Failed to delete files"));
+          }}
           title="Files"
         />
         <Box
@@ -478,7 +481,7 @@ export default function FileTable({
         onFileCreated={() => {
           setShowDialog(false);
           setShowToast(true);
-          mutate();
+          mutate().catch(reportError("Failed to refresh files"));
         }}
       />
       <Snackbar

--- a/src/components/part/CreatePartDialog.tsx
+++ b/src/components/part/CreatePartDialog.tsx
@@ -17,6 +17,7 @@ import React from "react";
 import useSWR, { SWRResponse } from "swr";
 
 import { toFilePage } from "../../lib/files";
+import { reportError } from "../../lib/report-error";
 import { CreatePartReq, CreatePartRes } from "../../pages/api/parts";
 
 interface CreatePartDialogProps {
@@ -161,7 +162,9 @@ export default function CreatePartDialog({
         <Button onClick={onClose}>Cancel</Button>
         <Button
           disabled={submitDisabled}
-          onClick={handleSubmit}
+          onClick={() => {
+            handleSubmit().catch(reportError("Failed to create the part"));
+          }}
           color="primary"
           variant="contained"
         >

--- a/src/components/part/PartRow.tsx
+++ b/src/components/part/PartRow.tsx
@@ -17,6 +17,7 @@ import { Paged } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartRevisionPage } from "../../lib/part-revisions";
 import { Part } from "../../lib/parts";
+import { reportError } from "../../lib/report-error";
 import { RowActionsMenu } from "../shared/RowActionsMenu";
 
 interface PartRowProps {
@@ -50,7 +51,7 @@ export default function PartRow({
     };
 
     if (open) {
-      fetchData();
+      fetchData().catch(reportError("Failed to load part revisions"));
     }
   }, [part.id, open]);
 

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -21,6 +21,7 @@ import useSWR, { SWRResponse } from "swr";
 import { buildQuery, SwrProps, useCursorPagingState } from "../../lib/paging";
 import { PartRevision } from "../../lib/part-revisions";
 import { toPartPage } from "../../lib/parts";
+import { reportError } from "../../lib/report-error";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
@@ -136,7 +137,7 @@ export default function PartTable({
       body: JSON.stringify({ ids: [...selected] }),
       method: "DELETE",
     });
-    mutate();
+    await mutate();
   }
 
   return (
@@ -144,7 +145,9 @@ export default function PartTable({
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            handleDelete().catch(reportError("Failed to delete parts"));
+          }}
           title="Parts"
         />
         <Box

--- a/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
+++ b/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
@@ -357,7 +357,12 @@ export default function CreatePropertyKeyPolicyDialog({
             <Button
               color="primary"
               disabled={submitDisabled}
-              onClick={handleSubmit}
+              onClick={() => {
+                handleSubmit().catch(() => {
+                  setSubmitting(false);
+                  setApiError("Could not create the property key policy.");
+                });
+              }}
               variant="contained"
             >
               Create

--- a/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
@@ -27,6 +27,7 @@ import {
   PropertyKeyPolicy,
   toPropertyKeyPolicyPage,
 } from "../../lib/property-key-policies";
+import { reportError } from "../../lib/report-error";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
 import { DataLoadError } from "../shared/DataLoadError";
 import { DefaultPageSize, DefaultRowHeight } from "../shared/Layout";
@@ -177,20 +178,20 @@ export default function PropertyKeyPolicyTable({
           (isErrorRes(body) ? body.message : undefined) ??
             "Could not delete the selected property key policies."
         );
-        mutate();
+        mutate().catch(reportError("Failed to refresh property key policies"));
       }
       return;
     }
 
     setDeleting(false);
     setSelected(new Set());
-    mutate();
+    mutate().catch(reportError("Failed to refresh property key policies"));
     onPoliciesDeleted?.(ids);
   }
 
   function handleCreated(): void {
     resetPaging();
-    mutate();
+    mutate().catch(reportError("Failed to refresh property key policies"));
   }
 
   const tableRows = loadFailed ? (
@@ -267,7 +268,14 @@ export default function PropertyKeyPolicyTable({
             ) : undefined
           }
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            handleDelete().catch(() => {
+              setDeleting(false);
+              setDeleteError(
+                "Could not delete the selected property key policies."
+              );
+            });
+          }}
           title="Property Key Policies"
         />
         <Box

--- a/src/components/scene/SceneDrawer.tsx
+++ b/src/components/scene/SceneDrawer.tsx
@@ -21,6 +21,7 @@ import React, { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import { toLocaleString } from "../../lib/dates";
+import { reportError } from "../../lib/report-error";
 import { Scene } from "../../lib/scenes";
 import { UpdateSceneReq } from "../../pages/api/scenes";
 import { Input } from "../shared/Input";
@@ -63,7 +64,7 @@ export function SceneDrawer({
     };
 
     if (scene != null && open) {
-      fetchData();
+      fetchData().catch(reportError("Failed to load scene details"));
     }
   }, [scene, open]);
 
@@ -110,7 +111,9 @@ export function SceneDrawer({
   }
 
   function copyCamera(): void {
-    navigator.clipboard.writeText(JSON.stringify(scene?.camera));
+    navigator.clipboard
+      .writeText(JSON.stringify(scene?.camera))
+      .catch(reportError("Failed to copy camera JSON to clipboard"));
   }
 
   React.useEffect(() => {
@@ -150,7 +153,13 @@ export function SceneDrawer({
       </Box>
       {scene && editing ? (
         <Box sx={{ mx: 2, mb: 2 }}>
-          <form onSubmit={handleSubmit(onSubmit)}>
+          <form
+            onSubmit={(e) => {
+              handleSubmit(onSubmit)(e).catch(
+                reportError("Failed to update the scene")
+              );
+            }}
+          >
             <Input<FormData> control={control} label="Name" name="name" />
             <Input<FormData>
               control={control}

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -24,6 +24,7 @@ import useSWR, { SWRResponse } from "swr";
 import { ErrorRes, GetRes } from "../../lib/api";
 import { toLocaleString } from "../../lib/dates";
 import { SwrProps } from "../../lib/paging";
+import { reportError } from "../../lib/report-error";
 import { Scene, toScenePage } from "../../lib/scenes";
 import CreateSceneDialog from "../shared/CreateSceneDialog";
 import { formatCursorPaginationLabel } from "../shared/cursor-pagination";
@@ -117,7 +118,7 @@ export default function SceneTable({
   });
 
   useEffect(() => {
-    mutate();
+    mutate().catch(reportError("Failed to refresh scenes"));
   }, [invalidationCount, mutate]);
 
   const router = useRouter();
@@ -185,7 +186,7 @@ export default function SceneTable({
       body: JSON.stringify({ ids: [...selected] }),
       method: "DELETE",
     });
-    mutate();
+    await mutate();
   }
 
   function handleEditClick(s: Scene): void {
@@ -194,7 +195,9 @@ export default function SceneTable({
   }
 
   function handleViewClick(sceneId: string): void {
-    router.push(`/scene-viewer/${encodeURIComponent(sceneId)}`);
+    router
+      .push(`/scene-viewer/${encodeURIComponent(sceneId)}`)
+      .catch(reportError("Failed to navigate to the scene viewer"));
   }
 
   async function handleGetStreamKey(sceneId: string): Promise<void> {
@@ -219,7 +222,9 @@ export default function SceneTable({
       <Paper sx={{ m: 2 }}>
         <TableToolbar
           numSelected={selected.size}
-          onDelete={handleDelete}
+          onDelete={() => {
+            handleDelete().catch(reportError("Failed to delete scenes"));
+          }}
           title="Scenes"
           customActions={[
             <React.Fragment key="merge">

--- a/src/components/shared/CreateSceneDialog.tsx
+++ b/src/components/shared/CreateSceneDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { MergeSceneReq, MergeSceneRes } from "../../pages/api/merged-scenes";
 import { CreateSceneReq, CreateSceneRes } from "../../pages/api/scenes";
 
@@ -118,7 +119,9 @@ export default function CreateSceneDialog({
         <Button onClick={onClose}>Cancel</Button>
         <Button
           disabled={submitDisabled}
-          onClick={handleSubmit}
+          onClick={() => {
+            handleSubmit().catch(reportError("Failed to create the scene"));
+          }}
           color="primary"
           variant="contained"
         >

--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -3,6 +3,7 @@ import { Box, Button } from "@mui/material";
 import Image from "next/image";
 import { useRouter } from "next/router";
 
+import { reportError } from "../../lib/report-error";
 import { AppLink } from "./AppLink";
 
 export function Header(): JSX.Element {
@@ -10,7 +11,7 @@ export function Header(): JSX.Element {
 
   async function handleSignOut(): Promise<void> {
     await fetch("/api/logout");
-    router.push("/login");
+    await router.push("/login");
   }
 
   return (
@@ -30,7 +31,13 @@ export function Header(): JSX.Element {
         <p>Vertex Developer Dashboard</p>
       </Box>
       <Box sx={{ ml: "auto" }}>
-        <Button onClick={handleSignOut}>Sign Out</Button>
+        <Button
+          onClick={() => {
+            handleSignOut().catch(reportError("Failed to sign out"));
+          }}
+        >
+          Sign Out
+        </Button>
       </Box>
     </Box>
   );

--- a/src/components/shared/LeftDrawer.tsx
+++ b/src/components/shared/LeftDrawer.tsx
@@ -18,6 +18,7 @@ import { drawerClasses } from "@mui/material/Drawer";
 import { useRouter } from "next/router";
 import React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { LeftDrawerWidth } from "../shared/Layout";
 
 export type Content = "settings" | "instructions" | "parts";
@@ -48,7 +49,9 @@ export function LeftDrawer(): JSX.Element {
         }}
       >
         <ListItemButton
-          onClick={() => router.push("/")}
+          onClick={() => {
+            router.push("/").catch(reportError("Failed to navigate to /"));
+          }}
           selected={router.route === "/" || isSectionActive("/scene-viewer")}
         >
           <ListItemIcon>
@@ -57,7 +60,11 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Scenes" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/files")}
+          onClick={() => {
+            router
+              .push("/files")
+              .catch(reportError("Failed to navigate to /files"));
+          }}
           selected={isSectionActive("/files")}
         >
           <ListItemIcon>
@@ -66,7 +73,11 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Files" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/file-collections")}
+          onClick={() => {
+            router
+              .push("/file-collections")
+              .catch(reportError("Failed to navigate to /file-collections"));
+          }}
           selected={isSectionActive("/file-collections")}
         >
           <ListItemIcon>
@@ -75,7 +86,13 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="File Collections" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/property-key-policies")}
+          onClick={() => {
+            router
+              .push("/property-key-policies")
+              .catch(
+                reportError("Failed to navigate to /property-key-policies")
+              );
+          }}
           selected={router.route === "/property-key-policies"}
         >
           <ListItemIcon>
@@ -84,7 +101,11 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Property Key Policies" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/parts")}
+          onClick={() => {
+            router
+              .push("/parts")
+              .catch(reportError("Failed to navigate to /parts"));
+          }}
           selected={isSectionActive("/parts")}
         >
           <ListItemIcon>
@@ -93,7 +114,11 @@ export function LeftDrawer(): JSX.Element {
           <ListItemText primary="Parts Library" />
         </ListItemButton>
         <ListItemButton
-          onClick={() => router.push("/translations")}
+          onClick={() => {
+            router
+              .push("/translations")
+              .catch(reportError("Failed to navigate to /translations"));
+          }}
           selected={isSectionActive("/translations")}
         >
           <ListItemIcon>

--- a/src/components/viewer/CreateSceneViewStateDialog.tsx
+++ b/src/components/viewer/CreateSceneViewStateDialog.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material";
 import React from "react";
 
+import { reportError } from "../../lib/report-error";
 import {
   CreateViewStateReq,
   CreateViewStateRes,
@@ -69,7 +70,11 @@ export default function CreatePartDialog({
         <Button onClick={onClose}>Cancel</Button>
         <Button
           disabled={submitDisabled}
-          onClick={handleSubmit}
+          onClick={() => {
+            handleSubmit().catch(
+              reportError("Failed to create the view state")
+            );
+          }}
           color="primary"
           variant="contained"
         >

--- a/src/components/viewer/ModelViews.tsx
+++ b/src/components/viewer/ModelViews.tsx
@@ -12,6 +12,7 @@ import { FixedSizeList } from "react-window";
 
 import { Metadata } from "../../lib/metadata";
 import { ModelViewsState } from "../../lib/model-views";
+import { reportError } from "../../lib/report-error";
 import { Title } from "../shared/Title";
 import { PmiAnnotations } from "./PmiAnnotations";
 
@@ -33,7 +34,13 @@ export function ModelViews({ metadata, modelViews }: Props): JSX.Element {
 
   return (
     <>
-      <DrawerTitle onClear={() => modelViews.actions.unloadModelView()} />
+      <DrawerTitle
+        onClear={() => {
+          modelViews.actions
+            .unloadModelView()
+            .catch(reportError("Failed to unload the model view"));
+        }}
+      />
       <Box sx={{ flexGrow: 1, overflow: "hidden" }}>
         <AutoSizer>
           {({ height, width }: Size) => {
@@ -48,7 +55,9 @@ export function ModelViews({ metadata, modelViews }: Props): JSX.Element {
                     renderState.visibleStopIndex ===
                     modelViewList.length - 1
                   ) {
-                    modelViews.actions.fetchNextModelViews(loadedSceneItemId);
+                    modelViews.actions
+                      .fetchNextModelViews(loadedSceneItemId)
+                      .catch(reportError("Failed to load model views"));
                   }
                 }}
               >
@@ -60,10 +69,9 @@ export function ModelViews({ metadata, modelViews }: Props): JSX.Element {
                       key={index}
                       style={style}
                       onClick={() => {
-                        modelViews.actions.loadModelView(
-                          loadedSceneItemId,
-                          modelView.id
-                        );
+                        modelViews.actions
+                          .loadModelView(loadedSceneItemId, modelView.id)
+                          .catch(reportError("Failed to load the model view"));
                       }}
                       alignItems="flex-start"
                       selected={loadedModelViewId === modelView.id}

--- a/src/components/viewer/PmiAnnotations.tsx
+++ b/src/components/viewer/PmiAnnotations.tsx
@@ -5,6 +5,7 @@ import { FixedSizeList } from "react-window";
 
 import { Metadata } from "../../lib/metadata";
 import { ModelViewsState } from "../../lib/model-views";
+import { reportError } from "../../lib/report-error";
 import { Title } from "../shared/Title";
 
 export interface Props {
@@ -56,7 +57,9 @@ export function PmiAnnotations({ metadata, modelViews }: Props): JSX.Element {
                     loadedModelViewId != null &&
                     renderState.visibleStopIndex === annotationList.length - 1
                   ) {
-                    modelViews.actions.fetchNextAnnotations(loadedModelViewId);
+                    modelViews.actions
+                      .fetchNextAnnotations(loadedModelViewId)
+                      .catch(reportError("Failed to load PMI annotations"));
                   }
                 }}
               >

--- a/src/components/viewer/SceneTree.tsx
+++ b/src/components/viewer/SceneTree.tsx
@@ -4,6 +4,7 @@ import { SceneTreeTableCellEventDetails } from "@vertexvis/viewer/dist/types/com
 import { VertexSceneTree } from "@vertexvis/viewer-react";
 import React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { viewerHasSelection, ViewerState } from "../../lib/viewer";
 import { EnvironmentWithCustom, NetworkConfig } from "../../lib/with-session";
 import { SceneTreeContextMenu } from "./SceneTreeContextMenu";
@@ -61,17 +62,29 @@ export function SceneTree({
 
   React.useEffect(() => {
     const effectRef = ref.current;
-    if (selectedItemId) effectRef?.scrollToItem(selectedItemId);
+    if (selectedItemId) {
+      effectRef
+        ?.scrollToItem(selectedItemId)
+        .catch(reportError("Failed to scroll to the scene item"));
+    }
   }, [selectedItemId]);
 
   React.useEffect(() => {
     const effectRef = ref.current;
-    if (expandAll) effectRef?.expandAll();
+    if (expandAll) {
+      effectRef
+        ?.expandAll()
+        .catch(reportError("Failed to expand the scene tree"));
+    }
   }, [expandAll]);
 
   React.useEffect(() => {
     const effectRef = ref.current;
-    if (collapseAll) effectRef?.collapseAll();
+    if (collapseAll) {
+      effectRef
+        ?.collapseAll()
+        .catch(reportError("Failed to collapse the scene tree"));
+    }
   }, [collapseAll]);
 
   return (

--- a/src/components/viewer/SceneTreeContextMenu.tsx
+++ b/src/components/viewer/SceneTreeContextMenu.tsx
@@ -2,6 +2,7 @@ import { Divider } from "@mui/material";
 import { Row } from "@vertexvis/viewer/dist/types/components/scene-tree/lib/row";
 import * as React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { ViewerActions } from "../../lib/viewer";
 import { ContextMenuItem } from "../shared/ContextMenuItem";
 import { ContextMenu } from "./ContextMenu";
@@ -26,9 +27,11 @@ export const SceneTreeContextMenu = ({
         target instanceof HTMLElement &&
         target.tagName.includes("VERTEX-SCENE-TREE")
       }
-      onOpen={async (event) =>
-        setItem(await sceneTree.current?.getRowForEvent(event))
-      }
+      onOpen={(event) => {
+        Promise.resolve(sceneTree.current?.getRowForEvent(event))
+          .then(setItem)
+          .catch(reportError("Failed to load scene tree row"));
+      }}
     >
       <ContextMenuItem
         iconName="eye-half"
@@ -37,7 +40,9 @@ export const SceneTreeContextMenu = ({
         disabled={!hasSelection}
         onClick={() => {
           if (item?.node.id?.hex != null) {
-            actions.setVisibilitySelected(false);
+            actions
+              .setVisibilitySelected(false)
+              .catch(reportError("Failed to hide selected items"));
           }
         }}
       />
@@ -46,7 +51,9 @@ export const SceneTreeContextMenu = ({
         iconSize="sm"
         label="Hide All Parts"
         onClick={() => {
-          actions.setVisibilityAll(false);
+          actions
+            .setVisibilityAll(false)
+            .catch(reportError("Failed to hide all parts"));
         }}
       />
       <ContextMenuItem
@@ -56,7 +63,9 @@ export const SceneTreeContextMenu = ({
         disabled={item == null}
         onClick={() => {
           if (item?.node.id?.hex != null) {
-            actions.showOnly(item.node.id.hex);
+            actions
+              .showOnly(item.node.id.hex)
+              .catch(reportError("Failed to show only part"));
           }
         }}
       />
@@ -66,7 +75,9 @@ export const SceneTreeContextMenu = ({
         label="Show Only Selected"
         disabled={!hasSelection}
         onClick={() => {
-          actions.showOnlySelected();
+          actions
+            .showOnlySelected()
+            .catch(reportError("Failed to show only selected items"));
         }}
       />
       <ContextMenuItem
@@ -74,7 +85,9 @@ export const SceneTreeContextMenu = ({
         iconSize="sm"
         label="Show All Parts"
         onClick={() => {
-          actions.setVisibilityAll(true);
+          actions
+            .setVisibilityAll(true)
+            .catch(reportError("Failed to show all parts"));
         }}
       />
       <Divider />
@@ -85,7 +98,9 @@ export const SceneTreeContextMenu = ({
         disabled={item == null || !item.node.visible}
         onClick={() => {
           if (item?.node.id?.hex != null) {
-            actions.fit(item.node.id.hex);
+            actions
+              .fit(item.node.id.hex)
+              .catch(reportError("Failed to fly to part"));
           }
         }}
       />
@@ -95,7 +110,9 @@ export const SceneTreeContextMenu = ({
         label="Fit Selected"
         disabled={!hasSelection}
         onClick={() => {
-          actions.fitSelected();
+          actions
+            .fitSelected()
+            .catch(reportError("Failed to fit selected items"));
         }}
       />
     </ContextMenu>

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -33,6 +33,7 @@ import React from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { StreamCredentials } from "../../lib/config";
+import { reportError } from "../../lib/report-error";
 import { copySceneViewCamera, fitAll, getCamera } from "../../lib/scene-items";
 import { viewerHasSelection, ViewerState } from "../../lib/viewer";
 import { NetworkConfig } from "../../lib/with-session";
@@ -128,12 +129,20 @@ function UnwrappedViewer({
     {
       icon: <ZoomOutMapOutlined fontSize="small" />,
       label: "Fit All",
-      onSelect: () => fitAll({ viewer: viewer.current }),
+      onSelect: () => {
+        fitAll({ viewer: viewer.current }).catch(
+          reportError("Failed to fit all")
+        );
+      },
     },
     {
       icon: <FileCopyOutlined fontSize="small" />,
       label: "Copy camera",
-      onSelect: () => copySceneViewCamera({ viewer: viewer.current }),
+      onSelect: () => {
+        copySceneViewCamera({ viewer: viewer.current }).catch(
+          reportError("Failed to copy scene view camera")
+        );
+      },
     },
     {
       icon: <CameraAltOutlined fontSize="small" />,
@@ -143,13 +152,19 @@ function UnwrappedViewer({
     {
       icon: <SystemUpdateAltOutlined fontSize="small" />,
       label: "Update base scene with current camera",
-      onSelect: handleUpdateBaseCamera,
+      onSelect: () => {
+        handleUpdateBaseCamera().catch(
+          reportError("Failed to update base scene camera")
+        );
+      },
     },
     {
       icon: <RestartAltOutlined fontSize="small" />,
       label: "Reset View",
       onSelect: () => {
-        viewerState.actions.reset();
+        viewerState.actions
+          .reset()
+          .catch(reportError("Failed to reset the view"));
         onViewReset?.();
       },
     },
@@ -288,7 +303,13 @@ function onTap<P extends ViewerProps>(
 
     return (
       <>
-        <WrappedViewer viewerState={viewerState} {...props} onTap={handleTap} />
+        <WrappedViewer
+          viewerState={viewerState}
+          {...props}
+          onTap={(e) => {
+            handleTap(e).catch(reportError("Failed to handle viewer tap"));
+          }}
+        />
         <ViewerContextMenu
           hit={hit}
           hasSelection={viewerHasSelection(viewerState.ref)}

--- a/src/components/viewer/ViewerContextMenu.tsx
+++ b/src/components/viewer/ViewerContextMenu.tsx
@@ -2,6 +2,7 @@ import { Divider } from "@mui/material";
 import { vertexvis } from "@vertexvis/frame-streaming-protos";
 import * as React from "react";
 
+import { reportError } from "../../lib/report-error";
 import { ViewerActions } from "../../lib/viewer";
 import { ContextMenuItem } from "../shared/ContextMenuItem";
 import { ContextMenu } from "./ContextMenu";
@@ -31,7 +32,9 @@ export const ViewerContextMenu = ({
         disabled={hit == null}
         onClick={() => {
           if (hit?.itemId?.hex != null) {
-            actions.setVisibility(hit.itemId.hex, false);
+            actions
+              .setVisibility(hit.itemId.hex, false)
+              .catch(reportError("Failed to hide part"));
           }
         }}
       />
@@ -41,7 +44,9 @@ export const ViewerContextMenu = ({
         label="Hide Selected"
         disabled={!hasSelection}
         onClick={() => {
-          actions.setVisibilitySelected(false);
+          actions
+            .setVisibilitySelected(false)
+            .catch(reportError("Failed to hide selected items"));
         }}
       />
       <ContextMenuItem
@@ -49,7 +54,9 @@ export const ViewerContextMenu = ({
         iconSize="sm"
         label="Hide All Parts"
         onClick={() => {
-          actions.setVisibilityAll(false);
+          actions
+            .setVisibilityAll(false)
+            .catch(reportError("Failed to hide all parts"));
         }}
       />
       <ContextMenuItem
@@ -59,7 +66,9 @@ export const ViewerContextMenu = ({
         disabled={hit == null}
         onClick={() => {
           if (hit?.itemId?.hex != null) {
-            actions.showOnly(hit.itemId.hex);
+            actions
+              .showOnly(hit.itemId.hex)
+              .catch(reportError("Failed to show only part"));
           }
         }}
       />
@@ -69,7 +78,9 @@ export const ViewerContextMenu = ({
         label="Show Only Selected"
         disabled={!hasSelection}
         onClick={() => {
-          actions.showOnlySelected();
+          actions
+            .showOnlySelected()
+            .catch(reportError("Failed to show only selected items"));
         }}
       />
       <ContextMenuItem
@@ -77,7 +88,9 @@ export const ViewerContextMenu = ({
         iconSize="sm"
         label="Show All Parts"
         onClick={() => {
-          actions.setVisibilityAll(true);
+          actions
+            .setVisibilityAll(true)
+            .catch(reportError("Failed to show all parts"));
         }}
       />
       <Divider />
@@ -88,7 +101,9 @@ export const ViewerContextMenu = ({
         disabled={hit == null}
         onClick={() => {
           if (hit?.itemId?.hex != null) {
-            actions.fit(hit.itemId.hex);
+            actions
+              .fit(hit.itemId.hex)
+              .catch(reportError("Failed to fly to part"));
           }
         }}
       />
@@ -98,7 +113,9 @@ export const ViewerContextMenu = ({
         label="Fit Selected"
         disabled={!hasSelection}
         onClick={() => {
-          actions.fitSelected();
+          actions
+            .fitSelected()
+            .catch(reportError("Failed to fit selected items"));
         }}
       />
     </ContextMenu>

--- a/src/lib/hooks/use-user.ts
+++ b/src/lib/hooks/use-user.ts
@@ -2,6 +2,8 @@ import Router from "next/router";
 import { useEffect } from "react";
 import useSWR from "swr";
 
+import { reportError } from "../report-error";
+
 interface UseUserResponse {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly user: any;
@@ -30,7 +32,7 @@ export default function useUser({
       // If redirectIfFound is also set, redirect if the user was found
       (redirectIfFound && user?.isLoggedIn)
     ) {
-      Router.push(redirectTo);
+      Router.push(redirectTo).catch(reportError("Failed to redirect"));
     }
   }, [user, redirectIfFound, redirectTo]);
 

--- a/src/lib/model-views.ts
+++ b/src/lib/model-views.ts
@@ -6,6 +6,7 @@ import {
 } from "@vertexvis/viewer";
 import React from "react";
 
+import { reportError } from "./report-error";
 import { ViewerState } from "./viewer";
 
 export interface UseModelViewsProps {
@@ -74,7 +75,9 @@ export function useModelViews({
       modelViewCursor == null
     ) {
       setLoadedSceneItemId(itemId);
-      actions.fetchNextModelViews(itemId);
+      actions
+        .fetchNextModelViews(itemId)
+        .catch(reportError("Failed to load model views"));
     }
   }, [actions, itemId, modelViewResponses, modelViewCursor]);
 
@@ -89,7 +92,9 @@ export function useModelViews({
       annotationResponses.length === 0 &&
       annotationCursor == null
     ) {
-      actions.fetchNextAnnotations(loadedModelViewId);
+      actions
+        .fetchNextAnnotations(loadedModelViewId)
+        .catch(reportError("Failed to load PMI annotations"));
     }
   }, [actions, loadedModelViewId, annotationResponses, annotationCursor]);
 

--- a/src/lib/report-error.ts
+++ b/src/lib/report-error.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns a rejection handler that logs the error with a short context
+ * message. Intended for fire-and-forget promises (background viewer
+ * operations, navigation, clipboard writes) that have no natural
+ * user-visible error sink.
+ */
+export function reportError(context: string): (error: unknown) => void {
+  return (error: unknown): void => {
+    console.error(`${context}:`, error);
+  };
+}

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -3,6 +3,8 @@ import { SceneItemQueryExecutor } from "@vertexvis/viewer/dist/types/lib/scenes/
 import { defineCustomElements } from "@vertexvis/viewer/loader";
 import React from "react";
 
+import { reportError } from "./report-error";
+
 export interface ViewerState {
   readonly ref: React.MutableRefObject<HTMLVertexViewerElement | null>;
   readonly isReady: boolean;
@@ -19,7 +21,9 @@ export function useViewer(): ViewerState {
   });
 
   React.useEffect(() => {
-    defineCustomElements().then(() => setIsReady(true));
+    defineCustomElements()
+      .then(() => setIsReady(true))
+      .catch(reportError("Failed to initialize the Vertex viewer"));
   }, []);
 
   return { ref: viewerRef, isReady, actions };

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -33,6 +33,7 @@ import {
 } from "../../lib/file-collections";
 import { FileJobRes } from "../../lib/file-jobs";
 import { File, FileDownloadUrlRes } from "../../lib/files";
+import { reportError } from "../../lib/report-error";
 import { getClientFromSession, makeCall } from "../../lib/vertex-api";
 import {
   CommonProps,
@@ -445,7 +446,9 @@ export default function FileCollectionDetails({
   React.useEffect(() => {
     const controller = new AbortController();
 
-    loadReadiness(controller.signal);
+    loadReadiness(controller.signal).catch(
+      reportError("Failed to check export availability")
+    );
 
     return () => controller.abort();
   }, [loadReadiness]);
@@ -681,9 +684,21 @@ export default function FileCollectionDetails({
                 exportError={currentExportError}
                 exportInFlight={exportInFlight}
                 jobStatus={currentJobStatus}
-                onDownloadArchive={handleDownloadArchive}
-                onExport={handleExport}
-                onRefreshReadiness={handleRefreshReadiness}
+                onDownloadArchive={() => {
+                  handleDownloadArchive().catch(
+                    reportError("Failed to download the archive")
+                  );
+                }}
+                onExport={() => {
+                  handleExport().catch(
+                    reportError("Failed to export the file collection")
+                  );
+                }}
+                onRefreshReadiness={() => {
+                  handleRefreshReadiness().catch(
+                    reportError("Failed to refresh export availability")
+                  );
+                }}
                 onRetry={handleRetry}
                 readinessCheckInFlight={readinessCheckInFlight}
                 readinessLoading={readinessLoading}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -119,7 +119,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     if (res.status === 401) {
       setError("Invalid credentials.");
       setLoading(false);
-    } else if (res.status === 200) router.push("/");
+    } else if (res.status === 200) await router.push("/");
   }
 
   const predefinedEnv =
@@ -449,7 +449,12 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
               <Button
                 sx={{ mt: 2 }}
                 variant="outlined"
-                onClick={handleSubmit}
+                onClick={() => {
+                  handleSubmit().catch(() => {
+                    setError("Could not sign in.");
+                    setLoading(false);
+                  });
+                }}
                 disabled={
                   loading || (env === "custom" && !customConfigurationValidated)
                 }
@@ -464,7 +469,12 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
           <Button
             sx={{ mt: 2 }}
             variant="outlined"
-            onClick={handleSubmit}
+            onClick={() => {
+              handleSubmit().catch(() => {
+                setError("Could not sign in.");
+                setLoading(false);
+              });
+            }}
             disabled={
               loading || (env === "custom" && !customConfigurationValidated)
             }

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -18,6 +18,7 @@ import { ErrorRes, GetRes } from "../../lib/api";
 import { head, StreamCredentials } from "../../lib/config";
 import { Metadata, toMetadataFromItem } from "../../lib/metadata";
 import { useModelViews } from "../../lib/model-views";
+import { reportError } from "../../lib/report-error";
 import { applySceneViewState, selectByHit } from "../../lib/scene-items";
 import { useViewer } from "../../lib/viewer";
 import {
@@ -130,7 +131,14 @@ export default function SceneViewer({
   }
 
   function handleViewStateSelected(id: string): void {
-    applySceneViewState({ id, viewer: viewerState.ref.current });
+    applySceneViewState({ id, viewer: viewerState.ref.current }).catch(
+      reportError("Failed to apply the scene view state")
+    );
+  }
+
+  async function handleSceneReady(): Promise<void> {
+    const scene = await viewerState.ref.current?.scene();
+    if (scene) setViewId(scene.sceneViewId);
   }
 
   React.useEffect(() => {
@@ -173,17 +181,24 @@ export default function SceneViewer({
             onSelect={handleSelect}
             viewerState={viewerState}
             viewerId={ViewerId}
-            onViewStateCreated={mutate}
+            onViewStateCreated={() => {
+              mutate().catch(
+                reportError("Failed to refresh scene view states")
+              );
+            }}
             networkConfig={networkConfig}
             featureLines={featureLines}
             rotateAroundTapPoint={true}
-            onSceneReady={async () => {
-              const scene = await viewerState.ref.current?.scene();
-              if (scene) setViewId(scene.sceneViewId);
+            onSceneReady={() => {
+              handleSceneReady().catch(
+                reportError("Failed to prepare the scene view")
+              );
             }}
             onViewReset={() => {
               setSelectedItemId(undefined);
-              modelViews.actions.unloadModelView();
+              modelViews.actions
+                .unloadModelView()
+                .catch(reportError("Failed to unload the model view"));
             }}
           />
         )


### PR DESCRIPTION
Part 4/6 of the PLAT-9101 ESLint-tightening stack · base: `PLAT-9105_eslint_stack_3_let_ban`

## What
Enables type-aware linting (`parserOptions.projectService`) with `@typescript-eslint/no-floating-promises` and `no-misused-promises` as errors, and semantically resolves all 78 findings (46 floating + 32 misused) across 27 files. Every fix awaits, returns, or attaches real rejection handling — zero `void`-escapes, zero disables:
- Async JSX handlers wrapped (`onClick={() => { handleX().catch(handler); }}`), routed to existing per-component error state where present (login, property-key-policy and file-collection deletes, create dialogs).
- `useEffect` loaders keep effects sync with `.catch()` on the kickoff; `router.push` awaited in async flows / `.catch(reportError)` in sync handlers; SWR `mutate()` awaited where results matter, `.catch(reportError(...))` for background revalidation (so a failed refresh after a successful delete no longer misreports as a failed delete); clipboard writes handled.
- New `src/lib/report-error.ts` — small shared `reportError(context)` rejection handler for sites without a natural error sink.

## Config delta
Add the typed-rules block (`projectService`, `no-floating-promises`, `no-misused-promises`). `await-thenable` follows in part 5/6.

## Why green independently
Exactly the 78 findings existed under this config; all resolved. `eslint . --max-warnings=0` exits 0.

## Validation
lint · format:check · typecheck · test (151) · build — all green.

## Possible regressions
Failures that were previously unhandled rejections now surface via existing error state or `console.error`; success paths unchanged (behavior parity independently reviewed on the reference PR).

## Related
[PLAT-9106](https://vertexvis.atlassian.net/browse/PLAT-9106) (parent [PLAT-9101](https://vertexvis.atlassian.net/browse/PLAT-9101)) · reference #370

[PLAT-9106]: https://vertexvis.atlassian.net/browse/PLAT-9106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ