### PR TITLE
[PLAT-9108] - Upgrade to Prettier 3 and reformat repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lefthook": "^2.1.10",
     "msw": "^2.15.0",
     "playwright": "^1.61.1",
-    "prettier": "^2.4",
+    "prettier": "^3.9.6",
     "testcontainers": "10.28.0",
     "ts-jest": "^29.4.11",
     "tslib": "^2.3",

--- a/scripts/format-staged.ts
+++ b/scripts/format-staged.ts
@@ -10,7 +10,8 @@ import * as fs from "fs";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
-const prettier: string = require.resolve("prettier/bin-prettier.js");
+// Prettier 3 renamed its CLI entry from bin-prettier.js to bin/prettier.cjs.
+const prettier: string = require.resolve("prettier/bin/prettier.cjs");
 
 type Mode = "write" | "check";
 
@@ -31,15 +32,15 @@ const supportedExtensions = new Set<string>([
 
 function git(
   args: string[],
-  options: SpawnSyncOptionsWithStringEncoding
+  options: SpawnSyncOptionsWithStringEncoding,
 ): SpawnSyncReturns<string>;
 function git(
   args: string[],
-  options?: SpawnSyncOptions
+  options?: SpawnSyncOptions,
 ): SpawnSyncReturns<Buffer>;
 function git(
   args: string[],
-  options: SpawnSyncOptions = {}
+  options: SpawnSyncOptions = {},
 ): SpawnSyncReturns<string | Buffer> {
   const result = spawnSync("git", args, options);
 
@@ -55,7 +56,7 @@ function git(
 function stagedFiles(): string[] {
   const result = git(
     ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
-    { encoding: "utf8" }
+    { encoding: "utf8" },
   );
 
   if (result.status !== 0) {
@@ -100,7 +101,7 @@ function isRegularFile(file: string): boolean {
 
 function formatBlob(
   file: string,
-  input: string | Buffer
+  input: string | Buffer,
 ): SpawnSyncReturns<Buffer> {
   return spawnSync(process.execPath, [prettier, "--stdin-filepath", file], {
     input,

--- a/scripts/playwright_login.ts
+++ b/scripts/playwright_login.ts
@@ -8,7 +8,7 @@ function readRequiredEnv(names: string[]): string[] {
   const missing = names.filter((name) => !process.env[name]);
   if (missing.length > 0) {
     throw new Error(
-      `Missing required environment variable(s): ${missing.join(", ")}`
+      `Missing required environment variable(s): ${missing.join(", ")}`,
     );
   }
 
@@ -21,7 +21,7 @@ function readCustomNetworkHosts(): { apiHost: string; renderingHost: string } {
 
   if (!apiHost || !renderingHost) {
     throw new Error(
-      "DEV_ENVIRONMENT=custom requires DEV_API_HOST and DEV_RENDERING_HOST to be set."
+      "DEV_ENVIRONMENT=custom requires DEV_API_HOST and DEV_RENDERING_HOST to be set.",
     );
   }
 
@@ -30,7 +30,7 @@ function readCustomNetworkHosts(): { apiHost: string; renderingHost: string } {
 
 function parseBoolean(
   value: string | undefined,
-  defaultValue: boolean
+  defaultValue: boolean,
 ): boolean {
   if (value == null) return defaultValue;
 
@@ -38,7 +38,7 @@ function parseBoolean(
   if (["0", "false", "no"].includes(value.toLowerCase())) return false;
 
   throw new Error(
-    `Expected PLAYWRIGHT_VISIBLE to be true or false; received ${value}`
+    `Expected PLAYWRIGHT_VISIBLE to be true or false; received ${value}`,
   );
 }
 
@@ -48,15 +48,15 @@ const [username, credential] = readRequiredEnv([
 ]);
 
 const baseUrl = new URL(
-  process.env.DEV_DASHBOARD_URL ?? "http://localhost:3000"
+  process.env.DEV_DASHBOARD_URL ?? "http://localhost:3000",
 );
 const destination = new URL(
   process.env.DEV_DASHBOARD_PATH ?? "/",
-  baseUrl
+  baseUrl,
 ).toString();
 const loginUrl = new URL("/login", baseUrl).toString();
 const storageStatePath = path.resolve(
-  process.env.PLAYWRIGHT_STORAGE_STATE ?? "playwright/.auth/dev-dashboard.json"
+  process.env.PLAYWRIGHT_STORAGE_STATE ?? "playwright/.auth/dev-dashboard.json",
 );
 const visible = parseBoolean(process.env.PLAYWRIGHT_VISIBLE, false);
 const environment = process.env.DEV_ENVIRONMENT ?? "platdev";
@@ -104,7 +104,7 @@ async function loginAndSaveState(browser: Browser): Promise<void> {
 }
 
 async function openAuthenticatedDashboard(
-  browser: Browser
+  browser: Browser,
 ): Promise<BrowserContext> {
   const context = await browser.newContext({ storageState: storageStatePath });
   const page = await context.newPage();
@@ -115,14 +115,14 @@ async function openAuthenticatedDashboard(
   if (new URL(page.url()).pathname.endsWith("/login")) {
     await context.close();
     throw new Error(
-      "Saved authentication state was not accepted by the dashboard."
+      "Saved authentication state was not accepted by the dashboard.",
     );
   }
 
   if (response != null && !response.ok()) {
     await context.close();
     throw new Error(
-      `Dashboard responded with HTTP ${response.status()} for ${destination}.`
+      `Dashboard responded with HTTP ${response.status()} for ${destination}.`,
     );
   }
 

--- a/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionFilesTable.test.tsx
@@ -26,7 +26,7 @@ describe("FileCollectionFilesTable", () => {
       const url = new URL(request.url);
 
       expect(request.url).toBe(
-        `http://localhost${collectionFilesApiPath}?pageSize=${DefaultPageSize}`
+        `http://localhost${collectionFilesApiPath}?pageSize=${DefaultPageSize}`,
       );
       expect(url.searchParams.get("pageSize")).toBe(DefaultPageSize.toString());
       expect(url.searchParams.get("cursor")).toBeNull();
@@ -41,7 +41,7 @@ describe("FileCollectionFilesTable", () => {
             created: "2026-06-12T15:30:00Z",
             uploaded: "2026-06-12T15:31:00Z",
           }),
-        ])
+        ]),
       );
     });
     const createDownloadUrl = jest.fn(({ params }) => {
@@ -67,26 +67,26 @@ describe("FileCollectionFilesTable", () => {
     expect(listCollectionFiles).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Name")).not.toHaveAttribute("role", "button");
     expect(
-      screen.queryByLabelText("Supplied ID Filter (exact)")
+      screen.queryByLabelText("Supplied ID Filter (exact)"),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "New" })
+      screen.queryByRole("button", { name: "New" }),
     ).not.toBeInTheDocument();
     expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Select File One")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Delete")).not.toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "Name" })).not.toHaveClass(
-      "MuiTableCell-paddingNone"
+      "MuiTableCell-paddingNone",
     );
     expect(screen.getByText("File One").closest("th")).not.toHaveClass(
-      "MuiTableCell-paddingNone"
+      "MuiTableCell-paddingNone",
     );
 
     const name = screen.getByLabelText("Download File One");
     await userEvent.hover(name);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Download File One"
+      "Download File One",
     );
 
     expect(name).toHaveAttribute("href", "/api/files/file-1/download");
@@ -104,10 +104,10 @@ describe("FileCollectionFilesTable", () => {
     });
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Actions for File One" })
+      screen.getByRole("button", { name: "Actions for File One" }),
     );
     await userEvent.click(
-      screen.getByRole("menuitem", { name: "Download file" })
+      screen.getByRole("menuitem", { name: "Download file" }),
     );
 
     await waitFor(() => {
@@ -116,7 +116,7 @@ describe("FileCollectionFilesTable", () => {
     expect(window.open).toHaveBeenLastCalledWith(
       downloadUrlById["file-1"],
       "_blank",
-      "noopener"
+      "noopener",
     );
   });
 
@@ -143,10 +143,10 @@ describe("FileCollectionFilesTable", () => {
     expect(screen.getByText("pending")).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Actions for File One" })
+      screen.getByRole("button", { name: "Actions for File One" }),
     );
     expect(
-      screen.getByRole("menuitem", { name: "Download file" })
+      screen.getByRole("menuitem", { name: "Download file" }),
     ).toHaveAttribute("aria-disabled", "true");
     expect(createDownloadUrl).not.toHaveBeenCalled();
   });
@@ -169,7 +169,7 @@ describe("FileCollectionFilesTable", () => {
 
     const statusLabel = await screen.findByText("ready");
     expect(statusLabel.closest(".MuiChip-root")).toHaveClass(
-      "MuiChip-colorDefault"
+      "MuiChip-colorDefault",
     );
   });
 
@@ -196,10 +196,10 @@ describe("FileCollectionFilesTable", () => {
     expect(await screen.findByText("completed")).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Actions for File One" })
+      screen.getByRole("button", { name: "Actions for File One" }),
     );
     expect(
-      screen.getByRole("menuitem", { name: "Download file" })
+      screen.getByRole("menuitem", { name: "Download file" }),
     ).toHaveAttribute("aria-disabled", "true");
     expect(createDownloadUrl).not.toHaveBeenCalled();
     expect(window.open).not.toHaveBeenCalled();
@@ -222,14 +222,14 @@ describe("FileCollectionFilesTable", () => {
           message: "Could not load collection files.",
           status: 500,
         },
-        { status: 500 }
+        { status: 500 },
       ),
     });
 
     renderTable();
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Error loading data."
+      "Error loading data.",
     );
   });
 });
@@ -239,7 +239,7 @@ function renderTable(onFileSelected = jest.fn()): void {
     <FileCollectionFilesTable
       apiPath={collectionFilesApiPath}
       onFileSelected={onFileSelected}
-    />
+    />,
   );
 }
 
@@ -254,7 +254,7 @@ function mockFileCollectionFilesApi({
   createDownloadUrl = jest.fn(({ params }) =>
     HttpResponse.json({
       url: `https://example.test/download/${params.id as string}`,
-    })
+    }),
   ),
   files = [
     fileResource({
@@ -275,7 +275,9 @@ function mockFileCollectionFilesApi({
 
       return listCollectionFiles(info);
     }),
-    http.post("*/api/files/:id/download-url", (info) => createDownloadUrl(info))
+    http.post("*/api/files/:id/download-url", (info) =>
+      createDownloadUrl(info),
+    ),
   );
 }
 

--- a/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
+++ b/src/__tests__/components/file-collection/FileCollectionTable.test.tsx
@@ -71,9 +71,9 @@ describe("FileCollectionTable", () => {
         return HttpResponse.json(
           url.searchParams.get("cursor") === "page-2"
             ? nextPage
-            : firstPageWithNextCursor
+            : firstPageWithNextCursor,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -90,7 +90,7 @@ describe("FileCollectionTable", () => {
         return (
           params.get("cursor") === "page-2" && params.get("pageSize") === "25"
         );
-      })
+      }),
     ).toBe(true);
   });
 
@@ -101,7 +101,7 @@ describe("FileCollectionTable", () => {
       http.get("*/api/file-collections", ({ request }) => {
         requests.push(new URL(request.url).search);
         return HttpResponse.json(firstPage);
-      })
+      }),
     );
 
     renderTable();
@@ -111,7 +111,7 @@ describe("FileCollectionTable", () => {
       requests.some((search) => {
         const params = new URLSearchParams(search);
         return params.get("pageSize") === "25" && !params.has("sort");
-      })
+      }),
     ).toBe(true);
   });
 
@@ -123,9 +123,9 @@ describe("FileCollectionTable", () => {
         const url = new URL(request.url);
         requests.push(url.search);
         return HttpResponse.json(
-          url.searchParams.get("sort") === "name" ? nextPage : firstPage
+          url.searchParams.get("sort") === "name" ? nextPage : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -136,16 +136,16 @@ describe("FileCollectionTable", () => {
     expect(await screen.findByText("Collection Two")).toBeInTheDocument();
     expect(
       requests.some(
-        (search) => new URLSearchParams(search).get("sort") === "name"
-      )
+        (search) => new URLSearchParams(search).get("sort") === "name",
+      ),
     ).toBe(true);
 
     await userEvent.click(screen.getByRole("button", { name: "Name" }));
     expect(await screen.findByText("Collection One")).toBeInTheDocument();
     expect(
       requests.some(
-        (search) => new URLSearchParams(search).get("sort") === "-name"
-      )
+        (search) => new URLSearchParams(search).get("sort") === "-name",
+      ),
     ).toBe(true);
   });
 
@@ -159,9 +159,9 @@ describe("FileCollectionTable", () => {
         return HttpResponse.json(
           url.searchParams.get("cursor") === "page-2"
             ? nextPage
-            : firstPageWithNextCursor
+            : firstPageWithNextCursor,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -177,7 +177,7 @@ describe("FileCollectionTable", () => {
       requests.some((search) => {
         const params = new URLSearchParams(search);
         return params.get("sort") === "created" && !params.has("cursor");
-      })
+      }),
     ).toBe(true);
   });
 
@@ -193,7 +193,7 @@ describe("FileCollectionTable", () => {
         deletedIds.push(body.ids ?? []);
 
         return HttpResponse.json({ status: 200 });
-      })
+      }),
     );
 
     renderTable();
@@ -209,7 +209,7 @@ describe("FileCollectionTable", () => {
     expect(screen.queryByText("1 selected")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Select Collection One")).not.toBeChecked();
     expect(
-      screen.queryByText("Could not delete collection-1.")
+      screen.queryByText("Could not delete collection-1."),
     ).not.toBeInTheDocument();
   });
 
@@ -224,9 +224,9 @@ describe("FileCollectionTable", () => {
         return HttpResponse.json(
           url.searchParams.get("suppliedId") === "supplied-2"
             ? nextPage
-            : firstPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -244,7 +244,7 @@ describe("FileCollectionTable", () => {
           params.get("pageSize") === "25" &&
           params.get("suppliedId") === "supplied-2"
         );
-      })
+      }),
     ).toBe(true);
   });
 
@@ -252,7 +252,7 @@ describe("FileCollectionTable", () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(multiCollectionPage);
-      })
+      }),
     );
 
     renderTable();
@@ -288,9 +288,9 @@ describe("FileCollectionTable", () => {
 
         return HttpResponse.json(
           { message: "Could not delete collection-1." },
-          { status: 500 }
+          { status: 500 },
         );
-      })
+      }),
     );
 
     renderTable();
@@ -301,7 +301,7 @@ describe("FileCollectionTable", () => {
     await userEvent.click(screen.getByLabelText("Delete"));
 
     expect(
-      await screen.findByText("Could not delete collection-1.")
+      await screen.findByText("Could not delete collection-1."),
     ).toBeInTheDocument();
     expect(screen.getByText("1 selected")).toBeInTheDocument();
     expect(screen.getByLabelText("Select Collection One")).toBeChecked();
@@ -317,9 +317,11 @@ describe("FileCollectionTable", () => {
         requests.push(url.search);
 
         return HttpResponse.json(
-          url.searchParams.get("suppliedId") === "LIED-2" ? nextPage : firstPage
+          url.searchParams.get("suppliedId") === "LIED-2"
+            ? nextPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -338,7 +340,7 @@ describe("FileCollectionTable", () => {
           params.get("pageSize") === "25" &&
           params.get("suppliedId") === "LIED-2"
         );
-      })
+      }),
     ).toBe(true);
   });
 
@@ -354,9 +356,9 @@ describe("FileCollectionTable", () => {
           url.searchParams.get("name") === "Collection" &&
             url.searchParams.get("suppliedId") === "2"
             ? nextPage
-            : firstPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -375,7 +377,7 @@ describe("FileCollectionTable", () => {
           params.get("name") === "Collection" &&
           params.get("suppliedId") === "2"
         );
-      })
+      }),
     ).toBe(true);
   });
 
@@ -387,9 +389,9 @@ describe("FileCollectionTable", () => {
         return HttpResponse.json(
           url.searchParams.get("name") === "missing"
             ? emptyCollectionPage
-            : firstPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -399,7 +401,7 @@ describe("FileCollectionTable", () => {
     await userEvent.type(screen.getByLabelText("Name"), "missing");
 
     expect(
-      await screen.findByText("No file collections found.")
+      await screen.findByText("No file collections found."),
     ).toBeInTheDocument();
   });
 
@@ -415,9 +417,9 @@ describe("FileCollectionTable", () => {
           url.searchParams.has("createdAtStart") &&
             url.searchParams.has("createdAtEnd")
             ? nextPage
-            : firstPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -437,7 +439,7 @@ describe("FileCollectionTable", () => {
       requests.some((search) => {
         const params = new URLSearchParams(search);
         return params.has("createdAtStart") && params.has("createdAtEnd");
-      })
+      }),
     ).toBe(true);
   });
 
@@ -445,7 +447,7 @@ describe("FileCollectionTable", () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(firstPage);
-      })
+      }),
     );
 
     renderTable();
@@ -462,7 +464,7 @@ describe("FileCollectionTable", () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(firstPage);
-      })
+      }),
     );
 
     renderTable();
@@ -480,9 +482,9 @@ describe("FileCollectionTable", () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(
-          fileCollectionsPage({ cursors: { self: "page-1" }, data: [] })
+          fileCollectionsPage({ cursors: { self: "page-1" }, data: [] }),
         );
-      })
+      }),
     );
 
     renderTable();
@@ -490,7 +492,7 @@ describe("FileCollectionTable", () => {
     await userEvent.click(screen.getByRole("button", { name: "Name" }));
 
     expect(
-      await screen.findByText("No file collections found.")
+      await screen.findByText("No file collections found."),
     ).toBeInTheDocument();
   });
 
@@ -498,7 +500,7 @@ describe("FileCollectionTable", () => {
     server.use(
       http.get("*/api/file-collections", () => {
         return HttpResponse.json(firstPage);
-      })
+      }),
     );
 
     renderTable();
@@ -507,7 +509,7 @@ describe("FileCollectionTable", () => {
 
     expect(screen.getByLabelText("Open Collection One")).toHaveAttribute(
       "href",
-      "/file-collections/collection-1"
+      "/file-collections/collection-1",
     );
   });
 });

--- a/src/__tests__/components/file/FileTable.test.tsx
+++ b/src/__tests__/components/file/FileTable.test.tsx
@@ -56,14 +56,14 @@ describe("FileTable", () => {
       http.get("*/api/files", ({ request }) => {
         requests.push(request.url);
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
 
     expect(await screen.findByText("alpha.jt")).toBeInTheDocument();
     expect(requests).toContain(
-      "http://localhost/api/files?pageSize=25&sort=-created"
+      "http://localhost/api/files?pageSize=25&sort=-created",
     );
   });
 
@@ -71,14 +71,14 @@ describe("FileTable", () => {
     server.use(
       http.get("*/api/files", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
 
     expect(await screen.findByLabelText("Download alpha.jt")).toHaveAttribute(
       "href",
-      "/api/files/file-1/download"
+      "/api/files/file-1/download",
     );
   });
 
@@ -89,7 +89,7 @@ describe("FileTable", () => {
       http.get("*/api/files", ({ request }) => {
         requests.push(request.url);
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
@@ -99,14 +99,14 @@ describe("FileTable", () => {
     await userEvent.click(getNameSortButton());
     await waitFor(() => {
       expect(requests).toContain(
-        "http://localhost/api/files?pageSize=25&sort=name"
+        "http://localhost/api/files?pageSize=25&sort=name",
       );
     });
 
     await userEvent.click(getNameSortButton());
     await waitFor(() => {
       expect(requests).toContain(
-        "http://localhost/api/files?pageSize=25&sort=-name"
+        "http://localhost/api/files?pageSize=25&sort=-name",
       );
     });
   });
@@ -126,9 +126,9 @@ describe("FileTable", () => {
         }
 
         return HttpResponse.json(
-          url.searchParams.get("sort") === "name" ? page : pagedPage
+          url.searchParams.get("sort") === "name" ? page : pagedPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -148,7 +148,7 @@ describe("FileTable", () => {
     server.use(
       http.get("*/api/files", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
@@ -171,7 +171,7 @@ describe("FileTable", () => {
     server.use(
       http.get("*/api/files", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
@@ -188,7 +188,7 @@ describe("FileTable", () => {
     server.use(
       http.get("*/api/files", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable();
@@ -210,7 +210,7 @@ describe("FileTable", () => {
 
 function renderTable(
   onFileSelected = jest.fn(),
-  props: Partial<React.ComponentProps<typeof FileTable>> = {}
+  props: Partial<React.ComponentProps<typeof FileTable>> = {},
 ): void {
   renderWithSWR(<FileTable onFileSelected={onFileSelected} {...props} />);
 }

--- a/src/__tests__/components/property-key-policy/CreatePropertyKeyPolicyDialog.test.tsx
+++ b/src/__tests__/components/property-key-policy/CreatePropertyKeyPolicyDialog.test.tsx
@@ -29,7 +29,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
 
     await userEvent.type(
       screen.getByLabelText("Property key 1"),
-      "Alpha{Enter}"
+      "Alpha{Enter}",
     );
 
     const secondField = screen.getByLabelText("Property key 2");
@@ -43,11 +43,11 @@ describe("CreatePropertyKeyPolicyDialog", () => {
 
     await userEvent.type(
       screen.getByLabelText("Property key 1"),
-      "Alpha{Enter}"
+      "Alpha{Enter}",
     );
     await userEvent.type(
       screen.getByLabelText("Property key 2"),
-      "Alpha{Enter}"
+      "Alpha{Enter}",
     );
 
     // Both fields are flagged as duplicates via the per-field error.
@@ -64,7 +64,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
     await userEvent.type(screen.getByLabelText("Property key 1"), "   ");
 
     expect(
-      screen.getByText("Property key cannot be blank.")
+      screen.getByText("Property key cannot be blank."),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
   });
@@ -75,7 +75,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
     await userEvent.type(screen.getByLabelText(/Name/), "My Policy");
     await userEvent.type(
       screen.getByLabelText("Property key 1"),
-      "Alpha{Enter}"
+      "Alpha{Enter}",
     );
     await userEvent.type(screen.getByLabelText("Property key 2"), "Alpha");
 
@@ -88,7 +88,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
     await userEvent.type(screen.getByLabelText("Property key 2"), "Beta");
 
     expect(
-      screen.queryByText("Duplicate property key.")
+      screen.queryByText("Duplicate property key."),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
   });
@@ -109,9 +109,9 @@ describe("CreatePropertyKeyPolicyDialog", () => {
         bodies.push((await request.json()) as Record<string, unknown>);
         return HttpResponse.json(
           propertyKeyPolicyRes(propertyKeyPolicy({ id: "policy-1" })),
-          { status: 201 }
+          { status: 201 },
         );
-      })
+      }),
     );
 
     const onCreated = jest.fn();
@@ -122,7 +122,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
     await userEvent.click(screen.getByRole("radio", { name: "Deny" }));
     await userEvent.type(
       screen.getByLabelText("Property key 1"),
-      "MixedCase_Key"
+      "MixedCase_Key",
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Create" }));
@@ -142,9 +142,9 @@ describe("CreatePropertyKeyPolicyDialog", () => {
       http.post("*/api/property-key-policies", () =>
         HttpResponse.json(
           { message: "Name already in use.", status: 400 },
-          { status: 400 }
-        )
-      )
+          { status: 400 },
+        ),
+      ),
     );
 
     const onCreated = jest.fn();
@@ -169,9 +169,9 @@ describe("CreatePropertyKeyPolicyDialog", () => {
             keysError: "Keys upsert failed.",
             status: 201,
           },
-          { status: 201 }
-        )
-      )
+          { status: 201 },
+        ),
+      ),
     );
 
     const onCreated = jest.fn();
@@ -192,7 +192,7 @@ describe("CreatePropertyKeyPolicyDialog", () => {
   describe("when fetch rejects (network error)", () => {
     it("shows the generic API error and keeps Create enabled", async () => {
       server.use(
-        http.post("*/api/property-key-policies", () => HttpResponse.error())
+        http.post("*/api/property-key-policies", () => HttpResponse.error()),
       );
 
       const onCreated = jest.fn();
@@ -204,16 +204,16 @@ describe("CreatePropertyKeyPolicyDialog", () => {
       await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
       expect(
-        await screen.findByText("Could not create the property key policy.")
+        await screen.findByText("Could not create the property key policy."),
       ).toBeInTheDocument();
       // onCreated must not be called — nothing was processed server-side.
       expect(onCreated).not.toHaveBeenCalled();
       // Dialog must stay in the normal state: Cancel + Create (not Close-only).
       expect(
-        screen.getByRole("button", { name: "Create" })
+        screen.getByRole("button", { name: "Create" }),
       ).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: "Close" })
+        screen.queryByRole("button", { name: "Close" }),
       ).not.toBeInTheDocument();
     });
   });
@@ -227,8 +227,8 @@ describe("CreatePropertyKeyPolicyDialog", () => {
             new HttpResponse("not json", {
               headers: { "Content-Type": "application/json" },
               status: 201,
-            })
-        )
+            }),
+        ),
       );
 
       const onCreated = jest.fn();
@@ -244,13 +244,13 @@ describe("CreatePropertyKeyPolicyDialog", () => {
       // The uncertain-outcome warning must be visible.
       expect(
         await screen.findByText(
-          /The request completed but the response could not be read/
-        )
+          /The request completed but the response could not be read/,
+        ),
       ).toBeInTheDocument();
       // Dialog must show only Close — no Create button (duplicate protection).
       expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: "Create" })
+        screen.queryByRole("button", { name: "Create" }),
       ).not.toBeInTheDocument();
       // onClose must NOT have been called automatically.
       expect(onClose).not.toHaveBeenCalled();
@@ -262,13 +262,13 @@ function renderDialog(
   props: {
     readonly onClose?: () => void;
     readonly onCreated?: () => void;
-  } = {}
+  } = {},
 ): void {
   renderWithSWR(
     <CreatePropertyKeyPolicyDialog
       onClose={props.onClose ?? jest.fn()}
       onCreated={props.onCreated ?? jest.fn()}
       open
-    />
+    />,
   );
 }

--- a/src/__tests__/components/property-key-policy/PropertyKeyPolicyDetailsDrawer.test.tsx
+++ b/src/__tests__/components/property-key-policy/PropertyKeyPolicyDetailsDrawer.test.tsx
@@ -35,9 +35,9 @@ describe("PropertyKeyPolicyDetailsDrawer", () => {
               propertyKeyPolicyKey({ id: "key-1", name: "MixedCase_Key" }),
               propertyKeyPolicyKey({ id: "key-2", name: "ALLCAPS" }),
             ],
-          })
-        )
-      )
+          }),
+        ),
+      ),
     );
 
     renderDrawer();
@@ -53,12 +53,12 @@ describe("PropertyKeyPolicyDetailsDrawer", () => {
 
     // Case-sensitivity note is present.
     expect(
-      screen.getByText("Metadata property keys are case-sensitive.")
+      screen.getByText("Metadata property keys are case-sensitive."),
     ).toBeInTheDocument();
 
     // No misleading "full policy details" error appears.
     expect(
-      screen.queryByText("Could not load the full policy details.")
+      screen.queryByText("Could not load the full policy details."),
     ).not.toBeInTheDocument();
   });
 
@@ -67,9 +67,9 @@ describe("PropertyKeyPolicyDetailsDrawer", () => {
       http.get("*/api/property-key-policies/:id/keys", () =>
         HttpResponse.json(
           { message: "Could not load entries.", status: 500 },
-          { status: 500 }
-        )
-      )
+          { status: 500 },
+        ),
+      ),
     );
 
     renderDrawer();
@@ -78,7 +78,7 @@ describe("PropertyKeyPolicyDetailsDrawer", () => {
     expect(await screen.findByText("My Policy")).toBeInTheDocument();
     // The entries branch surfaces its own error.
     expect(
-      await screen.findByText("Could not load property keys.")
+      await screen.findByText("Could not load property keys."),
     ).toBeInTheDocument();
   });
 });
@@ -89,6 +89,6 @@ function renderDrawer(): void {
       onClose={jest.fn()}
       open
       propertyKeyPolicy={policy}
-    />
+    />,
   );
 }

--- a/src/__tests__/components/property-key-policy/PropertyKeyPolicyTable.test.tsx
+++ b/src/__tests__/components/property-key-policy/PropertyKeyPolicyTable.test.tsx
@@ -56,9 +56,9 @@ describe("PropertyKeyPolicyTable", () => {
                 name: "Deny Policy",
               }),
             ],
-          })
-        )
-      )
+          }),
+        ),
+      ),
     );
 
     renderTable();
@@ -72,8 +72,8 @@ describe("PropertyKeyPolicyTable", () => {
   it("links the policy name to the detail route", async () => {
     server.use(
       http.get("*/api/property-key-policies", () =>
-        HttpResponse.json(firstPage)
-      )
+        HttpResponse.json(firstPage),
+      ),
     );
 
     renderTable();
@@ -81,7 +81,7 @@ describe("PropertyKeyPolicyTable", () => {
     expect(await screen.findByText("Policy One")).toBeInTheDocument();
     expect(screen.getByLabelText("Open Policy One")).toHaveAttribute(
       "href",
-      "/property-key-policies/policy-1"
+      "/property-key-policies/policy-1",
     );
   });
 
@@ -96,9 +96,9 @@ describe("PropertyKeyPolicyTable", () => {
         return HttpResponse.json(
           url.searchParams.get("suppliedId") === "supplied-2"
             ? filteredPage
-            : firstPage
+            : firstPage,
         );
-      })
+      }),
     );
 
     renderTable();
@@ -112,8 +112,8 @@ describe("PropertyKeyPolicyTable", () => {
     expect(
       requests.some(
         (search) =>
-          new URLSearchParams(search).get("suppliedId") === "supplied-2"
-      )
+          new URLSearchParams(search).get("suppliedId") === "supplied-2",
+      ),
     ).toBe(true);
   });
 
@@ -122,13 +122,13 @@ describe("PropertyKeyPolicyTable", () => {
 
     server.use(
       http.get("*/api/property-key-policies", () =>
-        HttpResponse.json(firstPage)
+        HttpResponse.json(firstPage),
       ),
       http.delete("*/api/property-key-policies", async ({ request }) => {
         const body = (await request.json()) as { ids?: string[] };
         deletedIds.push(body.ids ?? []);
         return HttpResponse.json({ status: 200 });
-      })
+      }),
     );
 
     renderTable();
@@ -160,9 +160,9 @@ describe("PropertyKeyPolicyTable", () => {
         deletedIds.push(body.ids ?? []);
         return HttpResponse.json(
           { message: "Could not delete policy-1.", status: 500 },
-          { status: 500 }
+          { status: 500 },
         );
-      })
+      }),
     );
 
     renderTable();
@@ -174,7 +174,7 @@ describe("PropertyKeyPolicyTable", () => {
     await userEvent.click(screen.getByLabelText("Delete"));
 
     expect(
-      await screen.findByText("Could not delete policy-1.")
+      await screen.findByText("Could not delete policy-1."),
     ).toBeInTheDocument();
     // On failure the selection clears and the list is reconciled with the
     // server via a re-fetch.
@@ -203,13 +203,13 @@ describe("PropertyKeyPolicyTable", () => {
             message: "Could not delete policy-2.",
             status: 207,
           },
-          { status: 207 }
-        )
-      )
+          { status: 207 },
+        ),
+      ),
     );
 
     renderWithSWR(
-      <PropertyKeyPolicyTable onPoliciesDeleted={onPoliciesDeleted} />
+      <PropertyKeyPolicyTable onPoliciesDeleted={onPoliciesDeleted} />,
     );
 
     expect(await screen.findByText("Deleted Policy")).toBeInTheDocument();
@@ -218,7 +218,7 @@ describe("PropertyKeyPolicyTable", () => {
     await userEvent.click(screen.getByLabelText("Delete"));
 
     expect(
-      await screen.findByText("Could not delete policy-2.")
+      await screen.findByText("Could not delete policy-2."),
     ).toBeInTheDocument();
     expect(onPoliciesDeleted).toHaveBeenCalledWith(["policy-1"]);
     expect(screen.getByLabelText("Select Deleted Policy")).not.toBeChecked();
@@ -235,8 +235,8 @@ describe("PropertyKeyPolicyTable", () => {
       }),
       http.delete(
         "*/api/property-key-policies",
-        () => new HttpResponse(null, { status: 500 })
-      )
+        () => new HttpResponse(null, { status: 500 }),
+      ),
     );
 
     renderTable();
@@ -251,8 +251,8 @@ describe("PropertyKeyPolicyTable", () => {
     // component is not stuck: the list refreshes.
     expect(
       await screen.findByText(
-        "Could not delete the selected property key policies."
-      )
+        "Could not delete the selected property key policies.",
+      ),
     ).toBeInTheDocument();
     await waitFor(() => expect(getCount).toBeGreaterThan(getsBeforeDelete));
   });
@@ -262,15 +262,15 @@ describe("PropertyKeyPolicyTable", () => {
 
     server.use(
       http.get("*/api/property-key-policies", () =>
-        HttpResponse.json(firstPage)
+        HttpResponse.json(firstPage),
       ),
       http.delete("*/api/property-key-policies", () =>
-        HttpResponse.json({ status: 200 })
-      )
+        HttpResponse.json({ status: 200 }),
+      ),
     );
 
     renderWithSWR(
-      <PropertyKeyPolicyTable onPoliciesDeleted={onPoliciesDeleted} />
+      <PropertyKeyPolicyTable onPoliciesDeleted={onPoliciesDeleted} />,
     );
 
     expect(await screen.findByText("Policy One")).toBeInTheDocument();
@@ -279,7 +279,7 @@ describe("PropertyKeyPolicyTable", () => {
     await userEvent.click(screen.getByLabelText("Delete"));
 
     await waitFor(() =>
-      expect(onPoliciesDeleted).toHaveBeenCalledWith(["policy-1"])
+      expect(onPoliciesDeleted).toHaveBeenCalledWith(["policy-1"]),
     );
   });
 
@@ -298,8 +298,8 @@ describe("PropertyKeyPolicyTable", () => {
 
     server.use(
       http.get("*/api/property-key-policies", () =>
-        HttpResponse.json(firstPageWithNext)
-      )
+        HttpResponse.json(firstPageWithNext),
+      ),
     );
 
     renderTable();
@@ -321,8 +321,8 @@ describe("PropertyKeyPolicyTable", () => {
   it("renders the load error state when the list request fails", async () => {
     server.use(
       http.get("*/api/property-key-policies", () =>
-        HttpResponse.json({ message: "boom", status: 500 }, { status: 500 })
-      )
+        HttpResponse.json({ message: "boom", status: 500 }, { status: 500 }),
+      ),
     );
 
     renderTable();

--- a/src/__tests__/components/property-key-policy/mode.test.ts
+++ b/src/__tests__/components/property-key-policy/mode.test.ts
@@ -12,7 +12,7 @@ describe("toModeLabel", () => {
 
   it("falls back to Unknown for unexpected modes", () => {
     expect(toModeLabel("something-else" as PropertyKeyPolicyMode)).toBe(
-      "Unknown"
+      "Unknown",
     );
   });
 });

--- a/src/__tests__/components/scene/SceneTable.test.tsx
+++ b/src/__tests__/components/scene/SceneTable.test.tsx
@@ -70,7 +70,7 @@ describe("SceneTable", () => {
     server.use(
       http.get("*/api/scenes", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     const { rerender } = renderTable(scene);
@@ -90,7 +90,7 @@ describe("SceneTable", () => {
     server.use(
       http.get("*/api/scenes", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable(scene);
@@ -111,7 +111,7 @@ describe("SceneTable", () => {
     server.use(
       http.get("*/api/scenes", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable(scene);
@@ -120,7 +120,7 @@ describe("SceneTable", () => {
     await userEvent.hover(name);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent(
-      "Open Scene One"
+      "Open Scene One",
     );
   });
 
@@ -130,14 +130,14 @@ describe("SceneTable", () => {
     server.use(
       http.get("*/api/scenes", () => {
         return HttpResponse.json(page);
-      })
+      }),
     );
 
     renderTable(scene, { onClick });
 
     expect(await screen.findByLabelText("Open Scene One")).toHaveAttribute(
       "href",
-      "/scene-viewer/scene-1"
+      "/scene-viewer/scene-1",
     );
   });
 });
@@ -151,14 +151,14 @@ function getSceneRow(name = "Scene One"): HTMLTableRowElement {
 
 function renderTable(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
 ): ReturnType<typeof renderWithSWR> {
   return renderWithSWR(renderTableElement(scene, props));
 }
 
 function renderTableElement(
   scene?: Scene,
-  props: Partial<React.ComponentProps<typeof SceneTable>> = {}
+  props: Partial<React.ComponentProps<typeof SceneTable>> = {},
 ): JSX.Element {
   return (
     <SceneTable

--- a/src/__tests__/components/shared/ResourceLink.test.tsx
+++ b/src/__tests__/components/shared/ResourceLink.test.tsx
@@ -11,12 +11,12 @@ describe("ResourceLink", () => {
         primaryActionLabel="Open Scene"
       >
         Scene
-      </ResourceLink>
+      </ResourceLink>,
     );
 
     expect(screen.getByRole("link", { name: "Open Scene" })).toHaveAttribute(
       "href",
-      "/scene-viewer/scene-1"
+      "/scene-viewer/scene-1",
     );
   });
 
@@ -28,7 +28,7 @@ describe("ResourceLink", () => {
         <ResourceLink href="#resource" primaryActionLabel="Open Resource">
           Resource
         </ResourceLink>
-      </div>
+      </div>,
     );
 
     const link = screen.getByRole("link", { name: "Open Resource" });
@@ -47,7 +47,7 @@ describe("ResourceLink", () => {
         <ResourceLink disabled primaryActionLabel="Download unavailable">
           Resource
         </ResourceLink>
-      </div>
+      </div>,
     );
 
     fireEvent.click(screen.getByRole("link", { name: "Download unavailable" }));

--- a/src/__tests__/components/viewer/RightDrawer.test.tsx
+++ b/src/__tests__/components/viewer/RightDrawer.test.tsx
@@ -22,7 +22,7 @@ describe("RightDrawer", () => {
 
   it("resizes with arrow keys from the drawer's perspective", () => {
     render(
-      <RightDrawer modelViews={modelViews} onViewStateSelected={jest.fn()} />
+      <RightDrawer modelViews={modelViews} onViewStateSelected={jest.fn()} />,
     );
 
     const resizeHandle = screen.getByRole("separator", {

--- a/src/__tests__/lib/dates.test.ts
+++ b/src/__tests__/lib/dates.test.ts
@@ -16,6 +16,6 @@ describe("toLocalDayBoundaryIso", () => {
       expect(result.getMinutes()).toBe(minutes);
       expect(result.getSeconds()).toBe(seconds);
       expect(result.getMilliseconds()).toBe(milliseconds);
-    }
+    },
   );
 });

--- a/src/__tests__/lib/property-key-policies.test.ts
+++ b/src/__tests__/lib/property-key-policies.test.ts
@@ -13,7 +13,7 @@ function policy(
     suppliedId?: string;
     createdAt: string;
     mode: PropertyKeyPolicyMode;
-  }> = {}
+  }> = {},
 ): PropertyKeyPolicyResource {
   return {
     type: "property-key-policy",
@@ -36,7 +36,7 @@ describe("property key policy converters", () => {
         suppliedId: "plm-123",
         createdAt: "2026-06-10T15:30:00Z",
         mode: PropertyKeyPolicyMode.Allowlist,
-      })
+      }),
     );
 
     expect(model).toEqual({

--- a/src/__tests__/pages/api/file-collection-files.test.ts
+++ b/src/__tests__/pages/api/file-collection-files.test.ts
@@ -42,8 +42,10 @@ jest.mock("../../../lib/file-collections", () => {
 
 type TestReq = Pick<NextIronRequest, "body" | "method" | "query" | "session">;
 
-interface TestRes
-  extends Pick<NextApiResponse, "json" | "setHeader" | "status"> {
+interface TestRes extends Pick<
+  NextApiResponse,
+  "json" | "setHeader" | "status"
+> {
   readonly body: () => unknown;
   readonly statusCode: () => number | undefined;
 }
@@ -154,7 +156,7 @@ async function callFileCollectionFiles(req: {
   const res = createRes();
   await handleFileCollectionFiles(
     createReq(req),
-    res as unknown as NextApiResponse
+    res as unknown as NextApiResponse,
   );
   return res;
 }

--- a/src/__tests__/pages/api/file-collections.test.ts
+++ b/src/__tests__/pages/api/file-collections.test.ts
@@ -35,10 +35,10 @@ describe("file collection API routes", () => {
           expect(searchParams.get("page[size]")).toBe("50");
           expect(searchParams.get("filter[name][contains]")).toBe("COLLECT");
           expect(searchParams.get("filter[suppliedId][contains]")).toBe(
-            "LIED-1"
+            "LIED-1",
           );
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFileCollections({
@@ -76,8 +76,8 @@ describe("file collection API routes", () => {
         ({ searchParams }) => {
           expect(searchParams.get("filter[name][contains]")).toBe("missing");
           expect(searchParams.get("page[size]")).toBe("10");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFileCollections({
@@ -114,14 +114,14 @@ describe("file collection API routes", () => {
         },
         ({ searchParams }) => {
           expect(searchParams.get("filter[createdAt][gte]")).toBe(
-            "2026-06-11T00:00:00.000Z"
+            "2026-06-11T00:00:00.000Z",
           );
           expect(searchParams.get("filter[createdAt][lte]")).toBe(
-            "2026-06-11T23:59:59.999Z"
+            "2026-06-11T23:59:59.999Z",
           );
           expect(searchParams.get("page[size]")).toBe("10");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFileCollections({
@@ -150,7 +150,7 @@ describe("file collection API routes", () => {
       stubListFileCollections(fileCollectionsList(data), ({ searchParams }) => {
         expect(searchParams.get("page[size]")).toBe("10");
         expect(searchParams.get("sort")).toBe("-created");
-      })
+      }),
     );
 
     const response = await callFileCollections({
@@ -176,7 +176,7 @@ describe("file collection API routes", () => {
       stubListFileCollections(fileCollectionsList(data), ({ searchParams }) => {
         expect(searchParams.get("page[size]")).toBe("10");
         expect(searchParams.get("sort")).toBe("name");
-      })
+      }),
     );
 
     const response = await callFileCollections({
@@ -201,8 +201,8 @@ describe("file collection API routes", () => {
         },
         ({ searchParams }) => {
           expect(searchParams.get("page[size]")).toBe("10");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFileCollections({ method: "GET" });
@@ -239,7 +239,7 @@ describe("file collection API routes", () => {
 
     nodeMswServer.use(
       stubDeleteCollection("collection-1", undefined, deletedIds),
-      stubDeleteCollection("collection-2", undefined, deletedIds)
+      stubDeleteCollection("collection-2", undefined, deletedIds),
     );
 
     const response = await callFileCollections({
@@ -256,7 +256,7 @@ describe("file collection API routes", () => {
     nodeMswServer.use(
       stubDeleteCollection("collection-1", {
         errors: [{ status: "404", title: "Collection not found." }],
-      })
+      }),
     );
 
     const response = await callFileCollections({
@@ -276,7 +276,7 @@ describe("file collection API routes", () => {
       stubGetFileCollection("collection-1", {
         data: fileCollectionData("collection-1"),
         links: {},
-      })
+      }),
     );
 
     const response = await callFileCollectionById("collection-1", {
@@ -304,8 +304,8 @@ describe("file collection API routes", () => {
         },
         ({ searchParams }) => {
           expect(searchParams.get("page[size]")).toBe("200");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFileCollectionById("collection-1", {
@@ -326,8 +326,8 @@ describe("file collection API routes", () => {
       stubGetFileCollection(
         "collection-1",
         failureBody("500", "Vertex is upset."),
-        500
-      )
+        500,
+      ),
     );
 
     const response = await callFileCollectionById("collection-1", {
@@ -371,7 +371,7 @@ function callFileCollections(req: ApiRouteRequest): Promise<ApiRouteResponse> {
 
 function callFileCollectionById(
   id: string,
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return callApi(handleFileCollection, {
     ...req,
@@ -381,7 +381,7 @@ function callFileCollectionById(
 
 function callApi(
   handler: Parameters<typeof invokeNextJsApiRouteHandler>[0],
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return invokeNextJsApiRouteHandler(handler, {
     ...req,
@@ -392,7 +392,7 @@ function callApi(
 function fileCollectionData(
   id: string,
   created = "2026-06-10T15:30:00Z",
-  name = "Collection One"
+  name = "Collection One",
 ): {
   attributes: { created: string; name: string; suppliedId: string };
   id: string;
@@ -411,7 +411,7 @@ function fileCollectionData(
 
 function fileData(
   id: string,
-  status: string
+  status: string,
 ): {
   attributes: {
     created: string;
@@ -438,7 +438,7 @@ function fileData(
 
 function failureBody(
   status: string,
-  title: string
+  title: string,
 ): { errors: Array<{ status: string; title: string }> } {
   return {
     errors: [{ status, title }],
@@ -470,7 +470,7 @@ function stubListFileCollections(
       self?: { href: string };
     };
   },
-  assertRequest?: (request: URL) => void
+  assertRequest?: (request: URL) => void,
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-collections`, ({ request }) => {
     const url = new URL(request.url);
@@ -489,7 +489,7 @@ function stubDeleteCollection(
   failure:
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
-  deletedIds?: string[]
+  deletedIds?: string[],
 ): ReturnType<typeof http.delete> {
   return http.delete(`${vertexApiOrigin}/file-collections/${id}`, () => {
     deletedIds?.push(id);
@@ -515,7 +515,7 @@ function stubGetFileCollection(
         data: ReturnType<typeof fileCollectionData>;
         links: Record<string, never>;
       },
-  status = 200
+  status = 200,
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-collections/${id}`, () => {
     return HttpResponse.json(body, {
@@ -530,7 +530,7 @@ function stubGetFileCollection(
 function stubListFileCollectionFiles(
   id: string,
   body: { data: ReturnType<typeof fileData>[]; links: Record<string, never> },
-  assertRequest?: (request: URL) => void
+  assertRequest?: (request: URL) => void,
 ): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/file-collections/${id}/files`,
@@ -542,6 +542,6 @@ function stubListFileCollectionFiles(
           "content-type": "application/vnd.api+json",
         },
       });
-    }
+    },
   );
 }

--- a/src/__tests__/pages/api/file-download.test.ts
+++ b/src/__tests__/pages/api/file-download.test.ts
@@ -33,7 +33,7 @@ describe("file download route", () => {
         query: { id: "file-1" },
         session: {},
       } as NextIronRequest,
-      res as unknown as NextApiResponse
+      res as unknown as NextApiResponse,
     );
 
     expect(mockCreateDownloadUrl).toHaveBeenCalledWith({
@@ -47,7 +47,7 @@ describe("file download route", () => {
     });
     expect(res.redirect).toHaveBeenCalledWith(
       302,
-      "https://downloads.example.test/file-1"
+      "https://downloads.example.test/file-1",
     );
   });
 });

--- a/src/__tests__/pages/api/file-jobs.test.ts
+++ b/src/__tests__/pages/api/file-jobs.test.ts
@@ -23,7 +23,7 @@ describe("file jobs API routes", () => {
         "cursor-2": [fileData("file-3", "complete")],
       }),
       stubCreateFile("collection-1", "file-collection-collection-1.zip"),
-      stubCreateFileJob(["file-1", "file-2", "file-3"])
+      stubCreateFileJob(["file-1", "file-2", "file-3"]),
     );
 
     const response = await callFileJobs({
@@ -47,7 +47,7 @@ describe("file jobs API routes", () => {
         "": [fileData("file-1", "complete")],
       }),
       stubCreateFile("collection-1", "Custom collection.zip"),
-      stubCreateFileJob(["file-1"])
+      stubCreateFileJob(["file-1"]),
     );
 
     const response = await callFileJobs({
@@ -83,7 +83,7 @@ describe("file jobs API routes", () => {
     nodeMswServer.use(
       stubListFileCollectionFiles("collection-1", {
         "": [fileData("file-1", "completed"), fileData("file-2", "ready")],
-      })
+      }),
     );
 
     const response = await callFileJobs({
@@ -104,7 +104,7 @@ describe("file jobs API routes", () => {
         data: queuedJobData("job-1", {
           links: { download: { href: "https://zip" } },
         }),
-      })
+      }),
     );
 
     const response = await callFileJobById("job-1", { method: "GET" });
@@ -158,7 +158,7 @@ function callFileJobs(req: ApiRouteRequest): Promise<ApiRouteResponse> {
 
 function callFileJobById(
   id: string | undefined,
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return callApi(handleFileJob, {
     ...req,
@@ -168,7 +168,7 @@ function callFileJobById(
 
 function callApi(
   handler: Parameters<typeof invokeNextJsApiRouteHandler>[0],
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return invokeNextJsApiRouteHandler(handler, {
     ...req,
@@ -178,7 +178,7 @@ function callApi(
 
 function stubListFileCollectionFiles(
   id: string,
-  pages: Record<string, ReturnType<typeof fileData>[]>
+  pages: Record<string, ReturnType<typeof fileData>[]>,
 ): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/file-collections/${id}/files`,
@@ -206,13 +206,13 @@ function stubListFileCollectionFiles(
                 },
               },
       });
-    }
+    },
   );
 }
 
 function stubCreateFile(
   fileCollectionId: string,
-  name: string
+  name: string,
 ): ReturnType<typeof http.post> {
   return http.post(`${vertexApiOrigin}/files`, async ({ request }) => {
     expect(await request.json()).toEqual({
@@ -257,7 +257,7 @@ function stubCreateFileJob(fileIds: string[]): ReturnType<typeof http.post> {
 
 function stubGetFileJob(
   id: string,
-  body: { data: ReturnType<typeof queuedJobData> }
+  body: { data: ReturnType<typeof queuedJobData> },
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/file-jobs/${id}`, () => {
     return HttpResponse.json(body);
@@ -266,7 +266,7 @@ function stubGetFileJob(
 
 function queuedJobData(
   id: string,
-  dataOverrides: Record<string, unknown> = {}
+  dataOverrides: Record<string, unknown> = {},
 ): {
   attributes: { created: string; status: string };
   id: string;
@@ -285,7 +285,7 @@ function queuedJobData(
 
 function fileData(
   id: string,
-  status: string
+  status: string,
 ): {
   attributes: {
     created: string;

--- a/src/__tests__/pages/api/files.test.ts
+++ b/src/__tests__/pages/api/files.test.ts
@@ -33,8 +33,8 @@ describe("files API route", () => {
           expect(searchParams.get("page[cursor]")).toBe("cursor-1");
           expect(searchParams.get("page[size]")).toBe("50");
           expect(searchParams.get("sort")).toBe("-created");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callFiles({
@@ -66,7 +66,7 @@ function stubListFiles(
       self: { href: string };
     };
   },
-  assertRequest: (request: URL) => void
+  assertRequest: (request: URL) => void,
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/files`, ({ request }) => {
     assertRequest(new URL(request.url));

--- a/src/__tests__/pages/api/property-key-policies.test.ts
+++ b/src/__tests__/pages/api/property-key-policies.test.ts
@@ -24,10 +24,10 @@ describe("property key policies API routes", () => {
           expect(searchParams.get("page[cursor]")).toBe("cursor-1");
           expect(searchParams.get("page[size]")).toBe("50");
           expect(searchParams.get("filter[suppliedId][contains]")).toBe(
-            "LIED-1"
+            "LIED-1",
           );
-        }
-      )
+        },
+      ),
     );
 
     const response = await callPolicies({
@@ -55,8 +55,8 @@ describe("property key policies API routes", () => {
           expect(searchParams.get("filter[name][contains]")).toBeNull();
           expect(searchParams.get("filter[createdAt][gte]")).toBeNull();
           expect(searchParams.get("filter[createdAt][lte]")).toBeNull();
-        }
-      )
+        },
+      ),
     );
 
     const response = await callPolicies({
@@ -82,8 +82,8 @@ describe("property key policies API routes", () => {
         { data: [policyData("policy-1")], links: {} },
         ({ searchParams }) => {
           expect(searchParams.get("page[size]")).toBe("10");
-        }
-      )
+        },
+      ),
     );
 
     const response = await callPolicies({ method: "GET" });
@@ -106,7 +106,7 @@ describe("property key policies API routes", () => {
       }),
       stubUpsertKeys("policy-1", undefined, async (request) => {
         entriesBody = await request.json();
-      })
+      }),
     );
 
     const response = await callPolicies({
@@ -152,7 +152,7 @@ describe("property key policies API routes", () => {
       stubCreatePolicy("policy-1", async (request) => {
         createBody = await request.json();
       }),
-      stubUpsertKeys("policy-1")
+      stubUpsertKeys("policy-1"),
     );
 
     const response = await callPolicies({
@@ -180,7 +180,7 @@ describe("property key policies API routes", () => {
       stubCreatePolicy("policy-1", async (request) => {
         createBody = await request.json();
       }),
-      stubUpsertKeys("policy-1")
+      stubUpsertKeys("policy-1"),
     );
 
     const response = await callPolicies({
@@ -212,7 +212,7 @@ describe("property key policies API routes", () => {
       http.delete(`${vertexApiOrigin}/property-key-policies/policy-1`, () => {
         deleteCalled = true;
         return new HttpResponse(null, { status: 204 });
-      })
+      }),
     );
 
     const response = await callPolicies({
@@ -237,7 +237,7 @@ describe("property key policies API routes", () => {
     nodeMswServer.use(
       stubCreatePolicy("policy-1", undefined, {
         errors: [{ status: "400", title: "Bad policy." }],
-      })
+      }),
     );
 
     const response = await callPolicies({
@@ -342,7 +342,7 @@ describe("property key policies API routes", () => {
 
     nodeMswServer.use(
       stubDeletePolicy("policy-1", undefined, deletedIds),
-      stubDeletePolicy("policy-2", undefined, deletedIds)
+      stubDeletePolicy("policy-2", undefined, deletedIds),
     );
 
     const response = await callPolicies({
@@ -362,7 +362,7 @@ describe("property key policies API routes", () => {
     nodeMswServer.use(
       stubDeletePolicy("policy-1", {
         errors: [{ status: "404", title: "Policy not found." }],
-      })
+      }),
     );
 
     const response = await callPolicies({
@@ -382,7 +382,7 @@ describe("property key policies API routes", () => {
       stubDeletePolicy("policy-1"),
       stubDeletePolicy("policy-2", {
         errors: [{ status: "404", title: "Policy not found." }],
-      })
+      }),
     );
 
     const response = await callPolicies({
@@ -404,7 +404,7 @@ describe("property key policies API routes", () => {
       stubGetPolicy("policy-1", {
         data: policyData("policy-1"),
         links: {},
-      })
+      }),
     );
 
     const response = await callPolicyById("policy-1", { method: "GET" });
@@ -418,7 +418,7 @@ describe("property key policies API routes", () => {
 
   it("returns Vertex API failures from get requests", async () => {
     nodeMswServer.use(
-      stubGetPolicy("policy-1", failureBody("500", "Vertex is upset."), 500)
+      stubGetPolicy("policy-1", failureBody("500", "Vertex is upset."), 500),
     );
 
     const response = await callPolicyById("policy-1", { method: "GET" });
@@ -457,7 +457,7 @@ function callPolicies(req: ApiRouteRequest): Promise<ApiRouteResponse> {
 
 function callPolicyById(
   id: string,
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return callApi(handlePropertyKeyPolicy, {
     ...req,
@@ -467,7 +467,7 @@ function callPolicyById(
 
 function callApi(
   handler: Parameters<typeof invokeNextJsApiRouteHandler>[0],
-  req: ApiRouteRequest
+  req: ApiRouteRequest,
 ): Promise<ApiRouteResponse> {
   return invokeNextJsApiRouteHandler(handler, {
     ...req,
@@ -478,7 +478,7 @@ function callApi(
 function policyData(
   id: string,
   createdAt = "2026-06-10T15:30:00Z",
-  name = "Policy One"
+  name = "Policy One",
 ): {
   attributes: {
     createdAt: string;
@@ -520,7 +520,7 @@ function policyList(data: ReturnType<typeof policyData>[]): {
 
 function failureBody(
   status: string,
-  title: string
+  title: string,
 ): { errors: Array<{ status: string; title: string }> } {
   return { errors: [{ status, title }] };
 }
@@ -530,7 +530,7 @@ function stubListPolicies(
     data: ReturnType<typeof policyData>[];
     links: { next?: { href: string }; self?: { href: string } };
   },
-  assertRequest?: (request: URL) => void
+  assertRequest?: (request: URL) => void,
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/property-key-policies`, ({ request }) => {
     assertRequest?.(new URL(request.url));
@@ -549,7 +549,7 @@ function stubGetPolicy(
         data: ReturnType<typeof policyData>;
         links: Record<string, never>;
       },
-  status = 200
+  status = 200,
 ): ReturnType<typeof http.get> {
   return http.get(`${vertexApiOrigin}/property-key-policies/${id}`, () => {
     return HttpResponse.json(body, {
@@ -564,7 +564,7 @@ function stubCreatePolicy(
   assertRequest?: (request: Request) => Promise<void> | void,
   failure:
     | { errors: Array<{ status: string; title: string }> }
-    | undefined = undefined
+    | undefined = undefined,
 ): ReturnType<typeof http.post> {
   return http.post(
     `${vertexApiOrigin}/property-key-policies`,
@@ -580,9 +580,9 @@ function stubCreatePolicy(
 
       return HttpResponse.json(
         { data: policyData(id), links: {} },
-        { headers: { "content-type": "application/vnd.api+json" } }
+        { headers: { "content-type": "application/vnd.api+json" } },
       );
-    }
+    },
   );
 }
 
@@ -591,7 +591,7 @@ function stubUpsertKeys(
   failure:
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
-  assertRequest?: (request: Request) => Promise<void> | void
+  assertRequest?: (request: Request) => Promise<void> | void,
 ): ReturnType<typeof http.post> {
   return http.post(
     `${vertexApiOrigin}/property-key-policies/${id}/keys`,
@@ -606,7 +606,7 @@ function stubUpsertKeys(
       }
 
       return new HttpResponse(null, { status: 204 });
-    }
+    },
   );
 }
 
@@ -615,7 +615,7 @@ function stubDeletePolicy(
   failure:
     | { errors: Array<{ status: string; title: string }> }
     | undefined = undefined,
-  deletedIds?: string[]
+  deletedIds?: string[],
 ): ReturnType<typeof http.delete> {
   return http.delete(`${vertexApiOrigin}/property-key-policies/${id}`, () => {
     deletedIds?.push(id);

--- a/src/__tests__/pages/api/property-key-policy-keys.test.ts
+++ b/src/__tests__/pages/api/property-key-policy-keys.test.ts
@@ -20,7 +20,7 @@ describe("property key policy keys API route", () => {
       stubListKeys("policy-1", {
         "": [keyData("key-1", "MixedCaseKey")],
         "cursor-2": [keyData("key-2", "another_key")],
-      })
+      }),
     );
 
     const response = await callKeys("policy-1", { method: "GET" });
@@ -40,9 +40,9 @@ describe("property key policy keys API route", () => {
           {
             status: 500,
             headers: { "content-type": "application/vnd.api+json" },
-          }
-        )
-      )
+          },
+        ),
+      ),
     );
 
     const response = await callKeys("policy-1", { method: "GET" });
@@ -61,7 +61,7 @@ describe("property key policy keys API route", () => {
         method: "GET",
         query: {},
         session: createAuthenticatedVertexApiTestSession(vertexApiOrigin),
-      }
+      },
     );
 
     expect(response.statusCode()).toBe(400);
@@ -88,9 +88,9 @@ describe("property key policy keys API route", () => {
               },
             },
           },
-          { headers: { "content-type": "application/vnd.api+json" } }
+          { headers: { "content-type": "application/vnd.api+json" } },
         );
-      })
+      }),
     );
 
     const response = await callKeys("policy-1", { method: "GET" });
@@ -124,7 +124,7 @@ function callKeys(id: string, req: ApiRouteRequest): Promise<ApiRouteResponse> {
 
 function keyData(
   id: string,
-  name: string
+  name: string,
 ): { attributes: { name: string }; id: string; type: string } {
   return {
     attributes: { name },
@@ -135,7 +135,7 @@ function keyData(
 
 function stubListKeys(
   policyId: string,
-  pages: Record<string, ReturnType<typeof keyData>[]>
+  pages: Record<string, ReturnType<typeof keyData>[]>,
 ): ReturnType<typeof http.get> {
   return http.get(
     `${vertexApiOrigin}/property-key-policies/${policyId}/keys`,
@@ -164,8 +164,8 @@ function stubListKeys(
                   },
                 },
         },
-        { headers: { "content-type": "application/vnd.api+json" } }
+        { headers: { "content-type": "application/vnd.api+json" } },
       );
-    }
+    },
   );
 }

--- a/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
+++ b/src/__tests__/pages/file-collections/fileCollectionId.test.tsx
@@ -27,7 +27,7 @@ const mockFileCollectionFilesTable = jest.fn(
     <div data-api-path={apiPath} data-testid="file-collection-files-table">
       File Collection Files Table
     </div>
-  )
+  ),
 );
 const originalFetch = global.fetch;
 
@@ -38,7 +38,7 @@ jest.mock("../../../components/shared/Layout", () => ({
 jest.mock(
   "next/dynamic",
   () => () => (props: Record<string, unknown>) =>
-    mockFileCollectionFilesTable(props)
+    mockFileCollectionFilesTable(props),
 );
 
 jest.mock("../../../lib/vertex-api", () => {
@@ -65,7 +65,7 @@ describe("FileCollectionDetails", () => {
       jsonResponse({
         export: { enabled: true, fileCount: 2 },
         status: 200,
-      })
+      }),
     );
     mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
     mockGetFileCollectionsApi.mockReturnValue({
@@ -91,11 +91,11 @@ describe("FileCollectionDetails", () => {
           expiresAt: "2026-07-10T15:30:00Z",
           metadata: { source: "unit-test" },
         }}
-      />
+      />,
     );
 
     expect(
-      screen.getByRole("link", { name: "File Collections" })
+      screen.getByRole("link", { name: "File Collections" }),
     ).toHaveAttribute("href", "/file-collections");
     expect(screen.getByText("File Collection Details")).toBeInTheDocument();
     expect(screen.getAllByText("Collection One").length).toBeGreaterThan(0);
@@ -105,8 +105,8 @@ describe("FileCollectionDetails", () => {
     expect(screen.getByText("unit-test")).toBeInTheDocument();
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Export Archive" })
-      ).toBeEnabled()
+        screen.getByRole("button", { name: "Export Archive" }),
+      ).toBeEnabled(),
     );
   });
 
@@ -121,21 +121,21 @@ describe("FileCollectionDetails", () => {
           expiresAt: "2026-07-10T15:30:00Z",
           metadata: { source: "unit-test" },
         }}
-      />
+      />,
     );
 
     const fileCollectionFilesTable = await screen.findByTestId(
-      "file-collection-files-table"
+      "file-collection-files-table",
     );
 
     expect(fileCollectionFilesTable).toHaveAttribute(
       "data-api-path",
-      "/api/file-collections/collection-1/files"
+      "/api/file-collections/collection-1/files",
     );
     await waitFor(() =>
       expect(
-        screen.getByRole("button", { name: "Export Archive" })
-      ).toBeEnabled()
+        screen.getByRole("button", { name: "Export Archive" }),
+      ).toBeEnabled(),
     );
   });
 
@@ -148,7 +148,7 @@ describe("FileCollectionDetails", () => {
           fileCount: 0,
         },
         status: 200,
-      })
+      }),
     );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -158,7 +158,7 @@ describe("FileCollectionDetails", () => {
     });
 
     expect(
-      await screen.findByText("File collection has no files to export.")
+      await screen.findByText("File collection has no files to export."),
     ).toBeInTheDocument();
     expect(button).toBeDisabled();
   });
@@ -174,13 +174,13 @@ describe("FileCollectionDetails", () => {
             fileCount: 2,
           },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -191,12 +191,12 @@ describe("FileCollectionDetails", () => {
     expect(exportButton).toBeDisabled();
     expect(
       await screen.findByText(
-        "File collection contains files that are not ready to export."
-      )
+        "File collection contains files that are not ready to export.",
+      ),
     ).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Refresh Availability" })
+      screen.getByRole("button", { name: "Refresh Availability" }),
     );
 
     await waitFor(() => expect(exportButton).toBeEnabled());
@@ -209,7 +209,7 @@ describe("FileCollectionDetails", () => {
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -219,11 +219,11 @@ describe("FileCollectionDetails", () => {
     });
     expect(exportButton).toBeDisabled();
     expect(
-      await screen.findByText("Could not check export availability.")
+      await screen.findByText("Could not check export availability."),
     ).toBeInTheDocument();
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Refresh Availability" })
+      screen.getByRole("button", { name: "Refresh Availability" }),
     );
 
     await waitFor(() => expect(exportButton).toBeEnabled());
@@ -237,7 +237,7 @@ describe("FileCollectionDetails", () => {
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse(
@@ -249,8 +249,8 @@ describe("FileCollectionDetails", () => {
             },
             status: 201,
           },
-          201
-        )
+          201,
+        ),
       )
       .mockResolvedValueOnce(
         jsonResponse({
@@ -259,7 +259,7 @@ describe("FileCollectionDetails", () => {
             id: "job-1",
           },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
@@ -268,13 +268,13 @@ describe("FileCollectionDetails", () => {
             id: "job-1",
           },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse({
           status: 200,
           url: "https://example.test/archive.zip",
-        })
+        }),
       );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -291,10 +291,10 @@ describe("FileCollectionDetails", () => {
         body: JSON.stringify({ fileCollectionId: "collection-1" }),
         headers: { "Content-Type": "application/json" },
         method: "POST",
-      })
+      }),
     );
     expect(
-      screen.getByRole("button", { name: "Exporting Archive" })
+      screen.getByRole("button", { name: "Exporting Archive" }),
     ).toBeDisabled();
     await screen.findByText("Archive job is running.");
 
@@ -307,10 +307,10 @@ describe("FileCollectionDetails", () => {
     });
 
     await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1"),
     );
     expect(
-      screen.getByRole("button", { name: "Exporting Archive" })
+      screen.getByRole("button", { name: "Exporting Archive" }),
     ).toBeDisabled();
 
     await act(async () => {
@@ -319,7 +319,7 @@ describe("FileCollectionDetails", () => {
     });
 
     await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1"),
     );
 
     const download = await screen.findByRole("button", {
@@ -327,10 +327,10 @@ describe("FileCollectionDetails", () => {
     });
     expect(global.fetch).not.toHaveBeenCalledWith(
       "/api/files/archive-file-1/download-url",
-      { method: "POST" }
+      { method: "POST" },
     );
     expect(
-      screen.getByText("Archive is ready to download.")
+      screen.getByText("Archive is ready to download."),
     ).toBeInTheDocument();
 
     fireEvent.click(download);
@@ -338,13 +338,13 @@ describe("FileCollectionDetails", () => {
     await waitFor(() =>
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/files/archive-file-1/download-url",
-        { method: "POST" }
-      )
+        { method: "POST" },
+      ),
     );
     expect(window.open).toHaveBeenCalledWith(
       "https://example.test/archive.zip",
       "_blank",
-      "noopener"
+      "noopener",
     );
   });
 
@@ -354,7 +354,7 @@ describe("FileCollectionDetails", () => {
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       )
       .mockRejectedValueOnce(new Error("Network error"));
 
@@ -368,12 +368,12 @@ describe("FileCollectionDetails", () => {
     fireEvent.click(exportButton);
 
     expect(
-      await screen.findByText("Could not start archive export.")
+      await screen.findByText("Could not start archive export."),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     expect(
-      screen.getByRole("button", { name: "Export Archive" })
+      screen.getByRole("button", { name: "Export Archive" }),
     ).toBeEnabled();
   });
 
@@ -384,7 +384,7 @@ describe("FileCollectionDetails", () => {
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse(
@@ -396,8 +396,8 @@ describe("FileCollectionDetails", () => {
             },
             status: 201,
           },
-          201
-        )
+          201,
+        ),
       )
       .mockResolvedValueOnce(
         jsonResponse({
@@ -406,7 +406,7 @@ describe("FileCollectionDetails", () => {
             id: "job-1",
           },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse(
@@ -414,8 +414,8 @@ describe("FileCollectionDetails", () => {
             message: "Could not create download URL.",
             status: 500,
           },
-          500
-        )
+          500,
+        ),
       );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -438,7 +438,7 @@ describe("FileCollectionDetails", () => {
     });
 
     await waitFor(() =>
-      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1")
+      expect(global.fetch).toHaveBeenCalledWith("/api/file-jobs/job-1"),
     );
 
     const download = await screen.findByRole("button", {
@@ -450,14 +450,14 @@ describe("FileCollectionDetails", () => {
     await waitFor(() =>
       expect(global.fetch).toHaveBeenCalledWith(
         "/api/files/archive-file-1/download-url",
-        { method: "POST" }
-      )
+        { method: "POST" },
+      ),
     );
     expect(
-      await screen.findByText("Could not create download URL.")
+      await screen.findByText("Could not create download URL."),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Download Archive" })
+      screen.getByRole("button", { name: "Download Archive" }),
     ).toBeEnabled();
   });
 
@@ -468,7 +468,7 @@ describe("FileCollectionDetails", () => {
         jsonResponse({
           export: { enabled: true, fileCount: 2 },
           status: 200,
-        })
+        }),
       )
       .mockResolvedValueOnce(
         jsonResponse(
@@ -480,8 +480,8 @@ describe("FileCollectionDetails", () => {
             },
             status: 201,
           },
-          201
-        )
+          201,
+        ),
       )
       .mockResolvedValueOnce(
         jsonResponse({
@@ -490,7 +490,7 @@ describe("FileCollectionDetails", () => {
             id: "job-1",
           },
           status: 200,
-        })
+        }),
       );
 
     render(<FileCollectionDetails fileCollection={fileCollection()} />);
@@ -516,7 +516,7 @@ describe("FileCollectionDetails", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     expect(
-      screen.getByRole("button", { name: "Export Archive" })
+      screen.getByRole("button", { name: "Export Archive" }),
     ).toBeEnabled();
   });
 

--- a/src/__tests__/pages/property-key-policies.test.tsx
+++ b/src/__tests__/pages/property-key-policies.test.tsx
@@ -38,7 +38,7 @@ jest.mock(
           </button>
         </>
       );
-    }
+    },
 );
 
 jest.mock("../../components/shared/Layout", () => ({
@@ -64,7 +64,7 @@ jest.mock(
         {open ? "open" : "closed"}
       </div>
     ),
-  })
+  }),
 );
 
 describe("PropertyKeyPolicies", () => {
@@ -72,21 +72,21 @@ describe("PropertyKeyPolicies", () => {
     renderWithSWR(<PropertyKeyPolicies />);
 
     expect(screen.getByTestId("property-key-policy-drawer")).toHaveTextContent(
-      "closed"
+      "closed",
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Select policy" })
+      screen.getByRole("button", { name: "Select policy" }),
     );
     expect(screen.getByTestId("property-key-policy-drawer")).toHaveTextContent(
-      "open"
+      "open",
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Delete policy" })
+      screen.getByRole("button", { name: "Delete policy" }),
     );
     expect(screen.getByTestId("property-key-policy-drawer")).toHaveTextContent(
-      "closed"
+      "closed",
     );
   });
 });

--- a/src/__tests__/pages/property-key-policies/[propertyKeyPolicyId].test.tsx
+++ b/src/__tests__/pages/property-key-policies/[propertyKeyPolicyId].test.tsx
@@ -53,8 +53,8 @@ describe("PropertyKeyPolicyDetails", () => {
   beforeEach(() => {
     server.use(
       http.get("*/api/property-key-policies/:id/keys", () =>
-        HttpResponse.json(propertyKeyPolicyKeysRes({ data: [] }))
-      )
+        HttpResponse.json(propertyKeyPolicyKeysRes({ data: [] })),
+      ),
     );
     mockGetClientFromSession.mockResolvedValue({ client: "test-client" });
     mockGetPropertyKeyPoliciesApi.mockReturnValue({
@@ -77,11 +77,11 @@ describe("PropertyKeyPolicyDetails", () => {
           createdAt: "2026-06-10T15:30:00Z",
           mode: "allowlist",
         }}
-      />
+      />,
     );
 
     expect(
-      screen.getByRole("link", { name: "Property Key Policies" })
+      screen.getByRole("link", { name: "Property Key Policies" }),
     ).toHaveAttribute("href", "/property-key-policies");
     expect(screen.getByText("Property Key Policy")).toBeInTheDocument();
     expect(screen.getAllByText("My Policy").length).toBeGreaterThan(0);
@@ -94,9 +94,9 @@ describe("PropertyKeyPolicyDetails", () => {
         HttpResponse.json(
           propertyKeyPolicyKeysRes({
             data: [propertyKeyPolicyKey({ id: "key-1", name: "entry-key-1" })],
-          })
-        )
-      )
+          }),
+        ),
+      ),
     );
 
     renderWithSWR(
@@ -108,7 +108,7 @@ describe("PropertyKeyPolicyDetails", () => {
           createdAt: "2026-06-10T15:30:00Z",
           mode: "allowlist",
         }}
-      />
+      />,
     );
 
     expect(await screen.findByText("entry-key-1")).toBeInTheDocument();
@@ -119,9 +119,9 @@ describe("PropertyKeyPolicyDetails", () => {
       http.get("*/api/property-key-policies/:id/keys", () =>
         HttpResponse.json(
           { message: "Could not load entries.", status: 500 },
-          { status: 500 }
-        )
-      )
+          { status: 500 },
+        ),
+      ),
     );
 
     renderWithSWR(
@@ -133,11 +133,11 @@ describe("PropertyKeyPolicyDetails", () => {
           createdAt: "2026-06-10T15:30:00Z",
           mode: "allowlist",
         }}
-      />
+      />,
     );
 
     expect(
-      await screen.findByText("Could not load property keys.")
+      await screen.findByText("Could not load property keys."),
     ).toBeInTheDocument();
   });
 
@@ -251,7 +251,7 @@ describe("PropertyKeyPolicyDetails", () => {
       serverSidePropsHandler({
         query: { propertyKeyPolicyId: "policy-1" },
         req: createReq(createSession()),
-      })
+      }),
     ).rejects.toThrow("Internal server error.");
   });
 });

--- a/src/components/file-collection/FileCollectionDetailsDrawer.tsx
+++ b/src/components/file-collection/FileCollectionDetailsDrawer.tsx
@@ -26,7 +26,7 @@ export function FileCollectionDetailsDrawer({
   const { data, error } = useSWR<GetFileCollectionRes | undefined>(
     fileCollection == null
       ? null
-      : `/api/file-collections/${encodeURIComponent(fileCollection.id)}`
+      : `/api/file-collections/${encodeURIComponent(fileCollection.id)}`,
   );
   const detailRequestFailed = error != null || isErrorRes(data);
   const fetchedFileCollection =
@@ -42,8 +42,8 @@ export function FileCollectionDetailsDrawer({
     fileCollection == null
       ? undefined
       : fetchedFileCollection == null
-      ? fileCollection
-      : { ...fileCollection, ...fetchedFileCollection };
+        ? fileCollection
+        : { ...fileCollection, ...fetchedFileCollection };
 
   return (
     <Drawer

--- a/src/components/file-collection/FileCollectionFilesTable.tsx
+++ b/src/components/file-collection/FileCollectionFilesTable.tsx
@@ -61,7 +61,7 @@ function useCollectionFiles({
     buildQuery(apiPath, {
       cursor,
       pageSize,
-    })
+    }),
   );
 }
 
@@ -74,7 +74,7 @@ function statusLabel(status?: string): string {
 }
 
 function statusColor(
-  status?: string
+  status?: string,
 ): "default" | "success" | "warning" | "error" {
   switch (normalizeFileStatus(status)) {
     case FileStatusComplete:
@@ -121,7 +121,7 @@ export default function FileCollectionFilesTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     handlePageChange(num);
   }
@@ -133,13 +133,13 @@ export default function FileCollectionFilesTable({
       `/api/files/${encodeURIComponent(id)}/download-url`,
       {
         method: "POST",
-      }
+      },
     );
 
     const body = await res.json();
     if (!res.ok || body.url == null) {
       setDownloadError(
-        body.message ?? "Could not create a download URL for this file."
+        body.message ?? "Could not create a download URL for this file.",
       );
       return;
     }
@@ -260,7 +260,7 @@ export default function FileCollectionFilesTable({
               displayedRows,
               paginationCursors?.next != null,
               pageLength,
-              page != null
+              page != null,
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/file-collection/FileCollectionTable.tsx
+++ b/src/components/file-collection/FileCollectionTable.tsx
@@ -69,7 +69,7 @@ function useFileCollections({
       pageSize,
       sort: sort != null ? toSortParam(sort) : undefined,
       suppliedId,
-    })
+    }),
   );
 }
 
@@ -121,7 +121,7 @@ export default function FileCollectionTable({
         resetPaging();
         setName(value === "" ? undefined : value);
       }, 300),
-    [resetPaging]
+    [resetPaging],
   );
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
@@ -130,7 +130,7 @@ export default function FileCollectionTable({
         resetPaging();
         setSuppliedId(value === "" ? undefined : value);
       }, 300),
-    [resetPaging]
+    [resetPaging],
   );
 
   React.useEffect(() => {
@@ -148,7 +148,7 @@ export default function FileCollectionTable({
     if (field !== "created" && field !== "name") return;
 
     setSort((current) =>
-      current == null ? { field, order: "asc" } : toggleSort(current, field)
+      current == null ? { field, order: "asc" } : toggleSort(current, field),
     );
     resetPaging();
   }
@@ -171,7 +171,7 @@ export default function FileCollectionTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     handlePageChange(num);
   }
@@ -189,7 +189,7 @@ export default function FileCollectionTable({
     if (!res.ok) {
       const body = await res.json();
       setDeleteError(
-        body.message ?? "Could not delete the selected file collections."
+        body.message ?? "Could not delete the selected file collections.",
       );
       setSelected(new Set(ids));
       return;
@@ -347,7 +347,7 @@ export default function FileCollectionTable({
               displayedRows,
               cursors?.next != null,
               pageLength,
-              page != null
+              page != null,
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/file/FileDetailsDrawer.tsx
+++ b/src/components/file/FileDetailsDrawer.tsx
@@ -130,9 +130,9 @@ function useFileCollections({
 
       const res = await fetch(
         `/api/files/${encodeURIComponent(
-          fileId
+          fileId,
         )}/file-collections?${params.toString()}`,
-        { signal: controller.signal }
+        { signal: controller.signal },
       );
       const body = await res.json();
 
@@ -141,7 +141,7 @@ function useFileCollections({
       if (!res.ok) {
         throw new Error(
           (body as { message?: string }).message ??
-            "Could not load file collections."
+            "Could not load file collections.",
         );
       }
 
@@ -168,7 +168,7 @@ function useFileCollections({
           setError(
             err instanceof Error
               ? err.message
-              : "Could not load file collections."
+              : "Could not load file collections.",
           );
           setLoading(false);
         }
@@ -319,7 +319,7 @@ function FileCollectionIdsRow({
                   <TableCell sx={{ px: 0, py: 0.75, verticalAlign: "top" }}>
                     <AppLink
                       href={`/file-collections/${encodeURIComponent(
-                        collection.id
+                        collection.id,
                       )}`}
                       underline="hover"
                     >
@@ -341,7 +341,7 @@ function FileCollectionIdsRow({
                     >
                       <AppLink
                         href={`/file-collections/${encodeURIComponent(
-                          collection.id
+                          collection.id,
                         )}`}
                         underline="hover"
                         sx={{ minWidth: 0 }}
@@ -366,7 +366,7 @@ function FileCollectionIdsRow({
                           aria-label={`Copy ${collection.id}`}
                           onClick={() => {
                             copyId(collection.id).catch(
-                              reportError("Failed to copy file collection ID")
+                              reportError("Failed to copy file collection ID"),
                             );
                           }}
                           size="small"

--- a/src/components/file/FileTable.tsx
+++ b/src/components/file/FileTable.tsx
@@ -84,7 +84,7 @@ function useFiles({
       pageSize,
       sort: sort != null ? toSortParam(sort) : undefined,
       suppliedId,
-    })
+    }),
   );
 }
 
@@ -97,7 +97,7 @@ function statusLabel(status?: string): string {
 }
 
 function statusColor(
-  status?: string
+  status?: string,
 ): "default" | "success" | "warning" | "error" {
   switch (normalizeFileStatus(status)) {
     case FileStatusComplete:
@@ -122,7 +122,7 @@ type SetOptionalString = React.Dispatch<
 >;
 function useDebouncedFilter(
   setFilter: SetOptionalString,
-  resetPaging: () => void
+  resetPaging: () => void,
 ): (value: string) => void {
   return React.useMemo(
     () =>
@@ -130,7 +130,7 @@ function useDebouncedFilter(
         resetPaging();
         setFilter(value === "" ? undefined : value);
       }, 300),
-    [resetPaging, setFilter]
+    [resetPaging, setFilter],
   );
 }
 
@@ -186,11 +186,11 @@ export default function FileTable({
   const debouncedSetNameFilter = useDebouncedFilter(setNameFilter, resetPaging);
   const debouncedSetFileIdFilter = useDebouncedFilter(
     setFileIdFilter,
-    resetPaging
+    resetPaging,
   );
   const debouncedSetSuppliedIdFilter = useDebouncedFilter(
     setSuppliedIdFilter,
-    resetPaging
+    resetPaging,
   );
 
   React.useEffect(() => {
@@ -217,7 +217,7 @@ export default function FileTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     handlePageChange(num);
   }
@@ -248,13 +248,13 @@ export default function FileTable({
       `/api/files/${encodeURIComponent(id)}/download-url`,
       {
         method: "POST",
-      }
+      },
     );
 
     const body = await res.json();
     if (!res.ok || body.url == null) {
       setDownloadError(
-        body.message ?? "Could not create a download URL for this file."
+        body.message ?? "Could not create a download URL for this file.",
       );
       return;
     }
@@ -462,7 +462,7 @@ export default function FileTable({
               displayedRows,
               paginationCursors?.next != null,
               pageLength,
-              visiblePage != null
+              visiblePage != null,
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/part/PartRevisionDetailsDrawer.tsx
+++ b/src/components/part/PartRevisionDetailsDrawer.tsx
@@ -38,7 +38,7 @@ export function PartRevisionDetailsDrawer({
   partRevision,
 }: Props): JSX.Element {
   const { data, error } = useSWR(
-    partRevision == null ? null : `/api/part-revisions/${partRevision.id}`
+    partRevision == null ? null : `/api/part-revisions/${partRevision.id}`,
   );
   const fetchedRevision =
     data != null && !isErrorRes(data) ? toPartRevision(data) : undefined;
@@ -46,8 +46,8 @@ export function PartRevisionDetailsDrawer({
     partRevision == null
       ? fetchedRevision
       : fetchedRevision == null
-      ? partRevision
-      : { ...partRevision, ...fetchedRevision };
+        ? partRevision
+        : { ...partRevision, ...fetchedRevision };
   const showMetadataLoading =
     partRevision != null && fetchedRevision?.metadata == null && error == null;
 
@@ -93,8 +93,8 @@ export function PartRevisionDetailsDrawer({
                   error != null
                     ? "error"
                     : showMetadataLoading
-                    ? "loading"
-                    : "ready"
+                      ? "loading"
+                      : "ready"
                 }
               />
             </TableBody>
@@ -235,7 +235,7 @@ function MetadataRow({
 }
 
 function normalizeMetadataEntries(
-  metadata: NonNullable<PartRevision["metadata"]>
+  metadata: NonNullable<PartRevision["metadata"]>,
 ): MetadataEntry[] {
   return Object.entries(metadata).map(([key, value]) => ({
     key,

--- a/src/components/part/PartTable.tsx
+++ b/src/components/part/PartTable.tsx
@@ -47,12 +47,12 @@ function useParts({ cursor, pageSize, suppliedId }: SwrProps): SWRResponse {
       pageSize,
       suppliedId,
     }),
-    { refreshInterval: 30000 }
+    { refreshInterval: 30000 },
   );
 }
 
 const maybeQueryParam = (
-  target: string | string[] | undefined
+  target: string | string[] | undefined,
 ): string | undefined => (Array.isArray(target) ? target[0] : target);
 
 interface Props {
@@ -77,7 +77,7 @@ export default function PartTable({
   const [toastMsg, setToastMsg] = React.useState<string | undefined>();
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [showCreatePartDialog, setShowCreatePartDialog] = React.useState(
-    !!router.query.create
+    !!router.query.create,
   );
   const [targetRevisionId, setTargetRevisionId] = React.useState<
     string | undefined
@@ -99,7 +99,7 @@ export default function PartTable({
         resetPaging();
         setSuppliedIdFilter(value);
       }, 300),
-    [resetPaging]
+    [resetPaging],
   );
 
   React.useEffect(() => {
@@ -126,7 +126,7 @@ export default function PartTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     handlePageChange(num);
   }
@@ -228,7 +228,7 @@ export default function PartTable({
               displayedRows,
               cursors?.next != null,
               pageLength,
-              page != null
+              page != null,
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
+++ b/src/components/property-key-policy/CreatePropertyKeyPolicyDialog.tsx
@@ -45,7 +45,7 @@ export default function CreatePropertyKeyPolicyDialog({
   const [name, setName] = React.useState("");
   const [suppliedId, setSuppliedId] = React.useState("");
   const [mode, setMode] = React.useState<PropertyKeyPolicyMode>(
-    PropertyKeyPolicyMode.Allowlist
+    PropertyKeyPolicyMode.Allowlist,
   );
   const [keys, setKeys] = React.useState<KeyField[]>([{ id: 0, value: "" }]);
   const [submitting, setSubmitting] = React.useState(false);
@@ -99,7 +99,7 @@ export default function CreatePropertyKeyPolicyDialog({
 
   function handleKeyChange(index: number, value: string): void {
     setKeys((current) =>
-      current.map((key, i) => (i === index ? { ...key, value } : key))
+      current.map((key, i) => (i === index ? { ...key, value } : key)),
     );
   }
 
@@ -117,7 +117,7 @@ export default function CreatePropertyKeyPolicyDialog({
   function handleKeyDown(
     e: React.KeyboardEvent<HTMLDivElement>,
     index: number,
-    value: string
+    value: string,
   ): void {
     if (e.key !== "Enter") return;
     e.preventDefault();
@@ -136,7 +136,7 @@ export default function CreatePropertyKeyPolicyDialog({
     setKeys((current) =>
       current.length === 1
         ? [newKeyField()]
-        : current.filter((_, i) => i !== index)
+        : current.filter((_, i) => i !== index),
     );
   }
 
@@ -198,9 +198,9 @@ export default function CreatePropertyKeyPolicyDialog({
     }
 
     const resBody:
-      | CreatePropertyKeyPolicyRes
-      | { message?: string }
-      | undefined = await res.json().catch(() => undefined);
+      CreatePropertyKeyPolicyRes | { message?: string } | undefined = await res
+      .json()
+      .catch(() => undefined);
     if (resBody == null) {
       // Response received but body could not be parsed. The server may have
       // already created the policy, so we must not let the user resubmit (duplicate
@@ -217,7 +217,7 @@ export default function CreatePropertyKeyPolicyDialog({
     if (!res.ok || isErrorRes(resBody)) {
       setApiError(
         (isErrorRes(resBody) ? resBody.message : undefined) ??
-          "Could not create the property key policy."
+          "Could not create the property key policy.",
       );
       return;
     }

--- a/src/components/property-key-policy/PropertyKeyPolicyDetailsDrawer.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyDetailsDrawer.tsx
@@ -34,7 +34,7 @@ export function PropertyKeyPolicyDetailsDrawer({
   >(
     id == null
       ? null
-      : `/api/property-key-policies/${encodeURIComponent(id)}/keys`
+      : `/api/property-key-policies/${encodeURIComponent(id)}/keys`,
   );
 
   const details = propertyKeyPolicy;

--- a/src/components/property-key-policy/PropertyKeyPolicyModeChip.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyModeChip.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 function modeColor(
-  mode: PropertyKeyPolicyMode
+  mode: PropertyKeyPolicyMode,
 ): "default" | "success" | "error" {
   switch (mode) {
     case PropertyKeyPolicyMode.Allowlist:

--- a/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
+++ b/src/components/property-key-policy/PropertyKeyPolicyTable.tsx
@@ -58,7 +58,7 @@ function usePropertyKeyPolicies({
       cursor,
       pageSize,
       suppliedId,
-    })
+    }),
   );
 }
 
@@ -66,7 +66,7 @@ interface Props {
   readonly activePropertyKeyPolicyId?: string;
   readonly onPoliciesDeleted?: (ids: string[]) => void;
   readonly onPropertyKeyPolicySelected?: (
-    propertyKeyPolicy: PropertyKeyPolicy
+    propertyKeyPolicy: PropertyKeyPolicy,
   ) => void;
 }
 
@@ -111,7 +111,7 @@ export default function PropertyKeyPolicyTable({
         setSuppliedId(value === "" ? undefined : value);
         setSelected(new Set());
       }, 300),
-    [resetPaging]
+    [resetPaging],
   );
 
   React.useEffect(() => {
@@ -138,7 +138,7 @@ export default function PropertyKeyPolicyTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     handlePageChange(num);
     setSelected(new Set());
@@ -162,9 +162,8 @@ export default function PropertyKeyPolicyTable({
     }
 
     const body:
-      | DeletePropertyKeyPoliciesRes
-      | { message?: string }
-      | undefined = await res.json().catch(() => undefined);
+      DeletePropertyKeyPoliciesRes | { message?: string } | undefined =
+      await res.json().catch(() => undefined);
 
     if (!res.ok || isPartialDelete(body)) {
       const deletedIds = isPartialDelete(body) ? body.deletedIds : [];
@@ -176,7 +175,7 @@ export default function PropertyKeyPolicyTable({
         setSelected(new Set(failedIds));
         setDeleteError(
           (isErrorRes(body) ? body.message : undefined) ??
-            "Could not delete the selected property key policies."
+            "Could not delete the selected property key policies.",
         );
         mutate().catch(reportError("Failed to refresh property key policies"));
       }
@@ -272,7 +271,7 @@ export default function PropertyKeyPolicyTable({
             handleDelete().catch(() => {
               setDeleting(false);
               setDeleteError(
-                "Could not delete the selected property key policies."
+                "Could not delete the selected property key policies.",
               );
             });
           }}
@@ -337,7 +336,7 @@ export default function PropertyKeyPolicyTable({
               displayedRows,
               cursors?.next != null,
               pageLength,
-              page != null
+              page != null,
             )
           }
           rowsPerPage={pageSize}
@@ -369,7 +368,7 @@ export default function PropertyKeyPolicyTable({
 }
 
 function isPartialDelete(
-  body: DeletePropertyKeyPoliciesRes | { message?: string } | undefined
+  body: DeletePropertyKeyPoliciesRes | { message?: string } | undefined,
 ): body is PartialDeletePropertyKeyPoliciesRes {
   const partial = body as Partial<PartialDeletePropertyKeyPoliciesRes>;
 

--- a/src/components/scene/SceneDrawer.tsx
+++ b/src/components/scene/SceneDrawer.tsx
@@ -50,11 +50,11 @@ export function SceneDrawer({
   });
 
   const [editableMetadata, setMetadata] = useState<string | undefined>(
-    undefined
+    undefined,
   );
 
   const [sceneDetails, setSceneDetails] = useState<SceneData | undefined>(
-    undefined
+    undefined,
   );
 
   React.useEffect(() => {
@@ -121,13 +121,13 @@ export function SceneDrawer({
   }, [defaultValues, reset]);
 
   function isOrthographic(
-    camera: OrthographicCamera | PerspectiveCamera
+    camera: OrthographicCamera | PerspectiveCamera,
   ): camera is OrthographicCamera {
     return camera.type === "orthographic";
   }
 
   function isPerspective(
-    camera: OrthographicCamera | PerspectiveCamera
+    camera: OrthographicCamera | PerspectiveCamera,
   ): camera is PerspectiveCamera {
     return camera.type === "perspective";
   }
@@ -156,7 +156,7 @@ export function SceneDrawer({
           <form
             onSubmit={(e) => {
               handleSubmit(onSubmit)(e).catch(
-                reportError("Failed to update the scene")
+                reportError("Failed to update the scene"),
               );
             }}
           >

--- a/src/components/scene/SceneTable.tsx
+++ b/src/components/scene/SceneTable.tsx
@@ -61,12 +61,12 @@ function useScenes({
   return useSWR<GetRes<SceneData>, ErrorRes>(
     `/api/scenes?pageSize=${pageSize}${cursor ? `&cursor=${cursor}` : ""}${
       suppliedId ? `&suppliedId=${encodeURIComponent(suppliedId)}` : ""
-    }${name ? `&name=${encodeURIComponent(name)}` : ""}`
+    }${name ? `&name=${encodeURIComponent(name)}` : ""}`,
   );
 }
 
 function stateColor(
-  state?: string
+  state?: string,
 ): "default" | "success" | "warning" | "error" {
   switch (state) {
     case "commit":
@@ -98,11 +98,11 @@ export default function SceneTable({
     string | undefined
   >();
   const [prev, setPrev] = React.useState<Record<number, string | undefined>>(
-    {}
+    {},
   );
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [activeSceneId, setActiveSceneId] = React.useState<string | undefined>(
-    () => scene?.id
+    () => scene?.id,
   );
   const [suppliedId, setSuppliedIdFilter] = React.useState<
     string | undefined
@@ -129,12 +129,12 @@ export default function SceneTable({
 
   const debouncedSetSuppliedIdFilter = React.useMemo(
     () => debounce(setSuppliedIdFilter, 300),
-    []
+    [],
   );
 
   const debouncedSetNameFilter = React.useMemo(
     () => debounce(setNameFilter, 300),
-    []
+    [],
   );
 
   React.useEffect(() => {
@@ -170,7 +170,7 @@ export default function SceneTable({
 
   function handleChangePage(
     _: React.MouseEvent<HTMLButtonElement> | null,
-    num: number
+    num: number,
   ): void {
     if (curPage < num) {
       setPrev({ ...prev, [num - 1]: cursors?.self });
@@ -374,7 +374,7 @@ export default function SceneTable({
               displayedRows,
               cursors?.next != null,
               pageLength,
-              page != null
+              page != null,
             )
           }
           rowsPerPage={pageSize}

--- a/src/components/shared/Icon.tsx
+++ b/src/components/shared/Icon.tsx
@@ -2,11 +2,7 @@ import { Box } from "@mui/material";
 import React from "react";
 
 export type IconName =
-  | "expand-all"
-  | "collapse-all"
-  | "eye-open"
-  | "eye-half"
-  | "fit";
+  "expand-all" | "collapse-all" | "eye-open" | "eye-half" | "fit";
 
 export type IconSize = "xs" | "sm" | "md" | "lg";
 

--- a/src/components/shared/LeftDrawer.tsx
+++ b/src/components/shared/LeftDrawer.tsx
@@ -29,7 +29,7 @@ export function LeftDrawer(): JSX.Element {
   const isSectionActive = React.useCallback(
     (base: string) =>
       router.route === base || router.route.startsWith(`${base}/`),
-    [router.route]
+    [router.route],
   );
 
   return (
@@ -90,7 +90,7 @@ export function LeftDrawer(): JSX.Element {
             router
               .push("/property-key-policies")
               .catch(
-                reportError("Failed to navigate to /property-key-policies")
+                reportError("Failed to navigate to /property-key-policies"),
               );
           }}
           selected={router.route === "/property-key-policies"}

--- a/src/components/shared/ResourceLink.tsx
+++ b/src/components/shared/ResourceLink.tsx
@@ -29,7 +29,7 @@ export function ResourceLink({
     <Tooltip title={primaryActionLabel}>
       <Box
         component={linkComponent}
-        href={disabled ? undefined : href ?? "#"}
+        href={disabled ? undefined : (href ?? "#")}
         {...(linkComponent === NextLink ? { prefetch } : {})}
         role="link"
         tabIndex={disabled ? -1 : undefined}

--- a/src/components/shared/TableHead.tsx
+++ b/src/components/shared/TableHead.tsx
@@ -41,7 +41,7 @@ export function TableHead({
         {renderHeadCells(
           headCells.filter((hc) => hc.beforeCheckbox),
           onSortChange,
-          sort
+          sort,
         )}
         <TableCell padding="checkbox">
           <Checkbox
@@ -54,7 +54,7 @@ export function TableHead({
         {renderHeadCells(
           headCells.filter((hc) => !hc.beforeCheckbox),
           onSortChange,
-          sort
+          sort,
         )}
       </TableRow>
     </MuiTableHead>
@@ -63,7 +63,7 @@ export function TableHead({
 function renderHeadCells(
   cells: readonly HeadCell[],
   onSortChange?: (field: string) => void,
-  sort?: SortState
+  sort?: SortState,
 ): JSX.Element[] {
   return cells.map((hc) => (
     <TableCell

--- a/src/components/shared/TableToolbar.tsx
+++ b/src/components/shared/TableToolbar.tsx
@@ -25,7 +25,7 @@ export const TableToolbar = ({
           bgcolor: (theme) =>
             alpha(
               theme.palette.primary.main,
-              theme.palette.action.activatedOpacity
+              theme.palette.action.activatedOpacity,
             ),
         }),
       }}

--- a/src/components/shared/cursor-pagination.ts
+++ b/src/components/shared/cursor-pagination.ts
@@ -8,7 +8,7 @@ export function formatCursorPaginationLabel(
   { from, to }: DisplayedRows,
   hasNextPage: boolean,
   visibleRowCount: number,
-  isLoaded: boolean
+  isLoaded: boolean,
 ): string {
   if (!isLoaded) return `${from}\u2013${to}`;
   if (isLoaded && visibleRowCount === 0) return "0–0";

--- a/src/components/translation/QueuedTranslationsTable.tsx
+++ b/src/components/translation/QueuedTranslationsTable.tsx
@@ -28,13 +28,13 @@ interface QueuedTranslationsTableProps {
 function useRunningTranslations(
   status: string,
   refreshInterval: number,
-  fetchAll: boolean
+  fetchAll: boolean,
 ): SWRResponse {
   return useSWR(
     `/api/queued-translations?status=${status}&fetchAll=${fetchAll}`,
     {
       refreshInterval,
-    }
+    },
   );
 }
 
@@ -48,7 +48,7 @@ export function QueuedTranslationsTable({
   const { data, isValidating } = useRunningTranslations(
     status,
     refreshInterval || 0,
-    fetchAll ?? false
+    fetchAll ?? false,
   );
   const page = data ? toQueuedJobPage(data) : undefined;
   const items = filter ? page?.items.filter(filter) : page?.items;

--- a/src/components/viewer/CreateSceneViewStateDialog.tsx
+++ b/src/components/viewer/CreateSceneViewStateDialog.tsx
@@ -72,7 +72,7 @@ export default function CreatePartDialog({
           disabled={submitDisabled}
           onClick={() => {
             handleSubmit().catch(
-              reportError("Failed to create the view state")
+              reportError("Failed to create the view state"),
             );
           }}
           color="primary"

--- a/src/components/viewer/Layout.tsx
+++ b/src/components/viewer/Layout.tsx
@@ -36,18 +36,18 @@ function shouldForwardProp(prop: PropertyKey): boolean {
   );
 }
 
-const AppBar = styled(MuiAppBar, { shouldForwardProp })<DrawerProps>(
-  ({ theme }) => {
-    return {
+const AppBar = styled(MuiAppBar, { shouldForwardProp })<DrawerProps>(({
+  theme,
+}) => {
+  return {
+    width: `100%`,
+    zIndex: theme.zIndex.drawer + 1,
+    [theme.breakpoints.down("sm")]: {
+      margin: 0,
       width: `100%`,
-      zIndex: theme.zIndex.drawer + 1,
-      [theme.breakpoints.down("sm")]: {
-        margin: 0,
-        width: `100%`,
-      },
-    };
-  }
-);
+    },
+  };
+});
 
 const Main = styled("main", { shouldForwardProp })<{
   bottomDrawerHeight: number;

--- a/src/components/viewer/RightDrawer.tsx
+++ b/src/components/viewer/RightDrawer.tsx
@@ -73,7 +73,7 @@ export function RightDrawer({
 
   React.useEffect(() => {
     setWidth((currentWidth) =>
-      clampWidth(readStoredWidth(), maxWidth(currentWidth))
+      clampWidth(readStoredWidth(), maxWidth(currentWidth)),
     );
   }, [maxWidth]);
 
@@ -92,13 +92,13 @@ export function RightDrawer({
       if (!draggingRef.current) return;
       const { clientX, width: startWidth } = dragStartRef.current;
       setWidth(
-        clampWidth(startWidth + clientX - event.clientX, maxWidth(startWidth))
+        clampWidth(startWidth + clientX - event.clientX, maxWidth(startWidth)),
       );
     }
 
     function onResize(): void {
       setWidth((currentWidth) =>
-        clampWidth(currentWidth, maxWidth(currentWidth))
+        clampWidth(currentWidth, maxWidth(currentWidth)),
       );
     }
 

--- a/src/components/viewer/SceneTree.tsx
+++ b/src/components/viewer/SceneTree.tsx
@@ -37,12 +37,12 @@ export function SceneTree({
     const effectRef = ref.current;
 
     const onSelection = (
-      event: VertexSceneTreeTableCellCustomEvent<SceneTreeTableCellEventDetails>
+      event: VertexSceneTreeTableCellCustomEvent<SceneTreeTableCellEventDetails>,
     ): void => {
       const node = event.detail.node;
       if (node != null && onRowClick) {
         console.debug(
-          `Selected ${node.suppliedId?.value ?? node.id?.hex},${node.name}`
+          `Selected ${node.suppliedId?.value ?? node.id?.hex},${node.name}`,
         );
 
         onRowClick(node.id?.hex || "");
@@ -51,12 +51,12 @@ export function SceneTree({
 
     effectRef?.addEventListener(
       "selectionToggled",
-      onSelection as EventListener
+      onSelection as EventListener,
     );
     return () =>
       effectRef?.removeEventListener(
         "selectionToggled",
-        onSelection as EventListener
+        onSelection as EventListener,
       );
   }, [ref, onRowClick]);
 

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -66,7 +66,7 @@ type HOCViewerProps = React.RefAttributes<HTMLVertexViewerElement>;
 interface OnSelectProps extends HOCViewerProps {
   readonly onSelect: (
     detail: TapEventDetails,
-    hit?: vertexvis.protobuf.stream.IHit
+    hit?: vertexvis.protobuf.stream.IHit,
   ) => Promise<void>;
 }
 
@@ -131,7 +131,7 @@ function UnwrappedViewer({
       label: "Fit All",
       onSelect: () => {
         fitAll({ viewer: viewer.current }).catch(
-          reportError("Failed to fit all")
+          reportError("Failed to fit all"),
         );
       },
     },
@@ -140,7 +140,7 @@ function UnwrappedViewer({
       label: "Copy camera",
       onSelect: () => {
         copySceneViewCamera({ viewer: viewer.current }).catch(
-          reportError("Failed to copy scene view camera")
+          reportError("Failed to copy scene view camera"),
         );
       },
     },
@@ -154,7 +154,7 @@ function UnwrappedViewer({
       label: "Update base scene with current camera",
       onSelect: () => {
         handleUpdateBaseCamera().catch(
-          reportError("Failed to update base scene camera")
+          reportError("Failed to update base scene camera"),
         );
       },
     },
@@ -273,7 +273,7 @@ function UnwrappedViewer({
 }
 
 function onTap<P extends ViewerProps>(
-  WrappedViewer: ViewerComponentType
+  WrappedViewer: ViewerComponentType,
 ): React.FunctionComponent<P & OnSelectProps> {
   return function Component({
     viewerState,
@@ -283,7 +283,7 @@ function onTap<P extends ViewerProps>(
     const [hit, setHit] = React.useState<vertexvis.protobuf.stream.IHit>();
 
     async function handleTap(
-      e: VertexViewerCustomEvent<TapEventDetails>
+      e: VertexViewerCustomEvent<TapEventDetails>,
     ): Promise<void> {
       if (props.onTap) props.onTap(e);
 

--- a/src/lib/api-handler.ts
+++ b/src/lib/api-handler.ts
@@ -51,7 +51,7 @@ export type MethodHandler = (req: NextIronRequest) => Promise<Res>;
 export function methodRouter(handlers: Partial<Record<Method, MethodHandler>>) {
   return async function handle(
     req: NextIronRequest,
-    res: NextApiResponse
+    res: NextApiResponse,
   ): Promise<void> {
     const handler = handlers[req.method as Method];
     if (handler == null) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,7 +15,7 @@ export interface StreamCredentials {
 }
 
 export function head<T>(items?: T | T[]): T | undefined {
-  return Array.isArray(items) ? items[0] : items ?? undefined;
+  return Array.isArray(items) ? items[0] : (items ?? undefined);
 }
 
 export function isValidHttpUrl(givenUrl?: string): boolean {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -20,7 +20,7 @@ export function toLocaleString(date?: string, fallback = ""): string {
  */
 export function toLocalDayBoundaryIso(
   value: string,
-  boundary: DayBoundary
+  boundary: DayBoundary,
 ): string {
   const [year, month, day] = value.split("-").map(Number);
   const date =

--- a/src/lib/file-collections.ts
+++ b/src/lib/file-collections.ts
@@ -47,14 +47,14 @@ interface FileCollectionSort {
  */
 export function sortFileCollections(
   fileCollections: FileCollectionList["data"],
-  sort?: string
+  sort?: string,
 ): FileCollectionList["data"] {
   const parsedSort = parseFileCollectionSort(sort);
   if (parsedSort == null) return fileCollections;
 
   return [...fileCollections].sort((left, right) => {
     const comparison = (left.attributes[parsedSort.field] ?? "").localeCompare(
-      right.attributes[parsedSort.field] ?? ""
+      right.attributes[parsedSort.field] ?? "",
     );
 
     return parsedSort.order === "asc" ? comparison : -comparison;
@@ -62,7 +62,7 @@ export function sortFileCollections(
 }
 
 function parseFileCollectionSort(
-  sort?: string
+  sort?: string,
 ): FileCollectionSort | undefined {
   if (sort == null) return undefined;
 
@@ -74,40 +74,40 @@ function parseFileCollectionSort(
 }
 
 function isFileCollectionSortField(
-  field: string
+  field: string,
 ): field is FileCollectionSortField {
   return FileCollectionSortFields.includes(field as FileCollectionSortField);
 }
 
 export function toFileCollection(
-  data: FileCollectionMetadataData
+  data: FileCollectionMetadataData,
 ): FileCollection {
   return { ...data.attributes, id: data.id };
 }
 
 export function toFileCollectionPage(
-  res: FileCollectionPageRes
+  res: FileCollectionPageRes,
 ): Paged<FileCollection> {
   return toPage<FileCollectionResource, FileCollectionAttributes>(res);
 }
 
 export function getFileCollectionsApi(
-  client: VertexClient
+  client: VertexClient,
 ): FileCollectionsApi {
   return new FileCollectionsApi(client.config, undefined, client.axiosInstance);
 }
 
 export function fetchAllFileCollectionFiles(
   api: FileCollectionsApi,
-  id: string
+  id: string,
 ): Promise<FileMetadataData[]> {
   return fetchAllPages((pageCursor) =>
-    api.listFileCollectionFiles({ id, pageCursor, pageSize: 200 })
+    api.listFileCollectionFiles({ id, pageCursor, pageSize: 200 }),
   );
 }
 
 export function getFileCollectionExportAvailability(
-  files: FileMetadataData[]
+  files: FileMetadataData[],
 ): FileCollectionExportAvailability {
   if (files.length === 0) {
     return {
@@ -118,7 +118,7 @@ export function getFileCollectionExportAvailability(
   }
 
   const hasIncompleteFiles = files.some(
-    (file) => !isCompleteFileStatus(file.attributes.status)
+    (file) => !isCompleteFileStatus(file.attributes.status),
   );
 
   if (hasIncompleteFiles) {

--- a/src/lib/file-jobs.ts
+++ b/src/lib/file-jobs.ts
@@ -23,7 +23,7 @@ export function getFileJobsApi(client: VertexClient): FileJobsApi {
 
 export function buildFileArchiveJobRequest(
   files: FileMetadataData[],
-  archiveFileId: string
+  archiveFileId: string,
 ): CreateFileJobRequest {
   const fileIds = files.map((file) => file.id);
 
@@ -46,7 +46,7 @@ export function buildFileArchiveJobRequest(
 export function toFileJobRes(
   job: QueuedJob,
   status = 200,
-  archiveFileId?: string
+  archiveFileId?: string,
 ): FileJobRes {
   return {
     ...(archiveFileId == null ? {} : { archiveFileId }),

--- a/src/lib/hooks/use-user.ts
+++ b/src/lib/hooks/use-user.ts
@@ -10,7 +10,7 @@ interface UseUserResponse {
   readonly mutate: (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data?: any,
-    shouldRevalidate?: boolean | undefined
+    shouldRevalidate?: boolean | undefined,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ) => Promise<any>;
 }

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -83,7 +83,7 @@ function alphabetize<T extends Record<string, unknown>>(obj: T): T {
 }
 
 function toValue(
-  property: vertexvis.protobuf.stream.IMetadataProperty
+  property: vertexvis.protobuf.stream.IMetadataProperty,
 ): string | undefined {
   if (property.asString) return property.asString;
   if (property.asFloat) return property.asFloat.toString();

--- a/src/lib/model-views.ts
+++ b/src/lib/model-views.ts
@@ -101,11 +101,11 @@ export function useModelViews({
   return {
     modelViewList: modelViewResponses.reduce(
       (modelViews, r) => [...modelViews, ...r.modelViews],
-      [] as ModelView[]
+      [] as ModelView[],
     ),
     annotationList: annotationResponses.reduce(
       (annotations, r) => [...annotations, ...r.annotations],
-      [] as PmiAnnotation[]
+      [] as PmiAnnotation[],
     ),
     loadedModelViewId,
     loadedSceneItemId,
@@ -124,7 +124,7 @@ interface UseModelViewActionsProps {
   readonly setLoadedSceneItemId: (id?: string) => void;
   readonly updateLoadedModelViews: (response: ModelViewListResponse) => void;
   readonly updateLoadedAnnotations: (
-    response: PmiAnnotationListResponse
+    response: PmiAnnotationListResponse,
   ) => void;
 }
 
@@ -159,7 +159,7 @@ function useModelViewActions({
             hasAnnotations: true,
             size: 100,
             cursor: modelViewCursor,
-          }
+          },
         );
 
         updateLoadedModelViews(resp);

--- a/src/lib/multer/api-storage-engine.ts
+++ b/src/lib/multer/api-storage-engine.ts
@@ -9,7 +9,7 @@ const VertexAPIStorageEngine = {
   _handleFile: async (
     req: Request & { session: ironSession.Session },
     file: Express.Multer.File,
-    cb: (error?: Error, info?: Partial<Express.Multer.File>) => void
+    cb: (error?: Error, info?: Partial<Express.Multer.File>) => void,
   ): Promise<void> => {
     await ironSession.applySession(req, null, CookieAttributes);
 

--- a/src/lib/paging.ts
+++ b/src/lib/paging.ts
@@ -21,7 +21,7 @@ const QueryParamOrder = ["pageSize", "cursor", "sort", "suppliedId", "name"];
 
 export function buildQuery(
   path: string,
-  params: Record<string, QueryValue>
+  params: Record<string, QueryValue>,
 ): string {
   const query = new URLSearchParams();
   const entries = Object.entries(params).sort(([leftKey], [rightKey]) => {
@@ -83,7 +83,7 @@ export function useCursorPagingState(): {
 
       setCurrentPage(nextPage);
     },
-    [currentPage, cursors, previous]
+    [currentPage, cursors, previous],
   );
 
   return {
@@ -116,7 +116,7 @@ interface CursorPage<T> {
 
 /** Fetch every cursor-paginated page using the API client's cursor parser. */
 export async function fetchAllPages<T, TPage extends CursorPage<T>>(
-  fetchPage: (cursor?: string) => Promise<AxiosResponse<TPage>>
+  fetchPage: (cursor?: string) => Promise<AxiosResponse<TPage>>,
 ): Promise<T[]> {
   const items: T[] = [];
   const seenCursors = new Set<string>();

--- a/src/lib/part-revisions.ts
+++ b/src/lib/part-revisions.ts
@@ -14,7 +14,7 @@ export function toPartRevision(data: PartRevisionData): PartRevision {
 }
 
 export function toPartRevisionPage(
-  res: GetRes<PartRevisionData>
+  res: GetRes<PartRevisionData>,
 ): Paged<PartRevision> {
   return toPage<PartRevisionData, PartRevisionDataAttributes>(res);
 }

--- a/src/lib/property-key-policies.ts
+++ b/src/lib/property-key-policies.ts
@@ -84,13 +84,13 @@ export type PartialDeletePropertyKeyPoliciesRes =
   };
 
 export function toPropertyKeyPolicy(
-  data: PropertyKeyPolicyResource
+  data: PropertyKeyPolicyResource,
 ): PropertyKeyPolicy {
   return { ...data.attributes, id: data.id };
 }
 
 export function toPropertyKeyPolicyPage(
-  res: PropertyKeyPolicyPageRes
+  res: PropertyKeyPolicyPageRes,
 ): Paged<PropertyKeyPolicy> {
   return toPage<
     PropertyKeyPolicyResource,
@@ -99,17 +99,17 @@ export function toPropertyKeyPolicyPage(
 }
 
 export function toPropertyKeyPolicyKey(
-  data: PropertyKeyPolicyKeyResource
+  data: PropertyKeyPolicyKeyResource,
 ): PropertyKeyPolicyKey {
   return { id: data.id, name: data.attributes.name };
 }
 
 export function getPropertyKeyPoliciesApi(
-  client: VertexClient
+  client: VertexClient,
 ): PropertyKeyPoliciesApi {
   return new PropertyKeyPoliciesApi(
     client.config,
     undefined,
-    client.axiosInstance
+    client.axiosInstance,
   );
 }

--- a/src/lib/query-filters.ts
+++ b/src/lib/query-filters.ts
@@ -15,7 +15,7 @@ const FilterOperations: FilterOperation[] = [
 export function setFilterExpression(
   params: URLSearchParams,
   field: string,
-  filter?: FilterExpression
+  filter?: FilterExpression,
 ): void {
   if (filter == null) return;
 

--- a/src/lib/query-params.ts
+++ b/src/lib/query-params.ts
@@ -1,6 +1,6 @@
 export function parsePositiveQueryInt(
   value: string | undefined,
-  defaultValue: number
+  defaultValue: number,
 ): number {
   const trimmed = value?.trim();
   if (trimmed == null || !/^\d+$/.test(trimmed)) return defaultValue;

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -6,14 +6,14 @@ export interface SortState<TField extends string = string> {
 }
 
 export function toSortParam<TField extends string>(
-  sort: SortState<TField>
+  sort: SortState<TField>,
 ): string {
   return sort.order === "desc" ? `-${sort.field}` : sort.field;
 }
 
 export function toggleSort<TField extends string>(
   current: SortState<TField>,
-  field: TField
+  field: TField,
 ): SortState<TField> {
   return {
     field,

--- a/src/lib/vertex-api.ts
+++ b/src/lib/vertex-api.ts
@@ -38,7 +38,7 @@ const basePath = (env: string, networkConfig?: NetworkConfig): string => {
 
 export async function makeCallRes<T>(
   res: NextApiResponse<T | Failure>,
-  apiCall: () => Promise<AxiosResponse<T>>
+  apiCall: () => Promise<AxiosResponse<T>>,
 ): Promise<void> {
   const result = await makeCall(apiCall);
   return isFailure(result)
@@ -47,7 +47,7 @@ export async function makeCallRes<T>(
 }
 
 export async function makeCall<T>(
-  apiCall: () => Promise<AxiosResponse<T>>
+  apiCall: () => Promise<AxiosResponse<T>>,
 ): Promise<T | Failure> {
   try {
     return (await apiCall()).data;
@@ -63,7 +63,7 @@ export async function getToken(
   id: string,
   secret: string,
   env: string,
-  networkConfig?: NetworkConfig
+  networkConfig?: NetworkConfig,
 ): Promise<OAuth2Token> {
   const auth = new Oauth2Api(
     new Configuration({
@@ -71,7 +71,7 @@ export async function getToken(
       username: id,
       password: secret,
     }),
-    basePath(env, networkConfig)
+    basePath(env, networkConfig),
   );
 
   return (await auth.createToken({ grantType: "client_credentials" })).data;
@@ -82,7 +82,7 @@ export async function getClientWithCreds(
   secret: string,
   env: string,
   token: OAuth2Token,
-  networkConfig?: NetworkConfig
+  networkConfig?: NetworkConfig,
 ): Promise<VertexClient> {
   const client = await VertexClient.build({
     basePath: basePath(env, networkConfig),
@@ -97,7 +97,7 @@ export async function getClientWithCreds(
 }
 
 export async function getClientFromSession(
-  session: Session
+  session: Session,
 ): Promise<VertexClient> {
   const creds = getCreds(session);
   const env = getEnv(session);
@@ -121,7 +121,7 @@ export async function getClientFromSession(
         ...newToken,
         expires_in: newExpiration,
       },
-      networkConfig
+      networkConfig,
     );
   }
 
@@ -133,7 +133,7 @@ export async function getClientFromSession(
       ...token.token,
       expires_in: expiresIn,
     },
-    networkConfig
+    networkConfig,
   );
 }
 

--- a/src/lib/viewer.ts
+++ b/src/lib/viewer.ts
@@ -51,7 +51,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
   async function updateVisibility(
     scene: Scene,
     visible: boolean,
-    queryBuilder: (op: SceneItemQueryExecutor) => SceneItemOperationsBuilder
+    queryBuilder: (op: SceneItemQueryExecutor) => SceneItemOperationsBuilder,
   ): Promise<void> {
     await scene
       .items((op) => {
@@ -69,7 +69,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
   async function updateSelection(
     scene: Scene,
     selected: boolean,
-    queryBuilder: (op: SceneItemQueryExecutor) => SceneItemOperationsBuilder
+    queryBuilder: (op: SceneItemQueryExecutor) => SceneItemOperationsBuilder,
   ): Promise<void> {
     await scene
       .items((op) => {
@@ -114,7 +114,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
 
       if (scene != null) {
         await updateVisibility(scene, visible, (op) =>
-          op.where((q) => q.withItemIds([itemId]))
+          op.where((q) => q.withItemIds([itemId])),
         );
       }
     },
@@ -123,7 +123,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
 
       if (scene != null) {
         await updateVisibility(scene, visible, (op) =>
-          op.where((q) => q.all())
+          op.where((q) => q.all()),
         );
       }
     },
@@ -132,7 +132,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
 
       if (scene != null) {
         await updateVisibility(scene, visible, (op) =>
-          op.where((q) => q.withSelected())
+          op.where((q) => q.withSelected()),
         );
       }
     },
@@ -141,7 +141,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
 
       if (scene != null) {
         await updateSelection(scene, selected, (op) =>
-          op.where((q) => q.withItemIds([itemId]))
+          op.where((q) => q.withItemIds([itemId])),
         );
       }
     },
@@ -181,7 +181,7 @@ function useViewerActions({ element }: UseViewerActionsProps): ViewerActions {
 }
 
 export function viewerHasSelection(
-  viewer: React.MutableRefObject<HTMLVertexViewerElement | null>
+  viewer: React.MutableRefObject<HTMLVertexViewerElement | null>,
 ): boolean {
   return (
     viewer.current?.frame?.scene.sceneViewSummary.selectedVisibleSummary !=

--- a/src/lib/with-session.ts
+++ b/src/lib/with-session.ts
@@ -56,14 +56,14 @@ export const CookieAttributes: SessionOptions = {
 export type NextIronRequest = NextApiRequest & { readonly session: Session };
 
 export default function withSession(
-  handler: Handler<NextIronRequest, NextApiResponse>
+  handler: Handler<NextIronRequest, NextApiResponse>,
 ): Handler<NextApiRequest, NextApiResponse> {
   return withIronSession(handler, CookieAttributes);
 }
 
 export const defaultServerSideProps = withIronSession(
   serverSidePropsHandler,
-  CookieAttributes
+  CookieAttributes,
 );
 
 export function serverSidePropsHandler({
@@ -106,7 +106,7 @@ export function setCreds(session: Session, val: OAuthCredentials): void {
 export function setEnv(
   session: Session,
   val: EnvironmentWithCustom,
-  networkConfig?: NetworkConfig
+  networkConfig?: NetworkConfig,
 ): void {
   session.set(EnvKey, val);
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -52,12 +52,11 @@ MyDocument.getInitialProps = async (ctx) => {
   ctx.renderPage = () =>
     originalRenderPage({
       // eslint-disable-next-line react/display-name
-      enhanceComponent: (Component) => (props) =>
-        (
-          <CacheProvider value={cache}>
-            <Component {...props} />
-          </CacheProvider>
-        ),
+      enhanceComponent: (Component) => (props) => (
+        <CacheProvider value={cache}>
+          <Component {...props} />
+        </CacheProvider>
+      ),
     });
 
   const initialProps = await Document.getInitialProps(ctx);

--- a/src/pages/api/file-collections.ts
+++ b/src/pages/api/file-collections.ts
@@ -32,7 +32,7 @@ export const handleFileCollections = methodRouter({ GET: get, DELETE: del });
 export default withSession(handleFileCollections);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<FileCollectionMetadataData>> {
   const client = await getClientFromSession(req.session);
   const ps = head(req.query.pageSize);
@@ -49,14 +49,14 @@ async function get(
   setFilterExpression(
     query,
     "name",
-    name != null ? ({ contains: name } satisfies FilterExpression) : undefined
+    name != null ? ({ contains: name } satisfies FilterExpression) : undefined,
   );
   setFilterExpression(
     query,
     "suppliedId",
     suppliedId != null
       ? ({ contains: suppliedId } satisfies FilterExpression)
-      : undefined
+      : undefined,
   );
   if (sort != null) query.set("sort", sort);
   setFilterExpression(
@@ -67,7 +67,7 @@ async function get(
           ...(createdAtStart != null ? { gte: createdAtStart } : {}),
           ...(createdAtEnd != null ? { lte: createdAtEnd } : {}),
         } satisfies FilterExpression)
-      : undefined
+      : undefined,
   );
 
   // TODO: Use FileCollectionsApi.listFileCollections once the SDK supports
@@ -81,8 +81,8 @@ async function get(
             Accept: "application/vnd.api+json",
             Authorization: `Bearer ${client.token.access_token}`,
           },
-        }
-      )
+        },
+      ),
   );
   return {
     cursors,
@@ -99,7 +99,7 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
 
   const c = getFileCollectionsApi(await getClientFromSession(req.session));
   const results = await Promise.all(
-    b.ids.map((id) => makeCall(() => c.deleteFileCollection({ id })))
+    b.ids.map((id) => makeCall(() => c.deleteFileCollection({ id }))),
   );
   const failure = results.find(isErrorFailure);
   if (failure != null) return toErrorRes({ failure });

--- a/src/pages/api/file-collections/[id]/files.ts
+++ b/src/pages/api/file-collections/[id]/files.ts
@@ -12,7 +12,7 @@ export const handleFileCollectionFiles = methodRouter({ GET: get });
 export default withSession(handleFileCollectionFiles);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<FileMetadataData>> {
   const id = head(req.query.id);
   if (id == null)
@@ -26,7 +26,7 @@ async function get(
       id,
       pageCursor: cursor,
       pageSize: parsePositiveQueryInt(pageSize, 10),
-    })
+    }),
   );
 
   return { cursors, data: page.data, status: 200 };

--- a/src/pages/api/file-collections/[id]/index.ts
+++ b/src/pages/api/file-collections/[id]/index.ts
@@ -16,7 +16,7 @@ export const handleFileCollection = methodRouter({ GET: get });
 export default withSession(handleFileCollection);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetFileCollectionRes> {
   const id = head(req.query.id);
   if (id == null)

--- a/src/pages/api/file-jobs.ts
+++ b/src/pages/api/file-jobs.ts
@@ -46,7 +46,7 @@ async function create(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
   const { fileCollectionId } = body;
   const files = await fetchAllFileCollectionFiles(
     getFileCollectionsApi(client),
-    fileCollectionId
+    fileCollectionId,
   );
 
   const exportAvailability = getFileCollectionExportAvailability(files);
@@ -71,7 +71,7 @@ async function create(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
           },
         },
       },
-    })
+    }),
   );
   if (isErrorFailure(archiveFile)) return toErrorRes({ failure: archiveFile });
 
@@ -79,9 +79,9 @@ async function create(req: NextIronRequest): Promise<ErrorRes | FileJobRes> {
     getFileJobsApi(client).createFileJob({
       createFileJobRequest: buildFileArchiveJobRequest(
         files,
-        archiveFile.data.id
+        archiveFile.data.id,
       ),
-    })
+    }),
   );
   if (isErrorFailure(job)) return toErrorRes({ failure: job });
 

--- a/src/pages/api/files.ts
+++ b/src/pages/api/files.ts
@@ -91,7 +91,7 @@ async function get(req: NextIronRequest): Promise<ErrorRes | GetRes<FileData>> {
           Accept: "application/vnd.api+json",
           Authorization: `Bearer ${c.token.access_token}`,
         },
-      }) as Promise<AxiosResponse<FileList>>
+      }) as Promise<AxiosResponse<FileList>>,
   );
   return { cursors, data: page.data, status: 200 };
 }
@@ -104,7 +104,7 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
 
   const c = await getClientFromSession(req.session);
   await Promise.all(
-    b.ids.map((id) => makeCall(() => c.files.deleteFile({ id })))
+    b.ids.map((id) => makeCall(() => c.files.deleteFile({ id }))),
   );
   return { status: 200 };
 }

--- a/src/pages/api/files/[id]/download-url.ts
+++ b/src/pages/api/files/[id]/download-url.ts
@@ -11,7 +11,7 @@ const DefaultDownloadExpirySeconds = 30;
 export default withSession(methodRouter({ POST: create }));
 
 async function create(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<FileDownloadUrlRes | ErrorRes> {
   const id = head(req.query.id);
   if (id == null) return InvalidBody;

--- a/src/pages/api/files/[id]/download.ts
+++ b/src/pages/api/files/[id]/download.ts
@@ -17,7 +17,7 @@ export default withSession(handleFileDownload);
 
 export async function handleFileDownload(
   req: NextIronRequest,
-  res: NextApiResponse<ErrorRes>
+  res: NextApiResponse<ErrorRes>,
 ): Promise<void> {
   if (req.method !== "GET") {
     return res.status(MethodNotAllowed.status).json(MethodNotAllowed);

--- a/src/pages/api/files/[id]/file-collections.ts
+++ b/src/pages/api/files/[id]/file-collections.ts
@@ -15,7 +15,7 @@ export const handleFileCollectionsByFile = methodRouter({ GET: get });
 export default withSession(handleFileCollectionsByFile);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<FileCollectionMetadataData>> {
   const id = head(req.query.id);
   if (id == null) return { message: "File ID required.", status: 400 };
@@ -29,7 +29,7 @@ async function get(
       id,
       pageCursor: cursor,
       pageSize: parsePositiveQueryInt(pageSize, 10),
-    })
+    }),
   );
 
   return { cursors, data: page.data, status: 200 };

--- a/src/pages/api/login.ts
+++ b/src/pages/api/login.ts
@@ -23,7 +23,7 @@ export interface LoginReq {
 
 export async function handleLogin(
   req: NextIronRequest,
-  res: NextApiResponse<Res | ErrorRes>
+  res: NextApiResponse<Res | ErrorRes>,
 ): Promise<void> {
   if (req.method === "POST") {
     const b: LoginReq = JSON.parse(req.body);

--- a/src/pages/api/logout.ts
+++ b/src/pages/api/logout.ts
@@ -4,7 +4,7 @@ import withSession, { NextIronRequest } from "../../lib/with-session";
 
 export default withSession(function (
   req: NextIronRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   req.session.destroy();
   const r = { status: 200 };

--- a/src/pages/api/merged-scenes.ts
+++ b/src/pages/api/merged-scenes.ts
@@ -78,7 +78,7 @@ async function create(req: NextIronRequest): Promise<ErrorRes | MergeSceneRes> {
           },
         },
       });
-    })
+    }),
   );
 
   await makeCall(() =>
@@ -95,7 +95,7 @@ async function create(req: NextIronRequest): Promise<ErrorRes | MergeSceneRes> {
           type: "scene",
         },
       },
-    })
+    }),
   );
 
   return { status: 200, queuedItemIds: items.map((i) => i.data.data.id) };

--- a/src/pages/api/part-revisions.ts
+++ b/src/pages/api/part-revisions.ts
@@ -9,7 +9,7 @@ import withSession, { NextIronRequest } from "../../lib/with-session";
 export default withSession(methodRouter({ GET: get }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<PartRevisionData>> {
   const c = await getClientFromSession(req.session);
   const ps = head(req.query.pageSize);
@@ -22,7 +22,7 @@ async function get(
     c.partRevisions.getPartRevisions({
       id: pId,
       pageSize: parsePositiveQueryInt(ps, 10),
-    })
+    }),
   );
   return { cursors, data: page.data, status: 200 };
 }

--- a/src/pages/api/part-revisions/[id].ts
+++ b/src/pages/api/part-revisions/[id].ts
@@ -8,7 +8,7 @@ import withSession, { NextIronRequest } from "../../../lib/with-session";
 export default withSession(methodRouter({ GET: get }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | (PartRevisionData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);

--- a/src/pages/api/parts.ts
+++ b/src/pages/api/parts.ts
@@ -30,7 +30,7 @@ export type CreatePartReq = Pick<
 export type CreatePartRes = Pick<QueuedJobData, "id"> & Res;
 
 export default withSession(
-  methodRouter({ GET: get, DELETE: del, POST: create })
+  methodRouter({ GET: get, DELETE: del, POST: create }),
 );
 
 async function get(req: NextIronRequest): Promise<ErrorRes | GetRes<PartData>> {
@@ -44,7 +44,7 @@ async function get(req: NextIronRequest): Promise<ErrorRes | GetRes<PartData>> {
       pageCursor: pc,
       pageSize: parsePositiveQueryInt(ps, 10),
       filterSuppliedId: sId,
-    })
+    }),
   );
   return { cursors, data: page.data, status: 200 };
 }
@@ -57,7 +57,7 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
 
   const c = await getClientFromSession(req.session);
   await Promise.all(
-    b.ids.map((id) => makeCall(() => c.parts.deletePart({ id })))
+    b.ids.map((id) => makeCall(() => c.parts.deletePart({ id }))),
   );
   return { status: 200 };
 }

--- a/src/pages/api/property-key-policies.ts
+++ b/src/pages/api/property-key-policies.ts
@@ -40,7 +40,7 @@ export async function handlePropertyKeyPolicies(
     | CreatePropertyKeyPolicyRes
     | DeletePropertyKeyPoliciesRes
     | ErrorRes
-  >
+  >,
 ): Promise<void> {
   if (req.method === "GET") {
     const r = await get(req);
@@ -63,7 +63,7 @@ export async function handlePropertyKeyPolicies(
 export default withSession(handlePropertyKeyPolicies);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | PropertyKeyPolicyPageRes> {
   try {
     const client = await getClientFromSession(req.session);
@@ -79,7 +79,7 @@ async function get(
       "suppliedId",
       suppliedId != null
         ? ({ contains: suppliedId } satisfies FilterExpression)
-        : undefined
+        : undefined,
     );
 
     const { cursors, page } = await getPage(
@@ -91,8 +91,8 @@ async function get(
               Accept: "application/vnd.api+json",
               Authorization: `Bearer ${client.token.access_token}`,
             },
-          }
-        )
+          },
+        ),
     );
     return {
       cursors,
@@ -109,7 +109,7 @@ async function get(
 }
 
 async function create(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | CreatePropertyKeyPolicyRes> {
   if (!req.body) return BodyRequired;
 
@@ -134,7 +134,7 @@ async function create(
             },
           },
         },
-      })
+      }),
     );
     if (isErrorFailure(created)) return toErrorRes({ failure: created });
 
@@ -144,7 +144,7 @@ async function create(
     const keys = await makeCall(() =>
       client.axiosInstance.post<void>(
         `${client.config.basePath}/property-key-policies/${encodeURIComponent(
-          created.data.id
+          created.data.id,
         )}/keys`,
         { data: body.keys.map((name) => ({ name })) },
         {
@@ -153,8 +153,8 @@ async function create(
             Authorization: `Bearer ${client.token.access_token}`,
             "Content-Type": "application/vnd.api+json",
           },
-        }
-      )
+        },
+      ),
     );
     if (isErrorFailure(keys)) {
       return {
@@ -175,7 +175,7 @@ async function create(
 }
 
 async function del(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<
   ErrorRes | DeletePropertyKeyPoliciesRes | PartialDeletePropertyKeyPoliciesRes
 > {
@@ -199,13 +199,13 @@ async function del(
 
   try {
     const c = getPropertyKeyPoliciesApi(
-      await getClientFromSession(req.session)
+      await getClientFromSession(req.session),
     );
     const results = await Promise.all(
-      ids.map((id) => makeCall(() => c.deletePropertyKeyPolicy({ id })))
+      ids.map((id) => makeCall(() => c.deletePropertyKeyPolicy({ id }))),
     );
     const deletedIds = ids.filter(
-      (_, index) => !isErrorFailure(results[index])
+      (_, index) => !isErrorFailure(results[index]),
     );
     const failedIds = ids.filter((_, index) => isErrorFailure(results[index]));
     if (failedIds.length > 0) {
@@ -233,7 +233,7 @@ async function del(
 }
 
 function parseCreatePropertyKeyPolicyReq(
-  body: unknown
+  body: unknown,
 ): CreatePropertyKeyPolicyReq | undefined {
   try {
     const parsed = (
@@ -268,7 +268,7 @@ function parseCreatePropertyKeyPolicyReq(
 }
 
 function isPropertyKeyPolicyMode(
-  value: unknown
+  value: unknown,
 ): value is PropertyKeyPolicyMode {
   return (
     value === PropertyKeyPolicyMode.Allowlist ||

--- a/src/pages/api/property-key-policies/[id]/index.ts
+++ b/src/pages/api/property-key-policies/[id]/index.ts
@@ -17,7 +17,7 @@ import withSession, { NextIronRequest } from "../../../../lib/with-session";
 
 export async function handlePropertyKeyPolicy(
   req: NextIronRequest,
-  res: NextApiResponse<GetPropertyKeyPolicyRes | ErrorRes>
+  res: NextApiResponse<GetPropertyKeyPolicyRes | ErrorRes>,
 ): Promise<void> {
   if (req.method === "GET") {
     const r = await get(req);
@@ -30,7 +30,7 @@ export async function handlePropertyKeyPolicy(
 export default withSession(handlePropertyKeyPolicy);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetPropertyKeyPolicyRes> {
   try {
     const id = head(req.query.id);
@@ -38,7 +38,7 @@ async function get(
       return { message: "Property Key Policy ID required.", status: 400 };
 
     const c = getPropertyKeyPoliciesApi(
-      await getClientFromSession(req.session)
+      await getClientFromSession(req.session),
     );
     const res = await makeCall(() => c.getPropertyKeyPolicy({ id }));
     if (isErrorFailure(res)) return toErrorRes({ failure: res });

--- a/src/pages/api/property-key-policies/[id]/keys.ts
+++ b/src/pages/api/property-key-policies/[id]/keys.ts
@@ -33,7 +33,7 @@ interface PropertyKeyPolicyKeyList {
 
 export async function handlePropertyKeyPolicyKeys(
   req: NextIronRequest,
-  res: NextApiResponse<GetPropertyKeyPolicyKeysRes | ErrorRes>
+  res: NextApiResponse<GetPropertyKeyPolicyKeysRes | ErrorRes>,
 ): Promise<void> {
   if (req.method === "GET") {
     const r = await get(req);
@@ -46,7 +46,7 @@ export async function handlePropertyKeyPolicyKeys(
 export default withSession(handlePropertyKeyPolicyKeys);
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetPropertyKeyPolicyKeysRes> {
   try {
     const id = head(req.query.id);
@@ -70,7 +70,7 @@ async function get(
           ...(pageCursor != null ? { "page[cursor]": pageCursor } : {}),
           "page[size]": KeysPageSize,
         },
-      })
+      }),
     );
 
     return { data, status: 200 };

--- a/src/pages/api/queued-translations.ts
+++ b/src/pages/api/queued-translations.ts
@@ -14,7 +14,7 @@ import withSession, { NextIronRequest } from "../../lib/with-session";
 export default withSession(methodRouter({ GET: get }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<QueuedJobData>> {
   const c = await getClientFromSession(req.session);
   const ps = head(req.query.pageSize);
@@ -43,7 +43,7 @@ async function get(
         pageCursor: pc,
         pageSize: parsePositiveQueryInt(ps, 200),
         filterStatus: status,
-      })
+      }),
     );
     return { cursors, data: page.data, status: 200 };
   }
@@ -51,7 +51,7 @@ async function get(
 
 export const fetchAllTranslations = async (
   c: VertexClient,
-  status: string
+  status: string,
 ): Promise<QueuedJobData[]> => {
   const queuedJobData: QueuedJobData[][] = [];
   let cursor: string | undefined;
@@ -63,7 +63,7 @@ export const fetchAllTranslations = async (
         pageCursor: cursor ?? undefined,
         pageSize: 200,
         filterStatus: status,
-      })
+      }),
     );
     promises.push(resPromise);
     const { cursors, page } = await resPromise;

--- a/src/pages/api/scene-items/[id].ts
+++ b/src/pages/api/scene-items/[id].ts
@@ -8,7 +8,7 @@ import withSession, { NextIronRequest } from "../../../lib/with-session";
 export default withSession(methodRouter({ GET: get }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | (SceneItemData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);

--- a/src/pages/api/scene-view-states.ts
+++ b/src/pages/api/scene-view-states.ts
@@ -23,7 +23,7 @@ export type CreateViewStateRes = Pick<SceneViewStateData, "id"> & Res;
 export default withSession(methodRouter({ GET: get, POST: create }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<SceneViewStateData>> {
   const c = await getClientFromSession(req.session);
   const vId = head(req.query.view);
@@ -38,13 +38,13 @@ async function get(
     c.sceneViewStates.getSceneViewStates({
       id: sceneId,
       pageSize: 50,
-    })
+    }),
   );
   return { cursors, data: page.data, status: 200 };
 }
 
 async function create(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | CreateViewStateRes> {
   if (!req.body) return BodyRequired;
 

--- a/src/pages/api/scenes.ts
+++ b/src/pages/api/scenes.ts
@@ -43,11 +43,11 @@ export type UpdateSceneReq = Pick<ScenesApiUpdateSceneRequest, "id"> &
   >;
 
 export default withSession(
-  methodRouter({ GET: get, DELETE: del, PATCH: upd, POST: create })
+  methodRouter({ GET: get, DELETE: del, PATCH: upd, POST: create }),
 );
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | GetRes<SceneData>> {
   const c = await getClientFromSession(req.session);
   const ps = head(req.query.pageSize);
@@ -63,7 +63,7 @@ async function get(
   query.set("page[size]", parsePositiveQueryInt(ps, 10).toString());
   query.set(
     "fields[scene]",
-    "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount"
+    "metadata,state,camera,worldOrientation,name,suppliedId,created,modified,sceneItemCount",
   );
   setFilterExpression(query, "name", filterName);
   setFilterExpression(query, "suppliedId", filterSuppliedId);
@@ -75,7 +75,7 @@ async function get(
           Accept: "application/vnd.api+json",
           Authorization: `Bearer ${c.token.access_token}`,
         },
-      }) as Promise<AxiosResponse<SceneList>>
+      }) as Promise<AxiosResponse<SceneList>>,
   );
   return { cursors, data: page.data, status: 200 };
 }
@@ -88,7 +88,7 @@ async function del(req: NextIronRequest): Promise<ErrorRes | Res> {
 
   const c = await getClientFromSession(req.session);
   await Promise.all(
-    b.ids.map((id) => makeCall(() => c.scenes.deleteScene({ id })))
+    b.ids.map((id) => makeCall(() => c.scenes.deleteScene({ id }))),
   );
   return { status: 200 };
 }
@@ -97,7 +97,7 @@ async function upd(req: NextIronRequest): Promise<ErrorRes | Res> {
   if (!req.body) return BodyRequired;
 
   const { id, name, suppliedId, camera, metadata }: UpdateSceneReq = JSON.parse(
-    req.body
+    req.body,
   );
   const c = await getClientFromSession(req.session);
   await makeCall(() =>
@@ -109,13 +109,13 @@ async function upd(req: NextIronRequest): Promise<ErrorRes | Res> {
           type: "scene",
         },
       },
-    })
+    }),
   );
   return { status: 200 };
 }
 
 async function create(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | CreateSceneRes> {
   const b: CreateSceneReq = JSON.parse(req.body);
   if (!req.body) return InvalidBody;
@@ -167,7 +167,7 @@ async function create(
           type: "scene",
         },
       },
-    })
+    }),
   );
 
   return { status: 200, id: res.data.data.id };

--- a/src/pages/api/scenes/[id].ts
+++ b/src/pages/api/scenes/[id].ts
@@ -8,7 +8,7 @@ import withSession, { NextIronRequest } from "../../../lib/with-session";
 export default withSession(methodRouter({ GET: get }));
 
 async function get(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | (SceneData & Res)> {
   const c = await getClientFromSession(req.session);
   const id = head(req.query.id);

--- a/src/pages/api/stream-keys.ts
+++ b/src/pages/api/stream-keys.ts
@@ -23,7 +23,7 @@ type CreateStreamKeyReq = Pick<StreamKeysApiCreateSceneStreamKeyRequest, "id">;
 export default withSession(methodRouter({ POST: create }));
 
 async function create(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<ErrorRes | CreateStreamKeyRes> {
   if (!req.body) return BodyRequired;
 
@@ -37,7 +37,7 @@ async function create(
       createStreamKeyRequest: {
         data: { type: "stream-key", attributes: { expiry: 86400 } },
       },
-    })
+    }),
   );
   return isFailure(r)
     ? toErrorRes({ failure: r })

--- a/src/pages/api/user.tsx
+++ b/src/pages/api/user.tsx
@@ -5,7 +5,7 @@ import withSession, { getToken, NextIronRequest } from "../../lib/with-session";
 
 export default withSession(function handler(
   req: NextIronRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) {
   const token = getToken(req.session);
   assert(token);

--- a/src/pages/file-collections.tsx
+++ b/src/pages/file-collections.tsx
@@ -11,7 +11,7 @@ const FileCollectionsTable = dynamic(
   () => import("../components/file-collection/FileCollectionTable"),
   {
     ssr: false,
-  }
+  },
 );
 
 export default function FileCollections(): JSX.Element {

--- a/src/pages/file-collections/[fileCollectionId].tsx
+++ b/src/pages/file-collections/[fileCollectionId].tsx
@@ -59,7 +59,7 @@ const FileCollectionFilesTable = dynamic(
   () => import("../../components/file-collection/FileCollectionFilesTable"),
   {
     ssr: false,
-  }
+  },
 );
 
 type ServerSideProps = CommonProps & Props;
@@ -344,7 +344,7 @@ export default function FileCollectionDetails({
   const fileCollectionIdRef = React.useRef(fileCollection.id);
   const [file, setFile] = React.useState<File | undefined>();
   const [exportStateCollectionId, setExportStateCollectionId] = React.useState(
-    fileCollection.id
+    fileCollection.id,
   );
   const [readiness, setReadiness] = React.useState<ExportReadinessState>();
   const [readinessError, setReadinessError] = React.useState<string>();
@@ -359,10 +359,10 @@ export default function FileCollectionDetails({
   const [jobStatus, setJobStatus] = React.useState<ExportJobStatus>("idle");
   const drawerOpen = Boolean(file);
   const filesApiPath = `/api/file-collections/${encodeURIComponent(
-    fileCollection.id
+    fileCollection.id,
   )}/files`;
   const readinessApiPath = `/api/file-collections/${encodeURIComponent(
-    fileCollection.id
+    fileCollection.id,
   )}?includeExportAvailability=true`;
   const exportStateIsCurrent = exportStateCollectionId === fileCollection.id;
   const currentArchiveFileId = exportStateIsCurrent ? archiveFileId : undefined;
@@ -404,7 +404,7 @@ export default function FileCollectionDetails({
           setReadiness(undefined);
           setReadinessError(
             ("message" in body ? body.message : undefined) ??
-              "Could not check export availability."
+              "Could not check export availability.",
           );
           return;
         }
@@ -425,7 +425,7 @@ export default function FileCollectionDetails({
         }
       }
     },
-    [fileCollection.id, readinessApiPath]
+    [fileCollection.id, readinessApiPath],
   );
 
   React.useEffect(() => {
@@ -447,7 +447,7 @@ export default function FileCollectionDetails({
     const controller = new AbortController();
 
     loadReadiness(controller.signal).catch(
-      reportError("Failed to check export availability")
+      reportError("Failed to check export availability"),
     );
 
     return () => controller.abort();
@@ -463,7 +463,7 @@ export default function FileCollectionDetails({
 
     const timeout = window.setTimeout(
       () => setArchiveReadyMessageVisible(false),
-      6000
+      6000,
     );
 
     return () => window.clearTimeout(timeout);
@@ -495,7 +495,7 @@ export default function FileCollectionDetails({
         if (signal.aborted) return;
 
         const res = await fetch(
-          `/api/file-jobs/${encodeURIComponent(currentJobId)}`
+          `/api/file-jobs/${encodeURIComponent(currentJobId)}`,
         );
         const body = (await res.json()) as FileJobRes | ErrorRes;
 
@@ -505,7 +505,7 @@ export default function FileCollectionDetails({
           setJobStatus("error");
           setExportError(
             ("message" in body ? body.message : undefined) ??
-              "Archive job failed."
+              "Archive job failed.",
           );
           return;
         }
@@ -548,7 +548,7 @@ export default function FileCollectionDetails({
     setJobStatus("creating");
 
     const created = await createFileJob(currentFileCollectionId).catch(
-      () => undefined
+      () => undefined,
     );
 
     if (created == null) {
@@ -583,7 +583,7 @@ export default function FileCollectionDetails({
               ready: false,
               status: body.status,
             }
-          : current
+          : current,
       );
       return;
     }
@@ -604,7 +604,7 @@ export default function FileCollectionDetails({
     try {
       const res = await fetch(
         `/api/files/${encodeURIComponent(currentArchiveFileId)}/download-url`,
-        { method: "POST" }
+        { method: "POST" },
       );
       const body = (await res.json()) as FileDownloadUrlRes | ErrorRes;
 
@@ -613,7 +613,7 @@ export default function FileCollectionDetails({
       if (!res.ok || !("url" in body)) {
         setExportError(
           ("message" in body ? body.message : undefined) ??
-            "Could not create a download URL for this archive."
+            "Could not create a download URL for this archive.",
         );
         return;
       }
@@ -686,17 +686,17 @@ export default function FileCollectionDetails({
                 jobStatus={currentJobStatus}
                 onDownloadArchive={() => {
                   handleDownloadArchive().catch(
-                    reportError("Failed to download the archive")
+                    reportError("Failed to download the archive"),
                   );
                 }}
                 onExport={() => {
                   handleExport().catch(
-                    reportError("Failed to export the file collection")
+                    reportError("Failed to export the file collection"),
                   );
                 }}
                 onRefreshReadiness={() => {
                   handleRefreshReadiness().catch(
-                    reportError("Failed to refresh export availability")
+                    reportError("Failed to refresh export availability"),
                   );
                 }}
                 onRetry={handleRetry}
@@ -729,7 +729,7 @@ export default function FileCollectionDetails({
 
 export const getServerSideProps = withIronSession(
   serverSidePropsHandler,
-  CookieAttributes
+  CookieAttributes,
 );
 
 export async function serverSidePropsHandler({
@@ -744,7 +744,7 @@ export async function serverSidePropsHandler({
 
   const api = getFileCollectionsApi(await getClientFromSession(req.session));
   const res = await makeCall(() =>
-    api.getFileCollection({ id: fileCollectionId })
+    api.getFileCollection({ id: fileCollectionId }),
   );
 
   if (isErrorFailure(res)) {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -71,7 +71,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
       }
 
       return {};
-    }
+    },
   );
 
   const router = useRouter();
@@ -81,10 +81,10 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
   const invalidApiHost = !isValidHttpUrl(networkConfig.apiHost);
   const invalidRenderingHost = !isValidHttpUrl(networkConfig.renderingHost);
   const invalidSceneTreeHost = !isValidHttpUrlNullable(
-    networkConfig.sceneTreeHost
+    networkConfig.sceneTreeHost,
   );
   const invalidSceneViewHost = !isValidHttpUrlNullable(
-    networkConfig.sceneViewHost
+    networkConfig.sceneViewHost,
   );
   const customConfigurationValidated =
     !invalidApiHost &&
@@ -96,7 +96,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
     if (networkConfig != null) {
       localStorage.setItem(
         "vertexvis.network.config",
-        JSON.stringify(networkConfig)
+        JSON.stringify(networkConfig),
       );
     }
     localStorage.setItem("vertexvis.env", env);
@@ -143,7 +143,7 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
   });
 
   const createEditButton = (
-    field: keyof typeof editableFields
+    field: keyof typeof editableFields,
   ): JSX.Element => (
     <InputAdornment position="end">
       <IconButton
@@ -189,8 +189,8 @@ const LoginPage = ({ serverProvidedNetworkConfig }: Props): JSX.Element => {
             serverProvidedNetworkConfig != null
               ? "800px"
               : env === "custom"
-              ? "800px"
-              : "500px",
+                ? "800px"
+                : "500px",
           minWidth: "30%",
           mx: 2,
           my: 4,

--- a/src/pages/property-key-policies.tsx
+++ b/src/pages/property-key-policies.tsx
@@ -11,7 +11,7 @@ const PropertyKeyPolicyTable = dynamic(
   () => import("../components/property-key-policy/PropertyKeyPolicyTable"),
   {
     ssr: false,
-  }
+  },
 );
 
 export default function PropertyKeyPolicies(): JSX.Element {

--- a/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
+++ b/src/pages/property-key-policies/[propertyKeyPolicyId].tsx
@@ -43,8 +43,8 @@ export default function PropertyKeyPolicyDetails({
 }: Props): JSX.Element {
   const { data, error } = useSWR<GetPropertyKeyPolicyKeysRes | undefined>(
     `/api/property-key-policies/${encodeURIComponent(
-      propertyKeyPolicy.id
-    )}/keys`
+      propertyKeyPolicy.id,
+    )}/keys`,
   );
 
   const keysFailed = error != null || isErrorRes(data);
@@ -96,7 +96,7 @@ export default function PropertyKeyPolicyDetails({
 
 export const getServerSideProps = withIronSession(
   serverSidePropsHandler,
-  CookieAttributes
+  CookieAttributes,
 );
 
 export async function serverSidePropsHandler({
@@ -110,10 +110,10 @@ export async function serverSidePropsHandler({
   if (propertyKeyPolicyId == null) return { notFound: true };
 
   const api = getPropertyKeyPoliciesApi(
-    await getClientFromSession(req.session)
+    await getClientFromSession(req.session),
   );
   const res = await makeCall(() =>
-    api.getPropertyKeyPolicy({ id: propertyKeyPolicyId })
+    api.getPropertyKeyPolicy({ id: propertyKeyPolicyId }),
   );
 
   if (isErrorFailure(res)) {

--- a/src/pages/scene-viewer.tsx
+++ b/src/pages/scene-viewer.tsx
@@ -24,7 +24,7 @@ export default function SceneViewerBySuppliedId(): JSX.Element {
 export const getServerSideProps = withSession(serverSidePropsHandler);
 
 export async function serverSidePropsHandler(
-  req: NextIronRequest
+  req: NextIronRequest,
 ): Promise<GetServerSidePropsResult<unknown>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const session = (req as any).req.session;
@@ -71,7 +71,7 @@ async function fetchSceneBySuppliedId(
   client: VertexClient,
   nameFilter: string,
   pageNumber = 0,
-  cursor?: string
+  cursor?: string,
 ): Promise<SceneData | undefined> {
   if (pageNumber >= 10) {
     throw new Error(`Failed to find requested scene in the first ten pages.`);
@@ -81,13 +81,13 @@ async function fetchSceneBySuppliedId(
     client.scenes.getScenes({
       pageCursor: cursor,
       pageSize: 50,
-    })
+    }),
   );
 
   const scene = page.data.find(
     (s) =>
       s.attributes.name?.includes(nameFilter) ||
-      s.attributes.name?.toLowerCase().includes(nameFilter)
+      s.attributes.name?.toLowerCase().includes(nameFilter),
   );
 
   if (scene != null) {
@@ -97,7 +97,7 @@ async function fetchSceneBySuppliedId(
       client,
       nameFilter,
       pageNumber + 1,
-      cursors.next
+      cursors.next,
     );
   }
 }

--- a/src/pages/scene-viewer/[sceneId].tsx
+++ b/src/pages/scene-viewer/[sceneId].tsx
@@ -36,7 +36,7 @@ function useSceneViewStates({
   viewId?: string;
 }): SWRResponse<GetRes<SceneViewStateData>, ErrorRes> {
   return useSWR<GetRes<SceneViewStateData>, ErrorRes>(
-    viewId ? `/api/scene-view-states?view=${viewId}` : null
+    viewId ? `/api/scene-view-states?view=${viewId}` : null,
   );
 }
 
@@ -46,7 +46,7 @@ function useSceneItem({
   itemId?: string;
 }): SWRResponse<SceneItemData, ErrorRes> {
   return useSWR<SceneItemData, ErrorRes>(
-    itemId ? `/api/scene-items/${itemId}` : null
+    itemId ? `/api/scene-items/${itemId}` : null,
   );
 }
 
@@ -101,17 +101,17 @@ export default function SceneViewer({
         router.replace(
           encodeCreds({ clientId: cId, sceneId, streamKey, vertexEnv: ve }),
           undefined,
-          { shallow: true }
-        )
+          { shallow: true },
+        ),
       )
       .catch(() =>
-        setStreamKeyError("Unable to create a stream key for this scene.")
+        setStreamKeyError("Unable to create a stream key for this scene."),
       );
   }, [clientId, router, vertexEnv]);
 
   async function handleSelect(
     detail: TapEventDetails,
-    hit?: vertexvis.protobuf.stream.IHit
+    hit?: vertexvis.protobuf.stream.IHit,
   ): Promise<void> {
     console.debug({
       hitNormal: hit?.hitNormal,
@@ -132,7 +132,7 @@ export default function SceneViewer({
 
   function handleViewStateSelected(id: string): void {
     applySceneViewState({ id, viewer: viewerState.ref.current }).catch(
-      reportError("Failed to apply the scene view state")
+      reportError("Failed to apply the scene view state"),
     );
   }
 
@@ -183,7 +183,7 @@ export default function SceneViewer({
             viewerId={ViewerId}
             onViewStateCreated={() => {
               mutate().catch(
-                reportError("Failed to refresh scene view states")
+                reportError("Failed to refresh scene view states"),
               );
             }}
             networkConfig={networkConfig}
@@ -191,7 +191,7 @@ export default function SceneViewer({
             rotateAroundTapPoint={true}
             onSceneReady={() => {
               handleSceneReady().catch(
-                reportError("Failed to prepare the scene view")
+                reportError("Failed to prepare the scene view"),
               );
             }}
             onViewReset={() => {
@@ -272,5 +272,5 @@ export function serverSidePropsHandler({
 
 export const getServerSideProps = withIronSession(
   serverSidePropsHandler,
-  CookieAttributes
+  CookieAttributes,
 );

--- a/src/pages/translations.tsx
+++ b/src/pages/translations.tsx
@@ -8,7 +8,7 @@ const TranslationTables = dynamic(
   () => import("../components/translation/TranslationTables"),
   {
     ssr: false,
-  }
+  },
 );
 
 export default function Translations(): JSX.Element {

--- a/test/api/nextJsApiRouteTest.ts
+++ b/test/api/nextJsApiRouteTest.ts
@@ -11,7 +11,7 @@ import {
 
 type NextJsApiRouteHandler = (
   req: NextIronRequest,
-  res: NextApiResponse
+  res: NextApiResponse,
 ) => Promise<void>;
 
 export interface ApiRouteRequest {
@@ -28,7 +28,7 @@ export interface ApiRouteResponse {
 
 export async function invokeNextJsApiRouteHandler(
   handler: NextJsApiRouteHandler,
-  request: ApiRouteRequest & { readonly session: Session }
+  request: ApiRouteRequest & { readonly session: Session },
 ): Promise<ApiRouteResponse> {
   const response = createResponse();
   await handler(createRequest(request), response as unknown as NextApiResponse);
@@ -36,7 +36,7 @@ export async function invokeNextJsApiRouteHandler(
 }
 
 export function createAuthenticatedVertexApiTestSession(
-  apiHost: string
+  apiHost: string,
 ): Session {
   const values = new Map<string, unknown>([
     [CredsKey, { id: "client-id", secret: "client-secret" }],

--- a/test/msw/handlers/property-key-policies.ts
+++ b/test/msw/handlers/property-key-policies.ts
@@ -45,7 +45,7 @@ export function propertyKeyPoliciesPage({
 }
 
 export function propertyKeyPolicyRes(
-  policy: PropertyKeyPolicyResource
+  policy: PropertyKeyPolicyResource,
 ): GetPropertyKeyPolicyRes {
   return { data: policy, status: 200 };
 }

--- a/test/msw/installJsdomMockServer.ts
+++ b/test/msw/installJsdomMockServer.ts
@@ -5,7 +5,7 @@ function createRelativeUrlFetch(nativeFetch: typeof fetch): typeof fetch {
     if (typeof input === "string" || input instanceof URL) {
       return nativeFetch(
         new URL(input.toString(), "http://localhost").toString(),
-        init
+        init,
       );
     }
 

--- a/test/msw/installNodeMswServer.ts
+++ b/test/msw/installNodeMswServer.ts
@@ -15,7 +15,7 @@ export function installNodeMswServer(): void {
 
         print.error();
         throw new Error(
-          `Unhandled outbound request: ${request.method} ${url.toString()}`
+          `Unhandled outbound request: ${request.method} ${url.toString()}`,
         );
       },
     });

--- a/test/render/renderWithSWR.tsx
+++ b/test/render/renderWithSWR.tsx
@@ -15,7 +15,7 @@ export function renderWithSWR(ui: React.ReactElement): Omit<
           dedupingInterval: 0,
           fetcher: (url: string) =>
             fetch(new URL(url, window.location.origin).toString()).then((res) =>
-              res.json()
+              res.json(),
             ),
           provider: () => new Map(),
         }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6241,12 +6241,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.8.4:
+prettier@^3.8.4, prettier@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.9.6.tgz#b3ea5146515d40fc53f18aa63f74dfab1e10dbf6"
   integrity sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==


### PR DESCRIPTION
Part 6/6 (top) of the PLAT-9101 ESLint-tightening stack · base: `PLAT-9107_eslint_stack_5_hooks_tests`

## What
Formatting-only layer, deliberately isolated at the top of the stack because it touches the most files and matters least:
- Prettier 2.8 → **3.9.6** (completes the connect-app version-family alignment from part 1/6).
- Repo-wide `yarn format`: 104 files, overwhelmingly Prettier 3's default `trailingComma: "es5"` → `"all"` churn.
- `scripts/format-staged.ts` updated to Prettier 3's bin path (`prettier/bin/prettier.cjs`) — the Prettier 2 path no longer exists and would have broken the lefthook staged-format check.

## Config delta
None — ESLint config was finalized in part 5/6.

## Stack-completion guarantee
With this layer applied, the stack's tree is **byte-identical** to reference PR #370 (`git diff` empty) — the stack exactly reproduces the tree that was already reviewed, Copilot-checked, and CI-green there. Full improvements summary and connect-app ruleset comparison: see #370.

## Validation
lint · format:check · typecheck · test (151) · build · lefthook quality-checks — all green.

## Related
[PLAT-9108](https://vertexvis.atlassian.net/browse/PLAT-9108) (parent [PLAT-9101](https://vertexvis.atlassian.net/browse/PLAT-9101)) · reference #370

[PLAT-9108]: https://vertexvis.atlassian.net/browse/PLAT-9108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ