### PR TITLE
[PLAT-9130] Exclude nested worktree/tooling dirs from Jest discovery

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,18 @@ const coverageConfig = {
   coverageReporters: ['text', 'lcov'],
 };
 
+// Directories that can appear inside the repo root depending on workflow
+// (git worktrees created in-tree, codex temp dirs, stray sibling checkouts).
+// Jest scans from rootDir, so without these ignores it would discover and run
+// their test files, causing spurious local failures. Applied to every project.
+const nestedCheckoutIgnorePatterns = [
+  '/node_modules/',
+  '<rootDir>/.worktrees/',
+  '<rootDir>/.claude/',
+  '<rootDir>/.codex[^/]*/',
+  '<rootDir>/vertex-web-sdk/',
+];
+
 const projectConfig = {
   preset: 'ts-jest',
   transform: {
@@ -19,6 +31,7 @@ const projectConfig = {
   transformIgnorePatterns: [
     '/node_modules/(?!(@mswjs|@open-draft|msw|rettime|until-async|headers-polyfill|is-node-process|outvariant|strict-event-emitter|path-to-regexp)/)',
   ],
+  testPathIgnorePatterns: nestedCheckoutIgnorePatterns,
 };
 
 module.exports = {
@@ -37,7 +50,10 @@ module.exports = {
         '**/?(*.)+(test).ts',
         '!**/src/__tests__/pages/api/**/*.test.ts',
       ],
-      testPathIgnorePatterns: ['/src/__tests__/pages/api/'],
+      testPathIgnorePatterns: [
+        ...nestedCheckoutIgnorePatterns,
+        '/src/__tests__/pages/api/',
+      ],
     },
     {
       ...projectConfig,

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,16 +11,15 @@ const coverageConfig = {
   coverageReporters: ['text', 'lcov'],
 };
 
-// Directories that can appear inside the repo root depending on workflow
-// (git worktrees created in-tree, codex temp dirs, stray sibling checkouts).
-// Jest scans from rootDir, so without these ignores it would discover and run
-// their test files, causing spurious local failures. Applied to every project.
+// Directories that dev tooling can create inside the repo root depending on
+// workflow (git worktrees created in-tree, codex temp dirs). Jest scans from
+// rootDir, so without these ignores it would discover and run their test files,
+// causing spurious local failures. Applied to every project.
 const nestedCheckoutIgnorePatterns = [
   '/node_modules/',
   '<rootDir>/.worktrees/',
   '<rootDir>/.claude/',
   '<rootDir>/.codex[^/]*/',
-  '<rootDir>/vertex-web-sdk/',
 ];
 
 const projectConfig = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,7 @@ const coverageConfig = {
   coverageReporters: ['text', 'lcov'],
 };
 
-// Directories that dev tooling can create inside the repo root depending on
-// workflow (git worktrees created in-tree, codex temp dirs). Jest scans from
-// rootDir, so without these ignores it would discover and run their test files,
-// causing spurious local failures. Applied to every project.
+// Ignore common in-tree worktree locations that would otherwise pollute Jest test discovery.
 const nestedCheckoutIgnorePatterns = [
   '/node_modules/',
   '<rootDir>/.worktrees/',


### PR DESCRIPTION
## Summary

Ignores common worktree locations that are created inside of the repos. I ran into this several times, where I, or an agent creates the worktree within the repo directory and then tests fail - and it takes me a minute to remember why. I think this is the default behavior of claude and codex so I think its worth adding the ignore list.

## Change

Add a shared `testPathIgnorePatterns` list, applied to both Jest projects (`browser` + `node`):

- `<rootDir>/.worktrees/`
- `<rootDir>/.claude/` (Claude worktrees now live here)
- `<rootDir>/.codex[^/]*/`

Config only — no production code changes.

## Verification

- Planted deliberately-failing `*.test.ts` files in all four nested locations → Jest ignored every one; real suite stayed green (26 suites / 151 tests).
- `prettier --check`, `eslint`, and the full lefthook gate (typecheck/lint/format/test) all pass.

Jira: PLAT-9130