### PR TITLE
[PLAT-9107] - Enable react-hooks immutability and await-thenable rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,6 +78,13 @@ const config = [
       'simple-import-sort/exports': 'error',
     },
   },
+  // React source files: react-hooks/immutability (v6 compiler-backed rule).
+  {
+    files: ['src/**/*.{ts,tsx}'],
+    rules: {
+      'react-hooks/immutability': 'error',
+    },
+  },
   // Production .tsx: prohibit `let`. Tests and all .ts files are exempt.
   {
     files: ['src/**/*.tsx'],
@@ -106,6 +113,7 @@ const config = [
     rules: {
       '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
     },
   },
   // Testing Library rules for test files.

--- a/src/__tests__/pages/scene-viewer/sceneId.test.ts
+++ b/src/__tests__/pages/scene-viewer/sceneId.test.ts
@@ -9,8 +9,8 @@ import {
 import { serverSidePropsHandler } from "../../../pages/scene-viewer/[sceneId]";
 
 describe("scene viewer route", () => {
-  it("does not create a stream key while serving a scene route", async () => {
-    const result = await serverSidePropsHandler({
+  it("does not create a stream key while serving a scene route", () => {
+    const result = serverSidePropsHandler({
       query: { sceneId: "scene-1" },
       req: createReq(),
     });
@@ -24,8 +24,8 @@ describe("scene viewer route", () => {
     });
   });
 
-  it("does not mutate when a supplied stream key is present", async () => {
-    const result = await serverSidePropsHandler({
+  it("does not mutate when a supplied stream key is present", () => {
+    const result = serverSidePropsHandler({
       query: { sceneId: "scene-1", streamKey: "provided-key" },
       req: createReq(),
     });

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -89,13 +89,13 @@ function UnwrappedViewer({
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
   const router = useRouter();
 
-  useHotkeys("s", () => handleShortcutS(), { keyup: true });
-
   function handleShortcutS(): void {
     if (ref?.current == null) return;
 
     ref.current.focus();
   }
+
+  useHotkeys("s", () => handleShortcutS(), { keyup: true });
 
   function handleClose(): void {
     setKey(Date.now());


### PR DESCRIPTION
Part 5/6 of the PLAT-9101 ESLint-tightening stack · base: `PLAT-9106_eslint_stack_4_async_safety`

## What
Enables the last two staged rules; the ESLint config reaches its final form at this layer (byte-identical to reference #370's):
- `react-hooks/immutability` (compiler-backed rule from eslint-plugin-react-hooks 6.1.1) as error for `src/**/*.{ts,tsx}` — fixes the one finding: `handleShortcutS` in `Viewer.tsx` was referenced by `useHotkeys` before its declaration.
- `@typescript-eslint/await-thenable` as error — removes 2 spurious awaits of the synchronous `serverSidePropsHandler` in `sceneId.test.ts` (assertions unchanged).

## Config delta
Add the `await-thenable` rule line + the immutability block. Config now final.

## Why green independently
Exactly the 3 findings existed under this config; all fixed. `eslint . --max-warnings=0` exits 0.

## Validation
lint · format:check · typecheck · test (151) · build — all green.

## Related
[PLAT-9107](https://vertexvis.atlassian.net/browse/PLAT-9107) (parent [PLAT-9101](https://vertexvis.atlassian.net/browse/PLAT-9101)) · reference #370

[PLAT-9107]: https://vertexvis.atlassian.net/browse/PLAT-9107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-9101]: https://vertexvis.atlassian.net/browse/PLAT-9101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ